### PR TITLE
fix: broken spawners in souls tab

### DIFF
--- a/src/main/java/com/enderio/base/common/init/EIOItems.java
+++ b/src/main/java/com/enderio/base/common/init/EIOItems.java
@@ -301,7 +301,7 @@ public class EIOItems {
 
     // TODO: Will need sorted once we have added more.
 
-    public static final ItemEntry<SoulVialItem> EMPTY_SOUL_VIAL = groupedItem("empty_soul_vial", SoulVialItem::new, () -> EIOCreativeTabs.GEAR);
+    public static final ItemEntry<SoulVialItem> EMPTY_SOUL_VIAL = groupedItem("empty_soul_vial", SoulVialItem::new, () -> EIOCreativeTabs.SOULS);
 
     public static final ItemEntry<SoulVialItem> FILLED_SOUL_VIAL = REGISTRATE
         .item("filled_soul_vial", SoulVialItem::new)

--- a/src/main/java/com/enderio/base/common/item/misc/BrokenSpawnerItem.java
+++ b/src/main/java/com/enderio/base/common/item/misc/BrokenSpawnerItem.java
@@ -40,7 +40,7 @@ public class BrokenSpawnerItem extends Item implements IMultiCapabilityItem {
 
     @Override
     public void fillItemCategory(CreativeModeTab pCategory, NonNullList<ItemStack> pItems) {
-        if (allowedIn(pCategory)) {
+        if (pCategory == getItemCategory()) {
             pItems.add(new ItemStack(this));
         } else if (pCategory == EIOCreativeTabs.SOULS) {
             // Register for every mob that can be captured.


### PR DESCRIPTION
# Description

- This fixes an issue where there wasn't a broken spawner for every supported entity like there was for the soul vial. The fix was simply to copy what the SoulVialItem was doing.
- Fixes issue where empty soul vial was registered under gears tab instead of souls tab

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
