### PR TITLE
Let there be graphics

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/client/ForgeHax.java
+++ b/enderio-base/src/main/java/com/enderio/base/client/ForgeHax.java
@@ -1,0 +1,44 @@
+package com.enderio.base.client;
+
+import com.enderio.base.EnderIO;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraftforge.client.ForgeHooksClient;
+
+import java.lang.reflect.Field;
+import java.util.Stack;
+
+public class ForgeHax {
+
+    private static Field guiLayersField;
+
+    static {
+        try {
+            guiLayersField = ForgeHooksClient.class.getDeclaredField("guiLayers");
+            guiLayersField.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void setItemRendererDepthForScreen(Screen screen, PoseStack poseStack) {
+        poseStack.translate(0, 0, -2000 * ForgeHax.getGuiLayer(screen));
+    }
+
+    private static int getGuiLayer(Screen screen) {
+        try {
+            Stack<Screen> guiLayers = (Stack<Screen>)guiLayersField.get(null);
+            for (int i = 0; i < guiLayers.size(); i++) {
+                if (guiLayers.get(i) == screen) {
+                    return guiLayers.size() - i - 1;
+                }
+            }
+            return guiLayers.size();
+        } catch (IllegalAccessException e) {
+            EnderIO.LOGGER.warning("Couldn't access guiLayers, report to enderio if you are using the latest Version");
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/enderio-base/src/main/java/com/enderio/base/client/ForgeHax.java
+++ b/enderio-base/src/main/java/com/enderio/base/client/ForgeHax.java
@@ -22,23 +22,36 @@ public class ForgeHax {
         }
     }
 
-    public static void setItemRendererDepthForScreen(Screen screen, PoseStack poseStack) {
-        poseStack.translate(0, 0, -2000 * ForgeHax.getGuiLayer(screen));
+    public static void setPoseStackDepth(Screen screen, PoseStack poseStack) {
+        poseStack.translate(0, 0, -2000 * ForgeHax.getReverseGuiLayer(screen));
     }
 
-    private static int getGuiLayer(Screen screen) {
-        try {
-            Stack<Screen> guiLayers = (Stack<Screen>)guiLayersField.get(null);
-            for (int i = 0; i < guiLayers.size(); i++) {
-                if (guiLayers.get(i) == screen) {
-                    return guiLayers.size() - i - 1;
-                }
+    /**
+     * returns the depth of the screen in the GuiStack. 0 is the topmost screen
+     * @param screen
+     * @return
+     */
+    public static int getReverseGuiLayer(Screen screen) {
+        return getGuiLayers().size() - getGuiLayer(screen);
+    }
+
+    public static int getGuiLayer(Screen screen) {
+        Stack<Screen> guiLayers = getGuiLayers();
+        for (int i = 0; i < guiLayers.size(); i++) {
+            if (guiLayers.get(i) == screen) {
+                return i + 1;
             }
-            return guiLayers.size();
+        }
+        return 0;
+    }
+
+    private static Stack<Screen> getGuiLayers() {
+        try {
+            return (Stack<Screen>)guiLayersField.get(null);
         } catch (IllegalAccessException e) {
             EnderIO.LOGGER.warning("Couldn't access guiLayers, report to enderio if you are using the latest Version");
             e.printStackTrace();
         }
-        return 0;
+        return new Stack<>();
     }
 }

--- a/enderio-base/src/main/java/com/enderio/base/client/screen/EnumIconWidget.java
+++ b/enderio-base/src/main/java/com/enderio/base/client/screen/EnumIconWidget.java
@@ -145,6 +145,8 @@ public class EnumIconWidget<T extends Enum<T> & IIcon, U extends Screen & IEnder
 
         @Override
         public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTicks) {
+            pPoseStack.pushPose();
+            ForgeHax.setItemRendererDepthForScreen(this, pPoseStack);
             tooltips.clear();
             renderSimpleArea(pPoseStack, expandTopLeft, expandBottomRight);
             super.render(pPoseStack, pMouseX, pMouseY, pPartialTicks);
@@ -152,6 +154,8 @@ public class EnumIconWidget<T extends Enum<T> & IIcon, U extends Screen & IEnder
             for (LateTooltipData tooltip : tooltips) {
                 renderTooltip(tooltip.getPoseStack(), tooltip.getText(), tooltip.getMouseX(), tooltip.getMouseY());
             }
+
+            pPoseStack.popPose();
         }
 
         @Override

--- a/enderio-base/src/main/java/com/enderio/base/client/screen/EnumIconWidget.java
+++ b/enderio-base/src/main/java/com/enderio/base/client/screen/EnumIconWidget.java
@@ -1,5 +1,6 @@
 package com.enderio.base.client.screen;
 
+import com.enderio.base.client.ForgeHax;
 import com.enderio.base.common.util.Vector2i;
 import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.blaze3d.vertex.PoseStack;

--- a/enderio-base/src/main/java/com/enderio/base/client/screen/EnumIconWidget.java
+++ b/enderio-base/src/main/java/com/enderio/base/client/screen/EnumIconWidget.java
@@ -147,7 +147,7 @@ public class EnumIconWidget<T extends Enum<T> & IIcon, U extends Screen & IEnder
         @Override
         public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTicks) {
             pPoseStack.pushPose();
-            ForgeHax.setItemRendererDepthForScreen(this, pPoseStack);
+            ForgeHax.setPoseStackDepth(this, pPoseStack);
             tooltips.clear();
             renderSimpleArea(pPoseStack, expandTopLeft, expandBottomRight);
             super.render(pPoseStack, pMouseX, pMouseY, pPartialTicks);


### PR DESCRIPTION
The EnumIconWidgets now works in 1.18

# Description

See above. I'll work on a forgefix and hope this reflective access can be removed in the future


# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
