### PR TITLE
Fix XP fluid conversions

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
@@ -131,10 +131,13 @@ public class SoulBinderBlockEntity extends PoweredMachineBlockEntity {
 
             @Override
             public int fill(FluidStack resource, FluidAction action) {
-                if (!this.getFluid().getFluid().isSame(EIOFluids.XP_JUICE.getSource()) && this.isFluidValid(resource)) { // Auto convert to own fluid (source) type
-                    resource = new FluidStack(EIOFluids.XP_JUICE.getSource(), resource.getAmount());
+                // Convert into XP Juice
+                if (this.isFluidValid(resource)) {
+                    return super.fill(new FluidStack(EIOFluids.XP_JUICE.getSource(), resource.getAmount()), action);
                 }
-                return super.fill(resource, action);
+
+                // Non-XP is not allowed.
+                return 0;
             }
         };
     }

--- a/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
@@ -29,6 +29,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.templates.FluidTank;
@@ -133,7 +134,12 @@ public class SoulBinderBlockEntity extends PoweredMachineBlockEntity {
             public int fill(FluidStack resource, FluidAction action) {
                 // Convert into XP Juice
                 if (this.isFluidValid(resource)) {
-                    return super.fill(new FluidStack(EIOFluids.XP_JUICE.getSource(), resource.getAmount()), action);
+                    var currentFluid = this.getFluid().getFluid();
+                    if (currentFluid == Fluids.EMPTY || resource.getFluid().isSame(currentFluid)) {
+                        return super.fill(resource, action);
+                    } else {
+                        return super.fill(new FluidStack(currentFluid, resource.getAmount()), action);
+                    }
                 }
 
                 // Non-XP is not allowed.


### PR DESCRIPTION
# Description

Fixes forge:experience fluid conversion to XP Juice. Could also convert to whatever xp fluid is already in the tank, but it makes very little difference tbh.

Fixes #350 and #310 

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
