### PR TITLE
add utils to Integration and IntegrationManager to make them more powerful

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/EnderIO.java
+++ b/enderio-base/src/main/java/com/enderio/base/EnderIO.java
@@ -2,6 +2,7 @@ package com.enderio.base;
 
 import com.enderio.api.capacitor.CapacitorKey;
 import com.enderio.base.common.init.*;
+import com.enderio.base.common.integration.IntegrationManager;
 import com.enderio.base.common.lang.EIOLang;
 import com.enderio.base.common.tag.EIOTags;
 import com.enderio.base.config.base.BaseConfig;
@@ -107,6 +108,7 @@ public class EnderIO {
             generator.addProvider(new EIOBlockTagsProvider(generator, event.getExistingFileHelper()));
             generator.addProvider(new FireCraftingLootProvider(generator));
         }
+        IntegrationManager.forAll(integration -> integration.createData(event));
     }
 
     public void onRecipeSerializerRegistry(RegistryEvent.Register<RecipeSerializer<?>> event) {

--- a/enderio-base/src/main/java/com/enderio/base/common/integration/Integration.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/integration/Integration.java
@@ -1,5 +1,7 @@
 package com.enderio.base.common.integration;
 
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
 
 public abstract class Integration {
 
@@ -13,5 +15,13 @@ public abstract class Integration {
         if (this.modid != null)
             throw new IllegalCallerException("You are not allowed to set the modid of an integration");
         this.modid = modid;
+    }
+
+    void addEventListener(IEventBus modEventBus, IEventBus forgeEventBus) {
+
+    }
+
+    public void createData(GatherDataEvent event) {
+
     }
 }

--- a/enderio-base/src/main/java/com/enderio/base/common/integration/IntegrationManager.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/integration/IntegrationManager.java
@@ -1,13 +1,36 @@
 package com.enderio.base.common.integration;
 
 
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+@Mod.EventBusSubscriber
 public class IntegrationManager {
 
-    //public static final IntegrationWrapper<DummyIntegration> DECORATION = wrapper("enderio_decoration", DummyIntegration::new);
+    static final List<Integration> ALL_INTEGRATIONS = new ArrayList<>();
 
     private static <T extends Integration> IntegrationWrapper<T> wrapper(String modid, Supplier<T> integration) {
         return new IntegrationWrapper<>(modid, integration);
+    }
+
+    public static boolean noneMatch(Predicate<Integration> predicate) {
+        return ALL_INTEGRATIONS.stream().noneMatch(predicate);
+    }
+
+    public static boolean allMatch(Predicate<Integration> predicate) {
+        return ALL_INTEGRATIONS.stream().allMatch(predicate);
+    }
+
+    public static boolean anyMatch(Predicate<Integration> predicate) {
+        return ALL_INTEGRATIONS.stream().anyMatch(predicate);
+    }
+
+    public static void forAll(Consumer<Integration> consumer) {
+        ALL_INTEGRATIONS.forEach(consumer);
     }
 }

--- a/enderio-base/src/main/java/com/enderio/base/common/integration/IntegrationManager.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/integration/IntegrationManager.java
@@ -1,15 +1,11 @@
 package com.enderio.base.common.integration;
 
-
-import net.minecraftforge.fml.common.Mod;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-@Mod.EventBusSubscriber
 public class IntegrationManager {
 
     static final List<Integration> ALL_INTEGRATIONS = new ArrayList<>();

--- a/enderio-base/src/main/java/com/enderio/base/common/integration/IntegrationWrapper.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/integration/IntegrationWrapper.java
@@ -1,9 +1,8 @@
 package com.enderio.base.common.integration;
 
-import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.common.util.NonNullConsumer;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.ModList;
-
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import javax.annotation.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -18,7 +17,11 @@ public class IntegrationWrapper<T extends Integration> {
     public IntegrationWrapper(String modid, Supplier<T> supplier) {
         this.modid = modid;
         value = ModList.get().isLoaded(modid) ? supplier.get() : null;
-        ifPresent(integration -> integration.setModid(modid));
+        ifPresent(integration -> {
+            integration.setModid(modid);
+            IntegrationManager.ALL_INTEGRATIONS.add(integration);
+            integration.addEventListener(FMLJavaModLoadingContext.get().getModEventBus(), MinecraftForge.EVENT_BUS);
+        });
     }
 
     public boolean isPresent() {
@@ -29,13 +32,6 @@ public class IntegrationWrapper<T extends Integration> {
         return value == null;
     }
 
-    /**
-     * If non-empty, invoke the specified {@link NonNullConsumer} with the object,
-     * otherwise do nothing.
-     *
-     * @param consumer The {@link NonNullConsumer} to run if this optional is non-empty.
-     * @throws NullPointerException if {@code consumer} is null and this {@link LazyOptional} is non-empty
-     */
     public void ifPresent(Consumer<? super T> consumer) {
         if (isPresent())
             consumer.accept(value);


### PR DESCRIPTION
It's something I did for Tinkers Integration, but wanted to get feedback on this, as tinkers is on hold, during 1.19 port and this shouldn't cause any conflicts

# Description
## Utils to IntegrationManager:
noneMatch: can be used for denylisting things
anyMatch: for allowlisting, like if the direct glm should apply on an itemstack for specific tinkers tools
allMatch: I don't have an idea for that rn, but it might get a use and is just there to complete the set
forAll: Do something on all integrations: Like sending the GatherDataEvent or other things

## Utils to Integration
addEventListener: with reference to relevant EventBuses
createData: has the GatherDataEvent, so not every Integration needs it's own EventListener

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
