### PR TITLE
Fix Dark Steel Door dropping in Creative mode

### DIFF
--- a/src/generated/resources/data/enderio/loot_tables/blocks/dark_steel_door.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/dark_steel_door.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+              {
+                  "block": "enderio:dark_steel_door",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                      "half": "lower"
+                  }
+              }
+          ],
           "name": "enderio:dark_steel_door"
         }
       ],


### PR DESCRIPTION


# Description
Added json data needed to stop modded doors from dropping their item once destroyed in creative mode.

Hopefully I haven't broken anything lol, first PR.

Fixes issue(s): #179 

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
