### PR TITLE
make itemstack capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build
 # other
 eclipse
 run
+run-server
 
 # Files from Forge MDK
 forge*changelog.txt

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ minecraft {
         }
 
         server {
-            workingDirectory project.file('run')
+            workingDirectory project.file('run-server')
 
             property 'forge.logging.markers', 'REGISTRIES'
             property 'forge.logging.console.level', 'debug'

--- a/src/api/java/com/enderio/api/capability/ICoordinateSelectionHolder.java
+++ b/src/api/java/com/enderio/api/capability/ICoordinateSelectionHolder.java
@@ -1,16 +1,8 @@
 package com.enderio.api.capability;
 
-import com.enderio.api.nbt.INamedNBTSerializable;
-import net.minecraft.nbt.Tag;
-
 import java.util.function.Consumer;
 
-public interface ICoordinateSelectionHolder extends INamedNBTSerializable<Tag> {
-
-    @Override
-    default String getSerializedName() {
-        return "CoordinateSelection";
-    }
+public interface ICoordinateSelectionHolder {
 
     CoordinateSelection getSelection();
 

--- a/src/api/java/com/enderio/api/capability/IToggled.java
+++ b/src/api/java/com/enderio/api/capability/IToggled.java
@@ -1,16 +1,9 @@
 package com.enderio.api.capability;
 
-import com.enderio.api.nbt.INamedNBTSerializable;
-import net.minecraft.nbt.Tag;
-
 /**
  * Defines something that can be toggled, like an item.
  */
-public interface IToggled extends INamedNBTSerializable<Tag> {
-    @Override
-    default String getSerializedName() {
-        return "ToggleState";
-    }
+public interface IToggled {
 
     /**
      * Get whether the toggleable is enabled.
@@ -26,10 +19,4 @@ public interface IToggled extends INamedNBTSerializable<Tag> {
      * Set whether this is enabled.
      */
     void setEnabled(boolean isEnabled);
-
-    @Override
-    Tag serializeNBT();
-
-    @Override
-    void deserializeNBT(Tag nbt);
 }

--- a/src/machines/java/com/enderio/machines/common/item/PoweredSpawnerItem.java
+++ b/src/machines/java/com/enderio/machines/common/item/PoweredSpawnerItem.java
@@ -6,7 +6,7 @@ import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.core.client.item.IAdvancedTooltipProvider;
 import com.enderio.core.common.util.EntityUtil;
 import com.enderio.core.common.util.TooltipUtil;
-import com.enderio.machines.common.capability.EntityStorageItemStack;
+import com.enderio.base.common.capability.EntityStorageItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;

--- a/src/machines/java/com/enderio/machines/common/recipe/AlloySmeltingRecipe.java
+++ b/src/machines/java/com/enderio/machines/common/recipe/AlloySmeltingRecipe.java
@@ -157,7 +157,7 @@ public class AlloySmeltingRecipe implements MachineRecipe<AlloySmeltingRecipe.Co
             // Load result, energy and experience.
             ItemStack result = CraftingHelper.getItemStack(serializedRecipe.getAsJsonObject("result"), false);
             int energy = serializedRecipe.get("energy").getAsInt();
-            float experience = serializedRecipe.get("experience").getAsInt();
+            float experience = serializedRecipe.get("experience").getAsFloat();
             return new AlloySmeltingRecipe(recipeId, inputs, result, energy, experience);
         }
 

--- a/src/machines/java/com/enderio/machines/common/recipe/SoulBindingRecipe.java
+++ b/src/machines/java/com/enderio/machines/common/recipe/SoulBindingRecipe.java
@@ -218,18 +218,12 @@ public class SoulBindingRecipe implements MachineRecipe<SoulBindingRecipe.Contai
 
                 ResourceLocation entityType = null;
                 if (buffer.readBoolean()) {
-                    try { //fails if not present
-                        entityType = buffer.readResourceLocation();
-                    } catch (Exception ignored) {
-                    }
+                    entityType = buffer.readResourceLocation();
                 }
 
                 MobCategory mobCategory = null;
                 if (buffer.readBoolean()) {
-                    try { //fails if not present
-                        mobCategory = MobCategory.byName(buffer.readUtf());
-                    } catch (Exception ignored) {
-                    }
+                    mobCategory = MobCategory.byName(buffer.readUtf());
                 }
 
                 return new SoulBindingRecipe(recipeId, output, input, energy, exp, entityType, mobCategory);

--- a/src/machines/java/com/enderio/machines/common/recipe/SoulBindingRecipe.java
+++ b/src/machines/java/com/enderio/machines/common/recipe/SoulBindingRecipe.java
@@ -217,15 +217,19 @@ public class SoulBindingRecipe implements MachineRecipe<SoulBindingRecipe.Contai
                 int exp = buffer.readInt();
 
                 ResourceLocation entityType = null;
-                try { //fails if not present
-                    entityType = buffer.readResourceLocation();
-                } catch (Exception ignored) {
+                if (buffer.readBoolean()) {
+                    try { //fails if not present
+                        entityType = buffer.readResourceLocation();
+                    } catch (Exception ignored) {
+                    }
                 }
 
                 MobCategory mobCategory = null;
-                try { //fails if not present
-                    mobCategory = MobCategory.byName(buffer.readUtf());
-                } catch (Exception ignored) {
+                if (buffer.readBoolean()) {
+                    try { //fails if not present
+                        mobCategory = MobCategory.byName(buffer.readUtf());
+                    } catch (Exception ignored) {
+                    }
                 }
 
                 return new SoulBindingRecipe(recipeId, output, input, energy, exp, entityType, mobCategory);
@@ -242,9 +246,13 @@ public class SoulBindingRecipe implements MachineRecipe<SoulBindingRecipe.Contai
                 recipe.input.toNetwork(buffer);
                 buffer.writeInt(recipe.energy);
                 buffer.writeInt(recipe.exp);
+
+                buffer.writeBoolean(recipe.entityType != null);
                 if (recipe.entityType != null) { //don't write null
                     buffer.writeResourceLocation(recipe.entityType);
                 }
+
+                buffer.writeBoolean(recipe.mobCategory != null);
                 if (recipe.mobCategory != null) { //don't write null
                     buffer.writeUtf(recipe.mobCategory.getName());
                 }

--- a/src/main/java/com/enderio/base/common/capability/CoordinateSelectionHolder.java
+++ b/src/main/java/com/enderio/base/common/capability/CoordinateSelectionHolder.java
@@ -4,42 +4,40 @@ import com.enderio.api.capability.CoordinateSelection;
 import com.enderio.api.capability.ICoordinateSelectionHolder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
-import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
-
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 public class CoordinateSelectionHolder implements ICoordinateSelectionHolder {
 
-    @Nullable
-    private CoordinateSelection selection;
+    private final ItemStack stack;
+
+    public CoordinateSelectionHolder(ItemStack stack) {
+        this.stack = stack;
+    }
 
     @Nullable
     @Override
     public CoordinateSelection getSelection() {
-        return selection;
+        CompoundTag tag = stack.getOrCreateTag();
+        if (tag.contains("Selection")) {
+            CompoundTag selectionnbt = tag.getCompound("Selection");
+            CoordinateSelection selection = new CoordinateSelection(new ResourceLocation(selectionnbt.getString("level")),
+                NbtUtils.readBlockPos(selectionnbt.getCompound("pos")));
+            return selection;
+        }
+        return null;
     }
 
     @Override
     public void setSelection(CoordinateSelection selection) {
-        this.selection = selection;
-    }
-
-    @Override
-    public CompoundTag serializeNBT() {
-        CompoundTag nbt = new CompoundTag();
         if (hasSelection()) {
-            nbt.putString("level", selection.level().toString());
-            nbt.put("pos", NbtUtils.writeBlockPos(selection.pos()));
+            CompoundTag selectionnbt = new CompoundTag();
+            selectionnbt.putString("level", selection.level().toString());
+            selectionnbt.put("pos", NbtUtils.writeBlockPos(selection.pos()));
+            CompoundTag stacktag = stack.getOrCreateTag();
+            stacktag.put("Selection", selectionnbt);
         }
-        return nbt;
-    }
 
-    @Override
-    public void deserializeNBT(Tag tag) {
-        if (tag instanceof CompoundTag nbt && !nbt.isEmpty()) {
-            selection = new CoordinateSelection(new ResourceLocation(nbt.getString("level")),
-                NbtUtils.readBlockPos(nbt.getCompound("pos")));
-        }
     }
 }

--- a/src/main/java/com/enderio/base/common/capability/EnergyStorageItemStack.java
+++ b/src/main/java/com/enderio/base/common/capability/EnergyStorageItemStack.java
@@ -1,0 +1,105 @@
+package com.enderio.base.common.capability;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.energy.IEnergyStorage;
+
+public class EnergyStorageItemStack implements IEnergyStorage {
+
+    private final ItemStack stack;
+
+    public EnergyStorageItemStack(ItemStack stack, int capacity) {
+        this(stack, capacity, capacity, capacity, 0);
+    }
+
+    public EnergyStorageItemStack(ItemStack stack, int capacity, int maxReceive, int maxExtract, int energy) {
+        this.stack = stack;
+        CompoundTag tag = this.stack.getOrCreateTag();
+        CompoundTag nbt = new CompoundTag();
+        if (!tag.contains("EnergyStorage")) {
+            nbt.putInt("Capacity", capacity);
+            nbt.putInt("MaxReceive", maxReceive);
+            nbt.putInt("MaxExtract", maxExtract);
+            nbt.putInt("Energy", energy);
+            tag.put("EnergyStorage", nbt);
+        }
+    }
+
+    @Override
+    public int receiveEnergy(int maxReceive, boolean simulate) {
+        CompoundTag tag = this.stack.getOrCreateTag();
+        if (tag.contains("EnergyStorage")) {
+            int capacity = tag.getCompound("EnergyStorage").getInt("Capacity");
+            int maxReceiveInternal = tag.getCompound("EnergyStorage").getInt("MaxReceive");
+            int energy = tag.getCompound("EnergyStorage").getInt("Energy");
+
+            if (maxReceiveInternal <= 0) {
+                return 0;
+            }
+            int energyReceived = Math.min(capacity - energy, Math.min(maxReceiveInternal, maxReceive));
+            if (!simulate) {
+                energy += energyReceived;
+                tag.getCompound("EnergyStorage").putInt("Energy", energy);
+
+            }
+            return energyReceived;
+        }
+        return 0;
+    }
+
+    @Override
+    public int extractEnergy(int maxExtract, boolean simulate) {
+        CompoundTag tag = this.stack.getOrCreateTag();
+        if (tag.contains("EnergyStorage")) {
+            int maxExtractInternal = tag.getCompound("EnergyStorage").getInt("MaxExtract");
+            int energy = tag.getCompound("EnergyStorage").getInt("Energy");
+
+            if (maxExtractInternal <= 0) {
+                return 0;
+            }
+            int energyExtracted = Math.min(energy, Math.min(maxExtractInternal, maxExtract));
+            if (!simulate) {
+                energy -= energyExtracted;
+                tag.getCompound("EnergyStorage").putInt("Energy", energy);
+            }
+            return energyExtracted;
+        }
+        return 0;
+    }
+
+    @Override
+    public int getEnergyStored() {
+        CompoundTag tag = this.stack.getOrCreateTag();
+        if (tag.contains("EnergyStorage") && tag.getCompound("EnergyStorage").contains("Energy")) {
+            return tag.getCompound("EnergyStorage").getInt("Energy");
+        }
+        return 0;
+    }
+
+    @Override
+    public int getMaxEnergyStored() {
+        CompoundTag tag = this.stack.getOrCreateTag();
+        if (tag.contains("EnergyStorage") && tag.getCompound("EnergyStorage").contains("Capacity")) {
+            return tag.getCompound("EnergyStorage").getInt("Capacity");
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean canExtract() {
+        CompoundTag tag = this.stack.getOrCreateTag();
+        if (tag.contains("EnergyStorage") && tag.getCompound("EnergyStorage").contains("MaxExtract")) {
+            return tag.getCompound("EnergyStorage").getInt("MaxExtract") > 0;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canReceive() {
+        CompoundTag tag = this.stack.getOrCreateTag();
+        if (tag.contains("EnergyStorage") && tag.getCompound("EnergyStorage").contains("MaxReceive")) {
+            return tag.getCompound("EnergyStorage").getInt("MaxReceive") > 0;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/enderio/base/common/capability/EntityStorageItemStack.java
+++ b/src/main/java/com/enderio/base/common/capability/EntityStorageItemStack.java
@@ -1,7 +1,6 @@
-package com.enderio.machines.common.capability;
+package com.enderio.base.common.capability;
 
 import com.enderio.api.capability.StoredEntityData;
-import com.enderio.base.common.capability.EntityStorage;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 

--- a/src/main/java/com/enderio/base/common/capability/Toggled.java
+++ b/src/main/java/com/enderio/base/common/capability/Toggled.java
@@ -2,11 +2,16 @@ package com.enderio.base.common.capability;
 
 import com.enderio.api.capability.IToggled;
 import com.enderio.base.common.init.EIOCapabilities;
-import net.minecraft.nbt.ByteTag;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 
 public class Toggled implements IToggled {
+
+    private final ItemStack stack;
+
+    public Toggled(ItemStack stack) {
+        this.stack = stack;
+    }
 
     public static boolean isEnabled(ItemStack itemStack) {
         return itemStack.getCapability(EIOCapabilities.TOGGLED).map(IToggled::isEnabled).orElse(false);
@@ -20,32 +25,22 @@ public class Toggled implements IToggled {
         itemStack.getCapability(EIOCapabilities.TOGGLED).ifPresent( iToggled -> iToggled.setEnabled(enabled));
     }
 
-    private boolean enabled = false;
-
     @Override
     public boolean isEnabled() {
-        return enabled;
+        CompoundTag tag = this.stack.getOrCreateTag();
+        if (tag.contains("Toggled"))
+            return tag.getBoolean("Toggled");
+        return false;
     }
 
     @Override
     public void toggle() {
-        enabled = !enabled;
+        setEnabled(!isEnabled());
     }
 
     @Override
     public void setEnabled(boolean isEnabled) {
-        enabled = isEnabled;
-    }
-
-    @Override
-    public Tag serializeNBT() {
-        return ByteTag.valueOf(enabled);
-    }
-
-    @Override
-    public void deserializeNBT(Tag nbt) {
-        if (!(nbt instanceof ByteTag byteTag))
-            throw new IllegalArgumentException("Incorrect NBT data read!");
-        enabled = byteTag.getAsByte() != 0;
+        CompoundTag tag = this.stack.getOrCreateTag();
+        tag.putBoolean("Toggled", isEnabled);
     }
 }

--- a/src/main/java/com/enderio/base/common/item/misc/BrokenSpawnerItem.java
+++ b/src/main/java/com/enderio/base/common/item/misc/BrokenSpawnerItem.java
@@ -3,7 +3,7 @@ package com.enderio.base.common.item.misc;
 import com.enderio.api.capability.IMultiCapabilityItem;
 import com.enderio.api.capability.MultiCapabilityProvider;
 import com.enderio.api.capability.StoredEntityData;
-import com.enderio.base.common.capability.EntityStorage;
+import com.enderio.base.common.capability.EntityStorageItemStack;
 import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.init.EIOItems;
 import com.enderio.base.common.util.EntityCaptureUtils;
@@ -17,7 +17,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.util.LazyOptional;
-
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -63,7 +62,7 @@ public class BrokenSpawnerItem extends Item implements IMultiCapabilityItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSerialized(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(EntityStorage::new));
+        provider.addSerialized(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(()-> new EntityStorageItemStack(stack)));
         return provider;
     }
 

--- a/src/main/java/com/enderio/base/common/item/misc/LocationPrintoutItem.java
+++ b/src/main/java/com/enderio/base/common/item/misc/LocationPrintoutItem.java
@@ -26,8 +26,8 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.network.NetworkHooks;
-
 import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -112,7 +112,7 @@ public class LocationPrintoutItem extends Item implements IMultiCapabilityItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSerialized(EIOCapabilities.COORDINATE_SELECTION_HOLDER, LazyOptional.of(CoordinateSelectionHolder::new));
+        provider.addSimple(EIOCapabilities.COORDINATE_SELECTION_HOLDER, LazyOptional.of(()-> new CoordinateSelectionHolder(stack)));
         return provider;
     }
 }

--- a/src/main/java/com/enderio/base/common/item/tool/PoweredToggledItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/PoweredToggledItem.java
@@ -2,31 +2,29 @@ package com.enderio.base.common.item.tool;
 
 import com.enderio.api.capability.IMultiCapabilityItem;
 import com.enderio.api.capability.MultiCapabilityProvider;
-import com.enderio.core.client.item.EnergyBarDecorator;
+import com.enderio.base.common.capability.EnergyStorageItemStack;
 import com.enderio.base.common.capability.Toggled;
 import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.lang.EIOLang;
+import com.enderio.core.client.item.EnergyBarDecorator;
 import com.enderio.core.client.item.IAdvancedTooltipProvider;
 import com.enderio.core.common.item.ITabVariants;
 import com.enderio.core.common.util.EnergyUtil;
 import com.enderio.core.common.util.TooltipUtil;
 import com.tterrag.registrate.util.CreativeModeTabModifier;
-import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.energy.EnergyStorage;
-
 import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
 public abstract class PoweredToggledItem extends Item implements IMultiCapabilityItem, IAdvancedTooltipProvider, ITabVariants {
@@ -109,8 +107,8 @@ public abstract class PoweredToggledItem extends Item implements IMultiCapabilit
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSerialized(EIOCapabilities.TOGGLED, LazyOptional.of(Toggled::new));
-        provider.addSerialized("Energy", ForgeCapabilities.ENERGY, LazyOptional.of(() -> new EnergyStorage(getMaxEnergy())));
+        provider.addSimple(EIOCapabilities.TOGGLED, LazyOptional.of(() -> new Toggled(stack)));
+        provider.addSimple(ForgeCapabilities.ENERGY, LazyOptional.of(() -> new EnergyStorageItemStack(stack, getMaxEnergy())));
         return provider;
     }
 

--- a/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
@@ -5,7 +5,7 @@ import com.enderio.api.capability.IEntityStorage;
 import com.enderio.api.capability.IMultiCapabilityItem;
 import com.enderio.api.capability.MultiCapabilityProvider;
 import com.enderio.api.capability.StoredEntityData;
-import com.enderio.base.common.capability.EntityStorage;
+import com.enderio.base.common.capability.EntityStorageItemStack;
 import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.init.EIOItems;
 import com.enderio.base.common.lang.EIOLang;
@@ -239,7 +239,7 @@ public class SoulVialItem extends Item implements IMultiCapabilityItem, IAdvance
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSerialized(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(EntityStorage::new));
+        provider.addSerialized(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(()-> new EntityStorageItemStack(stack)));
         return provider;
     }
 

--- a/src/main/java/com/enderio/base/common/recipe/ShapedEntityStorageRecipe.java
+++ b/src/main/java/com/enderio/base/common/recipe/ShapedEntityStorageRecipe.java
@@ -28,7 +28,7 @@ public class ShapedEntityStorageRecipe extends ShapedRecipe {
 
     public ShapedEntityStorageRecipe(ShapedRecipe recipe) {
         super(recipe.getId(), recipe.getGroup(), recipe.category(), recipe.getRecipeWidth(), recipe.getRecipeHeight(), recipe.getIngredients(),
-            recipe.getResultItem(Minecraft.getInstance().level != null ? Minecraft.getInstance().level.registryAccess() : null)); // Gross, but better than always passing null
+            recipe.result); // Gross, but better than always passing null
 
         REGISTERED_RECIPES.add(recipe.getId());
     }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -27,3 +27,6 @@ public-f net.minecraft.client.renderer.MultiBufferSource$BufferSource f_109905_ 
 public net.minecraft.data.recipes.SimpleCookingRecipeBuilder m_247292_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/item/crafting/CookingBookCategory; # determineSmeltingRecipeCategory
 public net.minecraft.data.recipes.SimpleCookingRecipeBuilder m_246122_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/item/crafting/CookingBookCategory; # determineBlastingRecipeCategory
 public net.minecraft.data.recipes.SimpleCookingRecipeBuilder m_246784_(Lnet/minecraft/world/item/crafting/RecipeSerializer;Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/item/crafting/CookingBookCategory; # determineRecipeCategory
+
+# For passing to our wrapped recipe
+public-f net.minecraft.world.item.crafting.ShapedRecipe f_44149_ # result


### PR DESCRIPTION
These capabilities directly store their data in the itemstack nbt.

# Description

The caps on itemstacks aren't synced in multiplayer, so we need to store and send them ourselves. For this we make use of the nbt data on the itemstack directly.

Fixes issue(s): #169 

# Todo <!-- Remove this section if you're submitting an already-complete PR -->

- [ ] Replace strings in NBT with constants
- [x] Verify multiplayer worlds

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
