### PR TITLE
ae2 undisabling a connection with a yeta wrench now properly reconnects

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
@@ -278,6 +278,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
             return Optional.of(conduit.bundle.getNodeFor(type));
         } else if (type.getTicker().canConnectTo(level, getBlockPos(), dir)) {
             connectEnd(dir, type);
+            updateConnectionToData(type);
         }
         return Optional.empty();
     }

--- a/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2ConduitType.java
+++ b/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2ConduitType.java
@@ -30,27 +30,6 @@ public class AE2ConduitType extends TieredConduit<AE2InWorldConduitNodeHost> {
 
     private final boolean dense;
 
-    private final IConduitTicker ticker = new IConduitTicker() {
-        @Override
-        public void tickGraph(IConduitType<?> type, Graph<Mergeable.Dummy> graph, ServerLevel level, TriFunction<ServerLevel, BlockPos, ColorControl, Boolean> isRedstoneActive) {
-            //ae2 graphs don't actually do anything, that's all done by ae2
-        }
-
-        @Override
-        public boolean canConnectTo(Level level, BlockPos conduitPos, Direction direction) {
-            return GridHelper.getExposedNode(level, conduitPos.relative(direction), direction.getOpposite()) != null;
-        }
-
-        @Override
-        public boolean hasConnectionDelay() {
-            return true;
-        }
-
-        @Override
-        public boolean canConnectTo(IConduitType<?> thisType, IConduitType<?> other) {
-            return other instanceof AE2ConduitType;
-        }
-    };
     public AE2ConduitType(boolean dense) {
         super(EnderIO.loc("block/conduit/" + (dense ? "dense_me" : "me")), new ResourceLocation("ae2", "me_cable"), dense ? 32 : 8,
             EnderConduitTypes.ICON_TEXTURE, new Vector2i(0, dense ? 72 : 48));
@@ -59,7 +38,7 @@ public class AE2ConduitType extends TieredConduit<AE2InWorldConduitNodeHost> {
 
     @Override
     public IConduitTicker getTicker() {
-        return ticker;
+        return Ticker.INSTANCE;
     }
 
     @Override
@@ -137,6 +116,30 @@ public class AE2ConduitType extends TieredConduit<AE2InWorldConduitNodeHost> {
         @Override
         public boolean showRedstoneExtract() {
             return false;
+        }
+    }
+
+    private static final class Ticker implements IConduitTicker {
+
+        private static final Ticker INSTANCE = new Ticker();
+        @Override
+        public void tickGraph(IConduitType<?> type, Graph<Mergeable.Dummy> graph, ServerLevel level, TriFunction<ServerLevel, BlockPos, ColorControl, Boolean> isRedstoneActive) {
+            //ae2 graphs don't actually do anything, that's all done by ae2
+        }
+
+        @Override
+        public boolean canConnectTo(Level level, BlockPos conduitPos, Direction direction) {
+            return GridHelper.getExposedNode(level, conduitPos.relative(direction), direction.getOpposite()) != null;
+        }
+
+        @Override
+        public boolean hasConnectionDelay() {
+            return true;
+        }
+
+        @Override
+        public boolean canConnectTo(IConduitType<?> thisType, IConduitType<?> other) {
+            return other instanceof AE2ConduitType;
         }
     }
 }


### PR DESCRIPTION
# Description
using a yeta wrench to disable and reable it didn't reconnect the underlying ae2 network and the visual grid, this is fixed


# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
