### PR TITLE
Fix typo in atlases/blocks.json

### DIFF
--- a/src/main/resources/assets/minecraft/atlases/blocks.json
+++ b/src/main/resources/assets/minecraft/atlases/blocks.json
@@ -1,5 +1,5 @@
 {
-  "souces": [
+  "sources": [
     {
       "type": "directory",
       "source": "enderio:block/overlay",


### PR DESCRIPTION
# Description

Minor typo fix in `atlases/blocks.json`. I noticed this from an error in the game log. 
