### PR TITLE
Fix capture of misc entity categories

### DIFF
--- a/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
@@ -136,7 +136,9 @@ public class SoulVialItem extends Item implements IMultiCapabilityItem, IAdvance
                 }
 
                 // Get the entity type and verify it is allowed to be captured
-                EntityCaptureUtils.CapturableStatus status = EntityCaptureUtils.getCapturableStatus(entity.getType(),entity);
+                // We ignore the unchecked cast, as entity is LivingEntity
+                // noinspection unchecked
+                EntityCaptureUtils.CapturableStatus status = EntityCaptureUtils.getCapturableStatus((EntityType<? extends LivingEntity>)entity.getType(), entity);
                 if (status != EntityCaptureUtils.CapturableStatus.CAPTURABLE) {
                     displayCallback.accept(status.errorMessage());
                     return InteractionResult.FAIL;

--- a/src/main/java/com/enderio/base/common/util/EntityCaptureUtils.java
+++ b/src/main/java/com/enderio/base/common/util/EntityCaptureUtils.java
@@ -3,32 +3,52 @@ package com.enderio.base.common.util;
 import com.enderio.base.common.config.BaseConfig;
 import com.enderio.base.common.lang.EIOLang;
 import com.enderio.core.common.util.EntityUtil;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class EntityCaptureUtils {
     // The id of the ender dragon for manual filtering.
     private static final ResourceLocation DRAGON = new ResourceLocation("minecraft", "ender_dragon");
 
+    @Nullable
+    private static List<ResourceLocation> capturableEntities = null;
+
     public static List<ResourceLocation> getCapturableEntities() {
-        List<ResourceLocation> entities = new ArrayList<>();
-        for (EntityType<?> type : ForgeRegistries.ENTITY_TYPES.getValues()) {
-            if (getCapturableStatus(type, null) == CapturableStatus.CAPTURABLE) {
-                ResourceLocation key = ForgeRegistries.ENTITY_TYPES.getKey(type);
-                if (key != null && !key.equals(DRAGON)) {
-                    entities.add(key);
+        if (capturableEntities == null) {
+            //noinspection unchecked
+            var livingEntities = ImmutableList.copyOf(
+                ForgeRegistries.ENTITY_TYPES.getValues().stream()
+                    .filter(DefaultAttributes::hasSupplier)
+                    .map(entityType -> (EntityType<? extends LivingEntity>) entityType)
+                    .collect(Collectors.toList()));
+
+            List<ResourceLocation> entities = new ArrayList<>();
+            for (EntityType<? extends LivingEntity> type : livingEntities) {
+                if (getCapturableStatus(type, null) == CapturableStatus.CAPTURABLE) {
+                    ResourceLocation key = ForgeRegistries.ENTITY_TYPES.getKey(type);
+                    if (key != null && !key.equals(DRAGON)) {
+                        entities.add(key);
+                    }
                 }
             }
+
+            capturableEntities = ImmutableList.copyOf(entities);
         }
-        return entities;
+
+        return capturableEntities;
     }
 
     public enum CapturableStatus {
@@ -53,16 +73,17 @@ public class EntityCaptureUtils {
      * @param entity The specific entity to be used or null if general information is wanted
      * @return the status on how this entity should be handled for capture
      */
-    public static CapturableStatus getCapturableStatus(EntityType<?> type, @Nullable Entity entity) {
+    public static CapturableStatus getCapturableStatus(EntityType<? extends LivingEntity> type, @Nullable Entity entity) {
 
         if (entity != null && isBlacklistedBoss(entity))
             return CapturableStatus.BOSS;
 
-        if (!type.canSerialize() || type.getCategory() == MobCategory.MISC)
+        if (!type.canSerialize())
             return CapturableStatus.INCOMPATIBLE;
 
-        if (BaseConfig.COMMON.ITEMS.SOUL_VIAL_BLACKLIST.get().contains(ForgeRegistries.ENTITY_TYPES.getKey(type).toString()))
+        if (BaseConfig.COMMON.ITEMS.SOUL_VIAL_BLACKLIST.get().contains(ForgeRegistries.ENTITY_TYPES.getKey(type).toString())) {
             return CapturableStatus.BLACKLISTED;
+        }
 
         return CapturableStatus.CAPTURABLE;
     }


### PR DESCRIPTION
# Description

We were excluding the "misc" category of entities to avoid having arrows and minecarts and such, but turns out villagers etc. are misc! Now we grab all living entities exclusively and we avoid doing that check.

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
