### PR TITLE
fix xp

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/types/FluidConduitTicker.java
+++ b/src/conduits/java/com/enderio/conduits/common/types/FluidConduitTicker.java
@@ -7,6 +7,8 @@ import dev.gigaherz.graph3.Graph;
 import dev.gigaherz.graph3.GraphObject;
 import dev.gigaherz.graph3.Mergeable;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.material.FlowingFluid;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.fluids.FluidStack;
@@ -69,7 +71,10 @@ public class FluidConduitTicker extends ICapabilityAwareConduitTicker<IFluidHand
                     if (lockFluids) {
                         for (GraphObject<Mergeable.Dummy> graphObject : graph.getObjects()) {
                             if (graphObject instanceof NodeIdentifier<?> node) {
-                                node.getExtendedConduitData().castTo(FluidExtendedData.class).lockedFluid = transferredFluid.getFluid();
+                                Fluid fluid = transferredFluid.getFluid();
+                                if (fluid instanceof FlowingFluid flowing)
+                                    fluid = flowing.getSource();
+                                node.getExtendedConduitData().castTo(FluidExtendedData.class).lockedFluid = fluid;
                             }
                         }
                     }

--- a/src/machines/java/com/enderio/machines/common/blockentity/XPVacuumBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/XPVacuumBlockEntity.java
@@ -26,7 +26,7 @@ public class XPVacuumBlockEntity extends VacuumMachineBlockEntity<ExperienceOrb>
         // Sync fluid level.
         addDataSlot(new IntegerNetworkDataSlot(
             () -> getFluidTankNN().getFluidInTank(0).getAmount(),
-            i -> getFluidTankNN().setFluid(new FluidStack(EIOFluids.XP_JUICE.get(), i))
+            i -> getFluidTankNN().setFluid(new FluidStack(EIOFluids.XP_JUICE.getSource(), i))
         ));
     }
 
@@ -42,7 +42,7 @@ public class XPVacuumBlockEntity extends VacuumMachineBlockEntity<ExperienceOrb>
 
     @Override
     public void handleEntity(ExperienceOrb xpe) {
-        int filled = getFluidTankNN().fill(new FluidStack(EIOFluids.XP_JUICE.get(), xpe.getValue() * EXP_TO_FLUID), FluidAction.EXECUTE);
+        int filled = getFluidTankNN().fill(new FluidStack(EIOFluids.XP_JUICE.getSource(), xpe.getValue() * EXP_TO_FLUID), FluidAction.EXECUTE);
         if (filled == xpe.getValue() * EXP_TO_FLUID) {
             xpe.discard();
         } else {


### PR DESCRIPTION
# Description

Because we use Flowing and Source XP differently for XP Vacuum and Soul Binder, all fillings after the first one couldn't be inserted, we convert and use the sources now everywhere

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
