### PR TITLE
Yeta wrench updates.

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -1,8 +1,11 @@
 package com.enderio.machines.common.blockentity.base;
 
+import com.enderio.api.capability.ISideConfig;
 import com.enderio.api.io.IIOConfig;
 import com.enderio.api.io.IOMode;
+import com.enderio.base.common.blockentity.IWrenchable;
 import com.enderio.base.common.blockentity.RedstoneControl;
+import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.core.common.blockentity.EnderBlockEntity;
 import com.enderio.core.common.sync.EnumDataSlot;
 import com.enderio.core.common.sync.NBTSerializableDataSlot;
@@ -15,13 +18,24 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.model.data.ModelProperty;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
@@ -29,14 +43,16 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandler;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Optional;
 
 import static net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
-public abstract class MachineBlockEntity extends EnderBlockEntity implements MenuProvider {
+public abstract class MachineBlockEntity extends EnderBlockEntity implements MenuProvider, IWrenchable {
 
     // region IO Configuration
 
@@ -166,7 +182,7 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
     }
 
     @Override
-    public ModelData getModelData() {
+    public @NotNull ModelData getModelData() {
         return getIOConfig().renderOverlay() ? modelData : ModelData.EMPTY;
     }
 
@@ -444,6 +460,9 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
         return getBlockState().getBlock().getName();
     }
 
+    //called when a player uses the block entity, before menu is may open.
+    public InteractionResult onBlockEntityUsed(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit){return InteractionResult.PASS;}
+
     public boolean stillValid(Player pPlayer) {
         if (this.level.getBlockEntity(this.worldPosition) != this)
             return false;
@@ -456,5 +475,36 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
 
     public void setRedstoneControl(RedstoneControl redstoneControl) {
         this.redstoneControl = redstoneControl;
+    }
+
+    //only called on server
+    @Override
+    public InteractionResult onWrenched(UseOnContext context) {
+        Player player = context.getPlayer();
+        if(player != null && level!= null && player.isSecondaryUseActive()) {//aka break block
+            BlockPos pos = context.getClickedPos();
+            BlockState state = context.getLevel().getBlockState(pos);
+            List<ItemStack> drops = Block.getDrops(state, (ServerLevel) level,pos, level.getBlockEntity(pos));//level is always ServerLevel since method only called on server.
+            level.setBlock(pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL_IMMEDIATE);
+            player.swing(InteractionHand.MAIN_HAND);
+            //TODO: custom sound when sound manager is up and running??
+            SoundType soundType = state.getBlock().getSoundType(state,level,pos,null);
+            level.playSound(null, pos,soundType.getBreakSound(), SoundSource.BLOCKS,soundType.volume, soundType.pitch);
+            for (ItemStack drop: drops) {
+                if(!player.addItem(drop)){
+                    level.addFreshEntity(new ItemEntity(level, pos.getX()+0.5, pos.getY()+0.5, pos.getZ()+0.5, drop));
+                }
+            }
+            return InteractionResult.CONSUME;
+        }else{
+            // Check for side config capability
+            LazyOptional<ISideConfig> optSideConfig = getCapability(EIOCapabilities.SIDE_CONFIG, context.getClickedFace());
+            if (optSideConfig.isPresent()) {
+                // Cycle state.
+                optSideConfig.ifPresent(ISideConfig::cycleMode);
+                return InteractionResult.CONSUME;
+            }
+        }
+        return InteractionResult.PASS;
     }
 }

--- a/src/main/java/com/enderio/base/common/blockentity/IWrenchable.java
+++ b/src/main/java/com/enderio/base/common/blockentity/IWrenchable.java
@@ -1,0 +1,9 @@
+package com.enderio.base.common.blockentity;
+
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraftforge.common.extensions.IForgeBlockEntity;
+
+public interface IWrenchable extends IForgeBlockEntity {
+    InteractionResult onWrenched(UseOnContext context);
+}


### PR DESCRIPTION
# Description

- The yeta wrench can now break blocks with shift right click.
- The Functionality is now mostly moved over to the block entity "MachineBlockEntity", if this is undesirable I can change it as per your wishes. But it makes it more flexible to intercept custom behaviours in the future, configured per block.
- New method to facilitate "use" on Machine blocks, it is now passed to machine block entities automagically. (Useful for upcoming Vat update)

# Todo <!-- Remove this section if you're submitting an already-complete PR -->
- Implement custom sound to Yeta wrench, when breaking stuff. But it's a minor thing that has to happen after the sounds are merged together with the hang glider.

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation(N/A?)

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
