### PR TITLE
add insets to ioconfig

### DIFF
--- a/src/machines/java/com/enderio/machines/client/gui/widget/ioconfig/IOConfigButton.java
+++ b/src/machines/java/com/enderio/machines/client/gui/widget/ioconfig/IOConfigButton.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 public class IOConfigButton<U extends EIOScreen<?>, T extends AbstractWidget> extends AbstractWidget {
     private static final int RENDERER_HEIGHT = 80;
     public static final ResourceLocation IOCONFIG = EnderIO.loc("textures/gui/icons/io_config.png");
+    private static final Inset INSET_ZERO = new Inset(0, 0, 0, 0);
     private final IOConfigWidget<U> configRenderer;
     private final ImageButton neighbourButton;
     private final Supplier<Boolean> playerInvVisible;
@@ -31,6 +32,11 @@ public class IOConfigButton<U extends EIOScreen<?>, T extends AbstractWidget> ex
     private final U addedOn;
 
     public IOConfigButton(U addedOn, int x, int y, int width, int height, MachineMenu<?> menu, Function<AbstractWidget, T> addRenderableWidget, Font font) {
+        this(addedOn, x, y, width, height, menu, addRenderableWidget, font, INSET_ZERO);
+    }
+
+    public IOConfigButton(U addedOn, int x, int y, int width, int height, MachineMenu<?> menu, Function<AbstractWidget, T> addRenderableWidget, Font font,
+        Inset inset) {
         super(x, y, width, height, EIOLang.IOCONFIG);
         this.addedOn = addedOn;
         this.playerInvVisible = menu::getPlayerInvVisible;
@@ -38,10 +44,12 @@ public class IOConfigButton<U extends EIOScreen<?>, T extends AbstractWidget> ex
         setTooltip(Tooltip.create(EIOLang.IOCONFIG.copy().withStyle(ChatFormatting.WHITE)));
 
         var show = !playerInvVisible.get();
-        List<BlockPos> configurables = menu.getBlockEntity() instanceof MultiConfigurable multiConfigurable
-            ? multiConfigurable.getConfigurables() : List.of(menu.getBlockEntity().getBlockPos());
-        configRenderer = new IOConfigWidget<>(addedOn, addedOn.getGuiLeft() + 5, addedOn.getGuiTop() + addedOn.getYSize() - RENDERER_HEIGHT - 5,
-            addedOn.getXSize() - 10, RENDERER_HEIGHT, configurables, font);
+        List<BlockPos> configurables = menu.getBlockEntity() instanceof MultiConfigurable multiConfigurable ?
+            multiConfigurable.getConfigurables() :
+            List.of(menu.getBlockEntity().getBlockPos());
+        configRenderer = new IOConfigWidget<>(addedOn, addedOn.getGuiLeft() + 5 + inset.left,
+            addedOn.getGuiTop() + addedOn.getYSize() - RENDERER_HEIGHT - 5 + inset.top, addedOn.getXSize() - 10 - inset.left - inset.right,
+            RENDERER_HEIGHT - inset.top - inset.bottom, configurables, font);
         configRenderer.visible = show;
         addRenderableWidget.apply(configRenderer);
 
@@ -71,5 +79,7 @@ public class IOConfigButton<U extends EIOScreen<?>, T extends AbstractWidget> ex
 
     @Override
     public void updateWidgetNarration(NarrationElementOutput pNarrationElementOutput) {}
+
+    public record Inset(int left, int right, int top, int bottom) {}
 
 }


### PR DESCRIPTION
# Description

Allows adding insets to ioconfig renderer. This lets it fit in shape/size of screen. Merge before #172.

Create an inset like following and pass it to IOConfigButton constructor:
>  var inset = new IOConfigButton.Inset(20, 20, 20, 20);

# Checklist:

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have performed a self-review of my own code.
- [X] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
