### PR TITLE
Replace missed NBTKeys + Add paint to paint recipe

### DIFF
--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_crafting_table.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_crafting_table.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_fence.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_fence.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_fence_gate.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_fence_gate.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_glowstone.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_glowstone.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_redstone_block.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_redstone_block.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_sand.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_sand.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_slab.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_slab.json
@@ -24,8 +24,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"
@@ -59,8 +59,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint2",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint2",
+                  "target": "BlockEntityTag.Paint2"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_stairs.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_stairs.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_trapdoor.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_trapdoor.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/loot_tables/blocks/painted_wooden_pressure_plate.json
+++ b/src/generated/resources/data/enderio/loot_tables/blocks/painted_wooden_pressure_plate.json
@@ -12,8 +12,8 @@
               "ops": [
                 {
                   "op": "replace",
-                  "source": "paint",
-                  "target": "BlockEntityTag.paint"
+                  "source": "Paint",
+                  "target": "BlockEntityTag.Paint"
                 }
               ],
               "source": "block_entity"

--- a/src/generated/resources/data/enderio/recipes/painting/painted_crafting_table_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_crafting_table_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_crafting_table"
+  },
+  "output": "enderio:painted_crafting_table"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_fence_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_fence_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_fence"
+  },
+  "output": "enderio:painted_fence"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_fence_gate_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_fence_gate_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_fence_gate"
+  },
+  "output": "enderio:painted_fence_gate"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_glowstone_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_glowstone_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_glowstone"
+  },
+  "output": "enderio:painted_glowstone"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_redstone_block_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_redstone_block_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_redstone_block"
+  },
+  "output": "enderio:painted_redstone_block"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_sand_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_sand_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_sand"
+  },
+  "output": "enderio:painted_sand"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_slab_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_slab_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_slab"
+  },
+  "output": "enderio:painted_slab"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_stairs_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_stairs_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_stairs"
+  },
+  "output": "enderio:painted_stairs"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_trapdoor_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_trapdoor_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_trapdoor"
+  },
+  "output": "enderio:painted_trapdoor"
+}

--- a/src/generated/resources/data/enderio/recipes/painting/painted_wooden_pressure_plate_frompainted.json
+++ b/src/generated/resources/data/enderio/recipes/painting/painted_wooden_pressure_plate_frompainted.json
@@ -1,0 +1,7 @@
+{
+  "type": "enderio:painting",
+  "input": {
+    "item": "enderio:painted_wooden_pressure_plate"
+  },
+  "output": "enderio:painted_wooden_pressure_plate"
+}

--- a/src/machines/java/com/enderio/machines/data/recipes/PaintingRecipeProvider.java
+++ b/src/machines/java/com/enderio/machines/data/recipes/PaintingRecipeProvider.java
@@ -37,11 +37,26 @@ public class PaintingRecipeProvider extends EnderRecipeProvider {
         build(EIOBlocks.PAINTED_WOODEN_PRESSURE_PLATE, Ingredient.of(ItemTags.WOODEN_PRESSURE_PLATES), pFinishedRecipeConsumer);
         build(EIOBlocks.PAINTED_SLAB, Ingredient.of(ItemTags.WOODEN_SLABS), pFinishedRecipeConsumer);
         build(EIOBlocks.PAINTED_GLOWSTONE, Ingredient.of(Items.GLOWSTONE), pFinishedRecipeConsumer);
+        //Painted block to painted block
+        build(EIOBlocks.PAINTED_FENCE, Ingredient.of(EIOBlocks.PAINTED_FENCE), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_FENCE_GATE, Ingredient.of(EIOBlocks.PAINTED_FENCE_GATE), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_SAND, Ingredient.of(EIOBlocks.PAINTED_SAND), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_STAIRS, Ingredient.of(EIOBlocks.PAINTED_STAIRS), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_CRAFTING_TABLE, Ingredient.of(EIOBlocks.PAINTED_CRAFTING_TABLE), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_REDSTONE_BLOCK, Ingredient.of(EIOBlocks.PAINTED_REDSTONE_BLOCK), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_TRAPDOOR, Ingredient.of(EIOBlocks.PAINTED_TRAPDOOR), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_WOODEN_PRESSURE_PLATE, Ingredient.of(EIOBlocks.PAINTED_WOODEN_PRESSURE_PLATE), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_SLAB, Ingredient.of(EIOBlocks.PAINTED_SLAB), "_frompainted", pFinishedRecipeConsumer);
+        build(EIOBlocks.PAINTED_GLOWSTONE, Ingredient.of(EIOBlocks.PAINTED_GLOWSTONE), "_frompainted", pFinishedRecipeConsumer);
     }
 
 
     protected void build(ItemLike output, Ingredient input, Consumer<FinishedRecipe> recipeConsumer) {
-        recipeConsumer.accept(new FinishedPaintingRecipe(EnderIO.loc("painting/" + ForgeRegistries.ITEMS.getKey(output.asItem()).getPath()), input, output.asItem()));
+        build(output, input, "", recipeConsumer);
+    }
+
+    protected void build(ItemLike output, Ingredient input, String suffix, Consumer<FinishedRecipe> recipeConsumer) {
+        recipeConsumer.accept(new FinishedPaintingRecipe(EnderIO.loc("painting/" + ForgeRegistries.ITEMS.getKey(output.asItem()).getPath() + suffix), input, output.asItem()));
     }
 
     protected static class FinishedPaintingRecipe extends EnderFinishedRecipe {

--- a/src/main/java/com/enderio/base/client/renderer/PaintedBlockColor.java
+++ b/src/main/java/com/enderio/base/client/renderer/PaintedBlockColor.java
@@ -1,5 +1,6 @@
 package com.enderio.base.client.renderer;
 
+import com.enderio.base.EIONBTKeys;
 import com.enderio.base.common.block.painted.IPaintedBlock;
 import com.enderio.base.common.blockentity.DoublePaintedBlockEntity;
 import com.enderio.base.common.blockentity.IPaintableBlockEntity;
@@ -65,10 +66,10 @@ public class PaintedBlockColor implements BlockColor, ItemColor {
 
     @Override
     public int getColor(ItemStack itemStack, int tintIndex) {
-        if (itemStack.getTag() != null && itemStack.getTag().contains("BlockEntityTag")) {
-            CompoundTag blockEntityTag = itemStack.getTag().getCompound("BlockEntityTag");
-            if (blockEntityTag.contains("paint")) {
-                Block paint = PaintUtils.getBlockFromRL(blockEntityTag.getString("paint"));
+        if (itemStack.getTag() != null && itemStack.getTag().contains(EIONBTKeys.BLOCK_ENTITY_TAG)) {
+            CompoundTag blockEntityTag = itemStack.getTag().getCompound(EIONBTKeys.BLOCK_ENTITY_TAG);
+            if (blockEntityTag.contains(EIONBTKeys.PAINT)) {
+                Block paint = PaintUtils.getBlockFromRL(blockEntityTag.getString(EIONBTKeys.PAINT));
                 if (paint == null)
                     return 0;
                 return Minecraft.getInstance().getItemColors().getColor(paint.asItem().getDefaultInstance(), tintIndex);

--- a/src/main/java/com/enderio/base/common/block/painted/PaintedFenceBlock.java
+++ b/src/main/java/com/enderio/base/common/block/painted/PaintedFenceBlock.java
@@ -26,13 +26,7 @@ public class PaintedFenceBlock extends FenceBlock implements EntityBlock, IPaint
 
     @Override
     public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter level, BlockPos pos, Player player) {
-        ItemStack stack = new ItemStack(this);
-        BlockEntity be = level.getBlockEntity(pos);
-        if (be != null) {
-
-            stack.getOrCreateTag().put("BlockEntityTag", be.saveWithoutMetadata());
-        }
-        return stack;
+        return getPaintedStack(level, pos, this);
     }
 
 }

--- a/src/main/java/com/enderio/base/common/entity/PaintedSandEntity.java
+++ b/src/main/java/com/enderio/base/common/entity/PaintedSandEntity.java
@@ -77,7 +77,7 @@ public class PaintedSandEntity extends FallingBlockEntity implements IEntityAddi
         // Add block entity NBT to item stack
         if (!stack.isEmpty() && blockData != null) {
             CompoundTag itemNbt = new CompoundTag();
-            itemNbt.put("BlockEntityTag", blockData);
+            itemNbt.put(EIONBTKeys.BLOCK_ENTITY_TAG, blockData);
             stack.setTag(itemNbt);
         }
         return super.spawnAtLocation(stack, offsetY);

--- a/src/main/java/com/enderio/base/data/loot/DecorLootTable.java
+++ b/src/main/java/com/enderio/base/data/loot/DecorLootTable.java
@@ -1,5 +1,6 @@
 package com.enderio.base.data.loot;
 
+import com.enderio.base.EIONBTKeys;
 import com.tterrag.registrate.providers.loot.RegistrateBlockLootTables;
 import net.minecraft.advancements.critereon.StatePropertiesPredicate;
 import net.minecraft.world.level.block.Block;
@@ -19,7 +20,7 @@ public class DecorLootTable {
         loot.add(block, LootTable
             .lootTable()
             .withPool(new LootPool.Builder().add(
-                LootItem.lootTableItem(block).apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy("paint", "BlockEntityTag.paint")))));
+                LootItem.lootTableItem(block).apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy(EIONBTKeys.PAINT, EIONBTKeys.BLOCK_ENTITY_TAG + "." + EIONBTKeys.PAINT)))));
     }
 
     public static <T extends Block> void paintedSlab(RegistrateBlockLootTables loot, T block) {
@@ -27,12 +28,12 @@ public class DecorLootTable {
             .lootTable()
             .withPool(new LootPool.Builder().add(LootItem
                 .lootTableItem(block)
-                .apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy("paint", "BlockEntityTag.paint"))
+                .apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy(EIONBTKeys.PAINT, EIONBTKeys.BLOCK_ENTITY_TAG + "." + EIONBTKeys.PAINT))
                 .when(InvertedLootItemCondition.invert(new LootItemBlockStatePropertyCondition.Builder(block).setProperties(
                     StatePropertiesPredicate.Builder.properties().hasProperty(SlabBlock.TYPE, SlabType.TOP))))))
             .withPool(new LootPool.Builder().add(LootItem
                 .lootTableItem(block)
-                .apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy("paint2", "BlockEntityTag.paint"))
+                .apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy(EIONBTKeys.PAINT_2, EIONBTKeys.BLOCK_ENTITY_TAG + "." + EIONBTKeys.PAINT_2))
                 .when(InvertedLootItemCondition.invert(new LootItemBlockStatePropertyCondition.Builder(block).setProperties(
                     StatePropertiesPredicate.Builder.properties().hasProperty(SlabBlock.TYPE, SlabType.BOTTOM)))))));
     }


### PR DESCRIPTION
# Description

Some NBTKeys were missed causing painted blocks to not have the correct nbt.
Add a new recipe to repaint painted blocks.

Closes #304  <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [x] New recipe or add the painted blocks to the wood tag?

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
