### PR TITLE
Fix Color

### DIFF
--- a/src/decor/java/com/enderio/decoration/client/model/painted/PaintedBlockModel.java
+++ b/src/decor/java/com/enderio/decoration/client/model/painted/PaintedBlockModel.java
@@ -83,7 +83,6 @@ public class PaintedBlockModel implements IDynamicBakedModel {
                     List<BakedQuad> shape = getModel(replicaState.setValue(SlabBlock.TYPE, SlabType.TOP))
                         .getQuads(state, side, rand, ModelData.EMPTY, renderType);
                     // @formatter:on
-                    IQuadTransformer transformer = quad -> quad.tintIndex = PaintedBlockColor.moveTintIndex(quad.getTintIndex());
                     quads.addAll(getQuadsUsingShape(paint, shape, side, rand, null, renderType));
                 }
 
@@ -257,7 +256,7 @@ public class PaintedBlockModel implements IDynamicBakedModel {
         return List.of();
     }
 
-    private BlockState paintWithRotation(Block paint, Direction rotation) {
+    private BlockState paintWithRotation(Block paint, @Nullable Direction rotation) {
         BlockState state = paint.defaultBlockState();
         if (rotation != null) {
             for (Property<?> property : state.getProperties()) {
@@ -276,7 +275,7 @@ public class PaintedBlockModel implements IDynamicBakedModel {
      * @param rotation a rotation value, so that if both blocks support rotation, the correct texture is gathered
      * @return an Optional of a Pair of the texture of the Block and if the texture is tinted at that side
      */
-    private Optional<Pair<TextureAtlasSprite, Boolean>> getSpriteData(Block paint, Direction side, RandomSource rand, Direction rotation,
+    private Optional<Pair<TextureAtlasSprite, Boolean>> getSpriteData(Block paint, @Nullable Direction side, RandomSource rand, @Nullable Direction rotation,
         @Nullable RenderType renderType) {
         BlockState state = paintWithRotation(paint, rotation);
         List<BakedQuad> quads = getModel(state).getQuads(state, side, rand, ModelData.EMPTY, renderType);

--- a/src/decor/java/com/enderio/decoration/client/model/painted/PaintedBlockModel.java
+++ b/src/decor/java/com/enderio/decoration/client/model/painted/PaintedBlockModel.java
@@ -2,6 +2,7 @@ package com.enderio.decoration.client.model.painted;
 
 import com.enderio.core.client.RenderUtil;
 import com.enderio.core.data.model.EIOModel;
+import com.enderio.decoration.client.render.PaintedBlockColor;
 import com.enderio.decoration.common.blockentity.DoublePaintedBlockEntity;
 import com.enderio.decoration.common.blockentity.IPaintableBlockEntity;
 import com.enderio.decoration.common.blockentity.SinglePaintedBlockEntity;
@@ -71,7 +72,8 @@ public class PaintedBlockModel implements IDynamicBakedModel {
                     List<BakedQuad> shape = getModel(replicaState.setValue(SlabBlock.TYPE, SlabType.BOTTOM))
                         .getQuads(state, side, rand, ModelData.EMPTY, renderType);
                     // @formatter:on
-                    quads.addAll(getQuadsUsingShape(paint, shape, side, rand, null, renderType));
+                    IQuadTransformer transformer = quad -> quad.tintIndex = PaintedBlockColor.moveTintIndex(quad.getTintIndex());
+                    quads.addAll(transformer.process(getQuadsUsingShape(paint, shape, side, rand, null, renderType)));
                 }
 
                 // Top slab
@@ -81,6 +83,7 @@ public class PaintedBlockModel implements IDynamicBakedModel {
                     List<BakedQuad> shape = getModel(replicaState.setValue(SlabBlock.TYPE, SlabType.TOP))
                         .getQuads(state, side, rand, ModelData.EMPTY, renderType);
                     // @formatter:on
+                    IQuadTransformer transformer = quad -> quad.tintIndex = PaintedBlockColor.moveTintIndex(quad.getTintIndex());
                     quads.addAll(getQuadsUsingShape(paint, shape, side, rand, null, renderType));
                 }
 
@@ -240,7 +243,7 @@ public class PaintedBlockModel implements IDynamicBakedModel {
      * @return a List of BakedQuads from a shape using the paint as a texture
      */
     protected List<BakedQuad> getQuadsUsingShape(@Nullable Block paint, List<BakedQuad> shape, @Nullable Direction side, RandomSource rand,
-        @Nullable Direction rotation, RenderType renderType) {
+        @Nullable Direction rotation, @Nullable RenderType renderType) {
         if (paint != null) {
             BakedModel model = getModel(paintWithRotation(paint, rotation));
             Optional<Pair<TextureAtlasSprite, Boolean>> spriteOptional = getSpriteData(paint, side, rand, rotation, renderType);
@@ -274,7 +277,7 @@ public class PaintedBlockModel implements IDynamicBakedModel {
      * @return an Optional of a Pair of the texture of the Block and if the texture is tinted at that side
      */
     private Optional<Pair<TextureAtlasSprite, Boolean>> getSpriteData(Block paint, Direction side, RandomSource rand, Direction rotation,
-        RenderType renderType) {
+        @Nullable RenderType renderType) {
         BlockState state = paintWithRotation(paint, rotation);
         List<BakedQuad> quads = getModel(state).getQuads(state, side, rand, ModelData.EMPTY, renderType);
         return quads.isEmpty() ? Optional.empty() : Optional.of(Pair.of(quads.get(0).getSprite(), quads.get(0).isTinted()));

--- a/src/decor/java/com/enderio/decoration/client/render/PaintedBlockColor.java
+++ b/src/decor/java/com/enderio/decoration/client/render/PaintedBlockColor.java
@@ -1,5 +1,6 @@
 package com.enderio.decoration.client.render;
 
+import com.enderio.decoration.common.blockentity.DoublePaintedBlockEntity;
 import com.enderio.decoration.common.blockentity.IPaintableBlockEntity;
 import com.enderio.decoration.common.util.PaintUtils;
 import net.minecraft.client.Minecraft;
@@ -20,15 +21,37 @@ public class PaintedBlockColor implements BlockColor, ItemColor {
     // TODO: Buggy on the sides of blocks. (Grass)
     @Override
     public int getColor(BlockState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos, int tintIndex) {
-        if (level != null && pos != null && tintIndex != 0) {
+        if (level != null && pos != null) {
             BlockEntity entity = level.getBlockEntity(pos);
             if (entity instanceof IPaintableBlockEntity paintedBlockEntity) {
                 Block[] paints = paintedBlockEntity.getPaints();
-                for (Block paint : paints) {
+                if (paintedBlockEntity instanceof DoublePaintedBlockEntity doublePaintedBlockEntity) {
+                    if (tintIndex < 0) {
+                        tintIndex = unmoveTintIndex(tintIndex);
+                        if (paints[0] != null) {
+                            BlockState paintState = paints[0].defaultBlockState();
+                            int color = Minecraft.getInstance().getBlockColors().getColor(paintState, level, pos, tintIndex);
+                            if (color != -1)
+                                return color;
+                        }
+                        return 0;
+                    } else {
+                        tintIndex = unmoveTintIndex(tintIndex);
+                        if (paints[1] != null) {
+                            BlockState paintState = paints[1].defaultBlockState();
+                            int color = Minecraft.getInstance().getBlockColors().getColor(paintState, level, pos, tintIndex);
+                            if (color != -1)
+                                return color;
+                        }
+                        return 0;
+                    }
+                }
+                for (int i = 0; i < paints.length; i++) {
+                    Block paint = paints[i];
                     if (paint == null)
                         continue;
                     BlockState paintState = paint.defaultBlockState();
-                    int color = Minecraft.getInstance().getBlockColors().getColor(paintState, level, pos, tintIndex);
+                    int color = Minecraft.getInstance().getBlockColors().getColor(paintState, level, pos, i == 1 ? unmoveTintIndex(tintIndex) : tintIndex);
                     if (color != -1)
                         return color;
                 }
@@ -49,5 +72,17 @@ public class PaintedBlockColor implements BlockColor, ItemColor {
             }
         }
         return 0;
+    }
+
+    //Lets assume that no one uses negative tint indices, so that we can move bottomslab tint indices into the negative half
+    public static int moveTintIndex(int original) {
+        return -original - 2;
+    }
+    public static int unmoveTintIndex(int original) {
+        if (original > 0) {
+            return original;
+        } else {
+            return -original + 2;
+        }
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -10,3 +10,4 @@ public net.minecraft.world.level.block.DoublePlantBlock m_52903_(Lnet/minecraft/
 public net.minecraft.world.entity.item.FallingBlockEntity <init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/level/block/state/BlockState;)V
 public net.minecraft.world.inventory.CraftingMenu f_39350_ # access
 public net.minecraft.world.entity.item.FallingBlockEntity <init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/level/block/state/BlockState;)V
+public-f net.minecraft.client.renderer.block.model.BakedQuad f_111293_ # tintIndex


### PR DESCRIPTION
# Description

Shift one slab tintindices into the negatives to distuinguish between top and bottom slab and to get the correct blockcolors impl
I wanted to bake the color from the BlockColors impl into the vertexdata, so that it's not required to look them up after they are baked, but ealier, which seemed possible, but couldn't get it to work. I'll close this, if I can get the other solution to work
- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
