### PR TITLE
Consume inputs after processing

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
@@ -98,25 +98,15 @@ public abstract class CraftingMachineTask<R extends MachineRecipe<C>, C extends 
             outputs = recipe.craft(container, level.registryAccess());
 
             // TODO: Compact any items that are the same into singular stacks?
+
+            // Store the recipe energy cost.
+            progressRequired = getProgressRequired(recipe);
         }
 
         // If we can't input or output, cancel the task. However, if for some reason we can't output after the inputs are collected, don't.
-        if (!hasConsumedInputs && (!placeOutputs(outputs, true) || !recipe.matches(container, level))) {
+        if ((!placeOutputs(outputs, true) || !recipe.matches(container, level))) {
             isComplete = true;
-            // This means if a sag mill recipe outputs 2 it cancels the recipe, and the determined outputs are cleared. It's a weird behaviour but not necessarily a bug.
-            // We might want to review how this works in the future, as right now we wait for an inventory change rather than the machine tick repeatedly.
             return;
-        }
-
-        // If we haven't done so already, consume inputs for the recipe.
-        if (!hasConsumedInputs) {
-            // Consume inputs for the recipe.
-            consumeInputs(recipe);
-            hasConsumedInputs = true;
-
-            // Store the recipe energy cost.
-            // This is run afterward as it allows container context changes after takeInputs()
-            progressRequired = getProgressRequired(recipe);
         }
 
         // Try to consume as much energy as possible to finish the craft.
@@ -128,6 +118,9 @@ public abstract class CraftingMachineTask<R extends MachineRecipe<C>, C extends 
         if (progressMade >= progressRequired) {
             // Attempt to complete the craft
             if (placeOutputs(outputs, false)) {
+                // Take the inputs
+                consumeInputs(recipe);
+
                 // The receiver was able to take the outputs, task complete.
                 isComplete = true;
             }

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
@@ -104,7 +104,7 @@ public abstract class CraftingMachineTask<R extends MachineRecipe<C>, C extends 
         }
 
         // If we can't input or output, cancel the task. However, if for some reason we can't output after the inputs are collected, don't.
-        if ((!placeOutputs(outputs, true) || !recipe.matches(container, level))) {
+        if (!placeOutputs(outputs, true) || !recipe.matches(container, level)) {
             isComplete = true;
             return;
         }

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/host/CraftingMachineTaskHost.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/host/CraftingMachineTaskHost.java
@@ -65,6 +65,17 @@ public class CraftingMachineTaskHost<R extends MachineRecipe<C>, C extends Conta
         return task;
     }
 
+    @Override
+    protected boolean shouldStartNewTask() {
+        if (super.shouldStartNewTask()) {
+            return true;
+        }
+
+        // If recipe has changed
+        var currentRecipe = findRecipe();
+        return currentRecipe.map(r -> r != getCurrentTask().getRecipe()).orElse(true);
+    }
+
     // endregion
 
     protected Optional<R> findRecipe() {

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/host/CraftingMachineTaskHost.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/host/CraftingMachineTaskHost.java
@@ -73,7 +73,7 @@ public class CraftingMachineTaskHost<R extends MachineRecipe<C>, C extends Conta
 
         // If recipe has changed
         var currentRecipe = findRecipe();
-        return currentRecipe.map(r -> r != getCurrentTask().getRecipe()).orElse(true);
+        return currentRecipe.map(r -> !r.equals(getCurrentTask().getRecipe())).orElse(true);
     }
 
     // endregion

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/host/MachineTaskHost.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/host/MachineTaskHost.java
@@ -71,7 +71,11 @@ public abstract class MachineTaskHost {
     }
 
     public final boolean hasTask() {
-        return currentTask != null;
+        return currentTask != null && !currentTask.isCompleted();
+    }
+
+    protected boolean shouldStartNewTask() {
+        return (currentTask == null || currentTask.isCompleted());
     }
 
     public final float getProgress() {
@@ -94,7 +98,7 @@ public abstract class MachineTaskHost {
 
     public void tick() {
         // If we have no active task, get a new one
-        if ((currentTask == null || currentTask.isCompleted()) && isNewTaskAvailable && canAcceptNewTask.get()) {
+        if (isNewTaskAvailable && canAcceptNewTask.get() && shouldStartNewTask()) {
             currentTask = getNewTask();
             isNewTaskAvailable = false;
         }

--- a/src/machines/java/com/enderio/machines/common/integrations/vanilla/VanillaAlloySmeltingRecipe.java
+++ b/src/machines/java/com/enderio/machines/common/integrations/vanilla/VanillaAlloySmeltingRecipe.java
@@ -82,4 +82,15 @@ public class VanillaAlloySmeltingRecipe extends AlloySmeltingRecipe {
     public RecipeType<?> getType() {
         return vanillaRecipe.getType();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof SmeltingRecipe recipe && recipe.equals(vanillaRecipe)) {
+            return true;
+        }
+        if (obj instanceof VanillaAlloySmeltingRecipe alloySmeltingRecipe && vanillaRecipe.equals(alloySmeltingRecipe.vanillaRecipe)){
+            return true;
+        }
+        return super.equals(obj);
+    }
 }


### PR DESCRIPTION
# Description

This makes machines consume input ingredients after the crafting process has completed, this allows you to change what it is you are crafting, rather than having inputs snatched away.

I have given this a quick bout of testing and it seems to work without issue. Will need proper testing once #297 is merged to ensure both of these changes work well with one another.

This is an implementation of the concept discussed here in #323 and in our Discord.

In conjunction with #297 this should hopefully provide a great quality of life improvement.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
