### PR TITLE
Added an Energy Textbox Widget

### DIFF
--- a/src/machines/java/com/enderio/machines/client/gui/widget/EnergyTextboxWidget.java
+++ b/src/machines/java/com/enderio/machines/client/gui/widget/EnergyTextboxWidget.java
@@ -1,0 +1,104 @@
+package com.enderio.machines.client.gui.widget;
+
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.network.chat.Component;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+public class EnergyTextboxWidget extends EditBox {
+    private final Supplier<Integer> maxEnergy;
+    
+    public EnergyTextboxWidget(Supplier<Integer> maxEnergy, Font font, int x, int y, int width, int height, Component message) {
+        super(font, x, y, width, height, message);
+        this.maxEnergy = maxEnergy;
+        setCanLoseFocus(true);
+    }
+	
+	@Override
+    public void setCanLoseFocus(boolean canLoseFocus) {
+        super.setCanLoseFocus(canLoseFocus);
+    }
+
+    //Input only accepts numerals
+    @Override
+    public boolean charTyped(char codePoint, int modifiers) {
+
+        if (codePoint >= 48 && codePoint <= 57) {
+            int cursorPos = getCursorPosition() + 1;
+            super.charTyped(codePoint, modifiers);
+            setValue(formatEnergy(getValue()));
+            moveCursorTo(cursorPos);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        super.keyPressed(keyCode, scanCode, modifiers);
+
+        if (keyCode == 259) {
+            int cursorPos = getCursorPosition();
+            setValue(formatEnergy(getValue()));
+
+            if (getValue().equals("0")) {
+                moveCursorTo(1);
+            } else {
+                moveCursorTo(cursorPos);
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+
+        if (mouseX >= getX() && mouseX <= getX() + width && mouseY >= getY() && mouseY <= getY() + height) {
+            super.mouseClicked(mouseX, mouseY, button);
+            return true;
+        } else {
+            setFocused(false);
+            return false;
+        }
+    }
+
+    public String formatEnergy(String value) {
+
+        if (value.isEmpty()) {
+            return "0";
+        }
+
+        int energy = 0;
+        value = value.replace(",", "");
+
+        try {
+            energy = Integer.parseInt(value);
+            energy = Math.min(energy, maxEnergy.get());
+        } catch(Exception e) {
+            energy = 0;
+        }
+
+        try {
+            DecimalFormat decimalFormat = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+            decimalFormat.applyPattern("#,###");
+            return decimalFormat.format(energy);
+        } catch (NumberFormatException e) {
+            return "0";
+        }
+    }
+	
+	public int getInteger() {
+        String integer = getValue().replace(",", "");
+
+        try {
+            return Integer.parseInt(integer);
+        } catch(Exception e) {
+            return 0;
+        }
+    }
+}

--- a/src/machines/java/com/enderio/machines/client/gui/widget/EnergyTextboxWidget.java
+++ b/src/machines/java/com/enderio/machines/client/gui/widget/EnergyTextboxWidget.java
@@ -17,21 +17,18 @@ public class EnergyTextboxWidget extends EditBox {
         this.maxEnergy = maxEnergy;
         setCanLoseFocus(true);
     }
-	
-	@Override
-    public void setCanLoseFocus(boolean canLoseFocus) {
-        super.setCanLoseFocus(canLoseFocus);
-    }
 
-    //Input only accepts numerals
+    //Input only accepts digits (0, 1, ..., 9)
     @Override
     public boolean charTyped(char codePoint, int modifiers) {
 
         if (codePoint >= 48 && codePoint <= 57) {
             int cursorPos = getCursorPosition() + 1;
-            super.charTyped(codePoint, modifiers);
+            boolean res = super.charTyped(codePoint, modifiers);
             setValue(formatEnergy(getValue()));
             moveCursorTo(cursorPos);
+
+            return res;
         }
 
         return false;
@@ -39,7 +36,7 @@ public class EnergyTextboxWidget extends EditBox {
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        super.keyPressed(keyCode, scanCode, modifiers);
+        boolean res = super.keyPressed(keyCode, scanCode, modifiers);
 
         if (keyCode == 259) {
             int cursorPos = getCursorPosition();
@@ -52,7 +49,7 @@ public class EnergyTextboxWidget extends EditBox {
             }
         }
 
-        return false;
+        return res;
     }
 
     @Override
@@ -60,6 +57,13 @@ public class EnergyTextboxWidget extends EditBox {
 
         if (mouseX >= getX() && mouseX <= getX() + width && mouseY >= getY() && mouseY <= getY() + height) {
             super.mouseClicked(mouseX, mouseY, button);
+
+            //Clear content on right click
+            if (button == 1) {
+                setValue("0");
+                moveCursorTo(1);
+            }
+
             return true;
         } else {
             setFocused(false);


### PR DESCRIPTION
# Description

A Textbox that only accepts numbers and format with comma separator in real time.
It can be used in buffers to set energy i/o and was also used in capacitor banks in 1.12

The way I imagine it is that the menu in which it is used control whatever value is stored on it. When ticking, then menu gets the integer and do whatever we want with it (communicate it with the block entity etc...)

I am sure that this can be improved, I take suggestions from the main team (you guys are very skilled :D )

# Checklist:

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have performed a self-review of my own code.
- [X] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.
