### PR TITLE
Remove Serialization from MultiCapabilityProvider

### DIFF
--- a/src/api/java/com/enderio/api/capability/MultiCapabilityProvider.java
+++ b/src/api/java/com/enderio/api/capability/MultiCapabilityProvider.java
@@ -1,11 +1,8 @@
 package com.enderio.api.capability;
 
 import net.minecraft.core.Direction;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.ICapabilitySerializable;
-import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,24 +11,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Automatically combines multiple capabilities together; handling serialization too.
+ * Automatically combines multiple capabilities together.
  */
-public class MultiCapabilityProvider implements ICapabilitySerializable<CompoundTag> {
+public class MultiCapabilityProvider implements ICapabilityProvider {
     private final Map<Capability<?>, LazyOptional<?>> capabilities;
-    private final Map<String, LazyOptional<? extends INBTSerializable<Tag>>> serializedCaps;
 
     public MultiCapabilityProvider() {
         capabilities = new HashMap<>();
-        serializedCaps = new HashMap<>();
     }
 
     public <T> void addSimple(Capability<T> cap, LazyOptional<?> optional) {
         capabilities.putIfAbsent(cap, optional);
-    }
-
-    public <T> void addSerialized(String serializedName, Capability<T> cap, LazyOptional<? extends INBTSerializable<Tag>> optional) {
-        capabilities.putIfAbsent(cap, optional);
-        serializedCaps.putIfAbsent(serializedName, optional);
     }
 
     @NotNull
@@ -40,30 +30,5 @@ public class MultiCapabilityProvider implements ICapabilitySerializable<Compound
         return capabilities
             .getOrDefault(cap, LazyOptional.empty())
             .cast();
-    }
-
-    @Override
-    public CompoundTag serializeNBT() {
-        CompoundTag tag = new CompoundTag();
-
-        for (var entry : serializedCaps.entrySet()) {
-            entry.getValue().ifPresent(
-                capability -> tag.put(entry.getKey(), capability.serializeNBT())
-            );
-        }
-        return tag;
-    }
-
-    @Override
-    public void deserializeNBT(CompoundTag nbt) {
-        for (var entry : serializedCaps.entrySet()) {
-            entry
-                .getValue()
-                .ifPresent(capability -> {
-                    if (nbt.contains(entry.getKey())) {
-                        capability.deserializeNBT(nbt.get(entry.getKey()));
-                    }
-                });
-        }
     }
 }

--- a/src/api/java/com/enderio/api/capability/MultiCapabilityProvider.java
+++ b/src/api/java/com/enderio/api/capability/MultiCapabilityProvider.java
@@ -20,7 +20,7 @@ public class MultiCapabilityProvider implements ICapabilityProvider {
         capabilities = new HashMap<>();
     }
 
-    public <T> void addSimple(Capability<T> cap, LazyOptional<?> optional) {
+    public <T> void add(Capability<T> cap, LazyOptional<?> optional) {
         capabilities.putIfAbsent(cap, optional);
     }
 

--- a/src/machines/java/com/enderio/machines/common/item/PoweredSpawnerItem.java
+++ b/src/machines/java/com/enderio/machines/common/item/PoweredSpawnerItem.java
@@ -36,7 +36,7 @@ public class PoweredSpawnerItem extends BlockItem implements IMultiCapabilityIte
 
     @Override
     public @Nullable MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(() -> new EntityStorageItemStack(stack)));
+        provider.add(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(() -> new EntityStorageItemStack(stack)));
         return provider;
     }
 }

--- a/src/main/java/com/enderio/base/common/item/capacitors/FixedCapacitorItem.java
+++ b/src/main/java/com/enderio/base/common/item/capacitors/FixedCapacitorItem.java
@@ -24,7 +24,7 @@ public class FixedCapacitorItem extends Item implements IMultiCapabilityItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(EIOCapabilities.CAPACITOR, LazyOptional.of(() -> data));
+        provider.add(EIOCapabilities.CAPACITOR, LazyOptional.of(() -> data));
         return provider;
     }
 }

--- a/src/main/java/com/enderio/base/common/item/capacitors/LootCapacitorItem.java
+++ b/src/main/java/com/enderio/base/common/item/capacitors/LootCapacitorItem.java
@@ -2,7 +2,6 @@ package com.enderio.base.common.item.capacitors;
 
 import com.enderio.api.capability.IMultiCapabilityItem;
 import com.enderio.api.capability.MultiCapabilityProvider;
-import com.enderio.base.EIONBTKeys;
 import com.enderio.base.common.capacitor.LootCapacitorData;
 import com.enderio.base.common.init.EIOCapabilities;
 import net.minecraft.nbt.CompoundTag;
@@ -20,7 +19,7 @@ public class LootCapacitorItem extends Item implements IMultiCapabilityItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSerialized(EIONBTKeys.CAPACITOR_DATA, EIOCapabilities.CAPACITOR, LazyOptional.of(LootCapacitorData::new));
+        provider.addSimple(EIOCapabilities.CAPACITOR, LazyOptional.of(LootCapacitorData::new));
         return provider;
     }
 }

--- a/src/main/java/com/enderio/base/common/item/capacitors/LootCapacitorItem.java
+++ b/src/main/java/com/enderio/base/common/item/capacitors/LootCapacitorItem.java
@@ -19,7 +19,7 @@ public class LootCapacitorItem extends Item implements IMultiCapabilityItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(EIOCapabilities.CAPACITOR, LazyOptional.of(LootCapacitorData::new));
+        provider.add(EIOCapabilities.CAPACITOR, LazyOptional.of(LootCapacitorData::new));
         return provider;
     }
 }

--- a/src/main/java/com/enderio/base/common/item/darksteel/IDarkSteelItem.java
+++ b/src/main/java/com/enderio/base/common/item/darksteel/IDarkSteelItem.java
@@ -37,8 +37,8 @@ public interface IDarkSteelItem extends IMultiCapabilityItem, IAdvancedTooltipPr
     }
 
     default MultiCapabilityProvider initDarkSteelCapabilities(MultiCapabilityProvider provider, ResourceLocation forItem) {
-        provider.addSimple(EIOCapabilities.DARK_STEEL_UPGRADABLE, LazyOptional.of(() -> new DarkSteelUpgradeable(forItem))); //TODO This cap is probably broken now
-        provider.addSimple(ForgeCapabilities.ENERGY, LazyOptional.of(() -> new EnergyDelegator(provider)));
+        provider.add(EIOCapabilities.DARK_STEEL_UPGRADABLE, LazyOptional.of(() -> new DarkSteelUpgradeable(forItem))); //TODO This cap is probably broken now
+        provider.add(ForgeCapabilities.ENERGY, LazyOptional.of(() -> new EnergyDelegator(provider)));
         return provider;
     }
 

--- a/src/main/java/com/enderio/base/common/item/darksteel/IDarkSteelItem.java
+++ b/src/main/java/com/enderio/base/common/item/darksteel/IDarkSteelItem.java
@@ -3,7 +3,6 @@ package com.enderio.base.common.item.darksteel;
 import com.enderio.api.capability.IDarkSteelUpgrade;
 import com.enderio.api.capability.IMultiCapabilityItem;
 import com.enderio.api.capability.MultiCapabilityProvider;
-import com.enderio.base.EIONBTKeys;
 import com.enderio.base.common.capability.DarkSteelUpgradeable;
 import com.enderio.base.common.capability.EnergyDelegator;
 import com.enderio.base.common.init.EIOCapabilities;
@@ -38,7 +37,7 @@ public interface IDarkSteelItem extends IMultiCapabilityItem, IAdvancedTooltipPr
     }
 
     default MultiCapabilityProvider initDarkSteelCapabilities(MultiCapabilityProvider provider, ResourceLocation forItem) {
-        provider.addSerialized(EIONBTKeys.DARK_STEEL_UPGRADEABLE, EIOCapabilities.DARK_STEEL_UPGRADABLE, LazyOptional.of(() -> new DarkSteelUpgradeable(forItem)));
+        provider.addSimple(EIOCapabilities.DARK_STEEL_UPGRADABLE, LazyOptional.of(() -> new DarkSteelUpgradeable(forItem))); //TODO This cap is probably broken now
         provider.addSimple(ForgeCapabilities.ENERGY, LazyOptional.of(() -> new EnergyDelegator(provider)));
         return provider;
     }

--- a/src/main/java/com/enderio/base/common/item/misc/BrokenSpawnerItem.java
+++ b/src/main/java/com/enderio/base/common/item/misc/BrokenSpawnerItem.java
@@ -62,7 +62,7 @@ public class BrokenSpawnerItem extends Item implements IMultiCapabilityItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(()-> new EntityStorageItemStack(stack)));
+        provider.add(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(()-> new EntityStorageItemStack(stack)));
         return provider;
     }
 

--- a/src/main/java/com/enderio/base/common/item/misc/LocationPrintoutItem.java
+++ b/src/main/java/com/enderio/base/common/item/misc/LocationPrintoutItem.java
@@ -112,7 +112,7 @@ public class LocationPrintoutItem extends Item implements IMultiCapabilityItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(EIOCapabilities.COORDINATE_SELECTION_HOLDER, LazyOptional.of(()-> new CoordinateSelectionHolder(stack)));
+        provider.add(EIOCapabilities.COORDINATE_SELECTION_HOLDER, LazyOptional.of(()-> new CoordinateSelectionHolder(stack)));
         return provider;
     }
 }

--- a/src/main/java/com/enderio/base/common/item/tool/ColdFireIgniter.java
+++ b/src/main/java/com/enderio/base/common/item/tool/ColdFireIgniter.java
@@ -123,7 +123,7 @@ public class ColdFireIgniter extends Item implements IMultiCapabilityItem, ITabV
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(ForgeCapabilities.FLUID_HANDLER_ITEM,
+        provider.add(ForgeCapabilities.FLUID_HANDLER_ITEM,
             new AcceptingFluidItemHandler(stack, 1000, EIOTags.Fluids.COLD_FIRE_IGNITER_FUEL)
                 .getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM));
         return provider;

--- a/src/main/java/com/enderio/base/common/item/tool/LevitationStaffItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/LevitationStaffItem.java
@@ -66,7 +66,7 @@ public class LevitationStaffItem extends PoweredToggledItem {
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(ForgeCapabilities.FLUID_HANDLER_ITEM,
+        provider.add(ForgeCapabilities.FLUID_HANDLER_ITEM,
             new AcceptingFluidItemHandler(stack, 1000, EIOTags.Fluids.STAFF_OF_LEVITY_FUEL).getCapability(
                 ForgeCapabilities.FLUID_HANDLER_ITEM));
         return super.initCapabilities(stack, nbt, provider);

--- a/src/main/java/com/enderio/base/common/item/tool/PoweredToggledItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/PoweredToggledItem.java
@@ -107,8 +107,8 @@ public abstract class PoweredToggledItem extends Item implements IMultiCapabilit
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(EIOCapabilities.TOGGLED, LazyOptional.of(() -> new Toggled(stack)));
-        provider.addSimple(ForgeCapabilities.ENERGY, LazyOptional.of(() -> new EnergyStorageItemStack(stack, getMaxEnergy())));
+        provider.add(EIOCapabilities.TOGGLED, LazyOptional.of(() -> new Toggled(stack)));
+        provider.add(ForgeCapabilities.ENERGY, LazyOptional.of(() -> new EnergyStorageItemStack(stack, getMaxEnergy())));
         return provider;
     }
 

--- a/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
@@ -226,7 +226,7 @@ public class SoulVialItem extends Item implements IMultiCapabilityItem, IAdvance
     @Nullable
     @Override
     public MultiCapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt, MultiCapabilityProvider provider) {
-        provider.addSimple(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(() -> new EntityStorageItemStack(stack)));
+        provider.add(EIOCapabilities.ENTITY_STORAGE, LazyOptional.of(() -> new EntityStorageItemStack(stack)));
         return provider;
     }
 


### PR DESCRIPTION
# Description

Since we serialize ourselves directly to nbt, we no longer need a serializable provider. This solves an issue where the capacitors had not needed nbt data, stopping the autocrafting.

As a side note this change probably broke our current darksteel tools impl. This Impl however was most likely broken on servers, and thus needs a rework.

Closes #315  <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Hopefully nothing.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
