### PR TITLE
Machine Energy Input Cap

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/types/EnergyConduitTicker.java
+++ b/src/conduits/java/com/enderio/conduits/common/types/EnergyConduitTicker.java
@@ -44,6 +44,15 @@ public class EnergyConduitTicker extends ICapabilityAwareConduitTicker<IEnergySt
         }
     }
 
+    /**
+     * This ensures consistent behaviour for FE/t caps and more.
+     * @return how often the conduit should tick. 1 is every tick, 5 is every 5th tick, so 4 times a second
+     */
+    @Override
+    public int getTickRate() {
+        return 1;
+    }
+
     @Override
     public Capability<IEnergyStorage> getCapability() {
         return ForgeCapabilities.ENERGY;

--- a/src/machines/java/com/enderio/machines/common/io/energy/MachineEnergyStorage.java
+++ b/src/machines/java/com/enderio/machines/common/io/energy/MachineEnergyStorage.java
@@ -115,7 +115,7 @@ public class MachineEnergyStorage implements IMachineEnergyStorage, IEnderCapabi
     public int receiveEnergy(int maxReceive, boolean simulate) {
         if (!canReceive())
             return 0;
-        int energyReceived = Math.min(getMaxEnergyStored() - getEnergyStored(), maxReceive);
+        int energyReceived = Math.min(getMaxEnergyStored() - getEnergyStored(), Math.min(getMaxEnergyUse() * 2, maxReceive));
         if (!simulate) {
             addEnergy(energyReceived);
         }


### PR DESCRIPTION
# Description

Added an input cap to machine energy storage. Closes #168.
Also modifies the power ticker to run every tick to ensure consistent behaviour.

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
