### PR TITLE
Fix multiblock energy storage charging when reaching int.max

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/multienergy/MultiEnergyStorageWrapper.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/multienergy/MultiEnergyStorageWrapper.java
@@ -67,8 +67,19 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
     }
 
     @Override
+    public int receiveEnergy(int maxReceive, boolean simulate) {
+        if (!canReceive())
+            return 0;
+        int energyReceived = (int) Math.min(getLargeMaxEnergyStored() - getLargeEnergyStored(), Math.min(getMaxEnergyUse() * 2, maxReceive));
+        if (!simulate) {
+            addEnergy(energyReceived);
+        }
+        return energyReceived;
+    }
+
+    @Override
     public int takeEnergy(int energy) {
-        if (graph == null)
+        if (graph == null || energy == 0)
             return 0;
 
         int cumulativeEnergy = 0;
@@ -78,6 +89,9 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
         for (GraphObject<Mergeable.Dummy> object : nodes) {
             if (object instanceof MultiEnergyNode node) {
                 cumulativeEnergy += node.getInternal().get().extractEnergy(energy - cumulativeEnergy, false);
+                if (energy - cumulativeEnergy <= 0) {
+                    break;
+                }
             }
         }
         removedEnergy += cumulativeEnergy;
@@ -86,7 +100,7 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
 
     @Override
     public int addEnergy(int energy) {
-        if (graph == null)
+        if (graph == null || energy == 0)
             return 0;
 
         int cumulativeEnergy = 0;
@@ -96,6 +110,9 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
         for (GraphObject<Mergeable.Dummy> object : nodes) {
             if (object instanceof MultiEnergyNode node) {
                 cumulativeEnergy += node.getInternal().get().receiveEnergy(energy - cumulativeEnergy, false);
+                if (energy - cumulativeEnergy <= 0) {
+                    break;
+                }
             }
         }
         addedEnergy += cumulativeEnergy;


### PR DESCRIPTION
# Description

Small fix to make multiblock capacitor accept more than int.max energy. 

Also small optimisation to code extracting/receiving energy - but I believe this code overall could use more love... But I don't personally use enderio much for it and it requires bigger work so not motivated myself... 
Currently every operation on multiblock copies the data from graph, shuffles it, and iterates over all elements (well now not always all), this will make these multiblock structures to cause quite high load, especially when they are big and empty/full, as each operation will repeat every tick doing nothing.

Closes #302 

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.