### PR TITLE
Primitive Alloy Smelter Serializing Burn Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed the deletion of a bucket when using bucketed fuel in a smelting machine.
 - Fixed inability to add fuel to active primitive alloy smelter.
 - Fixed the output calculations for vanilla smelting in the alloy smelter.
+- Fixed Primitive Alloy Smelter not serializing burn time
 
 ## [6.0.3-alpha] - 2023-07-08
 

--- a/src/machines/java/com/enderio/machines/common/MachineNBTKeys.java
+++ b/src/machines/java/com/enderio/machines/common/MachineNBTKeys.java
@@ -15,4 +15,8 @@ public class MachineNBTKeys extends EIONBTKeys {
     // TODO: The next two should maybe go back into AlloySmelterBlockEntity.
     public static final String MACHINE_MODE = "Mode";
     public static final String PROCESSED_INPUTS = "ProcessedInputs";
+
+    // TODO: If the previous TODO is carried out, these should probably be moved to PrimitiveAlloySmelterBlockEntity
+    public static final String BURN_TIME = "BurnTime";
+    public static final String BURN_DURATION = "BurnDuration";
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/PrimitiveAlloySmelterBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/PrimitiveAlloySmelterBlockEntity.java
@@ -3,6 +3,7 @@ package com.enderio.machines.common.blockentity;
 import com.enderio.api.UseOnly;
 import com.enderio.api.io.energy.EnergyIOMode;
 import com.enderio.core.common.network.slot.FloatNetworkDataSlot;
+import com.enderio.machines.common.MachineNBTKeys;
 import com.enderio.machines.common.config.MachinesConfig;
 import com.enderio.machines.common.io.energy.MachineEnergyStorage;
 import com.enderio.machines.common.io.item.MachineInventoryLayout;
@@ -10,6 +11,7 @@ import com.enderio.machines.common.io.item.SingleSlotAccess;
 import com.enderio.machines.common.menu.PrimitiveAlloySmelterMenu;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -163,5 +165,19 @@ public class PrimitiveAlloySmelterBlockEntity extends AlloySmelterBlockEntity {
     protected boolean isActive() {
         // Ignores power.
         return canAct() && craftingTaskHost.hasTask();
+    }
+
+    @Override
+    public void saveAdditional(CompoundTag pTag) {
+        pTag.putInt(MachineNBTKeys.BURN_TIME, burnTime);
+        pTag.putInt(MachineNBTKeys.BURN_DURATION, burnDuration);
+        super.saveAdditional(pTag);
+    }
+
+    @Override
+    public void load(CompoundTag pTag) {
+        burnTime = pTag.getInt(MachineNBTKeys.BURN_TIME);
+        burnDuration = pTag.getInt(MachineNBTKeys.BURN_DURATION);
+        super.load(pTag);
     }
 }


### PR DESCRIPTION
# Description

Gave the PrimitiveAlloySmelterBlockEntity saveAdditional and load methods to serialize burnTime and burnDuration.

Closes #270 

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] I have added relevant player-facing changes to the `CHANGELOG.md` file.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->