### PR TITLE
Fix range and Powered Spawner

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/PoweredSpawnerBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/PoweredSpawnerBlockEntity.java
@@ -54,6 +54,8 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity {
         }));
         addDataSlot(new EnumNetworkDataSlot<>(SpawnerBlockedReason.class, this::getReason, this::setReason));
 
+        range = 4;
+
         taskHost = new MachineTaskHost(this, this::hasEnergy) {
             @Override
             protected @Nullable IMachineTask getNewTask() {

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -273,13 +273,17 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
 
     public void decreaseRange() {
         if (this.range > 0) {
-            this.range--;
+            if (level != null && level.isClientSide()) {
+                clientUpdateSlot(rangeDataSlot, range - 1);
+            } else this.range--;
         }
     }
 
     public void increaseRange() {
         if (this.range < getMaxRange()) {
-            this.range++;
+            if (level != null && level.isClientSide()) {
+                clientUpdateSlot(rangeDataSlot, range + 1);
+            } else this.range++;
         }
     }
 

--- a/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
+++ b/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
@@ -128,7 +128,7 @@ public class MachineBlocks {
         .loot((l,t) -> MachinesLootTable.copyNBTSingleCap(l, t, "EntityStorage"))
         .properties(props -> props.strength(2.5f, 8))
         .blockstate(MachineModelUtil::progressMachineBlock)
-        .tag(BlockTags.MINEABLE_WITH_PICKAXE)
+        .tag(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
         .item(PoweredSpawnerItem::new)
         .tab(EIOCreativeTabs.MACHINES)
         .build()

--- a/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
+++ b/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
@@ -29,13 +29,7 @@ import net.minecraft.Util;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraftforge.client.model.generators.BlockModelBuilder;
-import net.minecraftforge.client.model.generators.ConfiguredModel;
-import net.minecraftforge.client.model.generators.ModelFile;
 import net.minecraftforge.client.model.generators.loaders.CompositeModelBuilder;
-import net.minecraftforge.common.util.TransformationHelper;
-import org.joml.Vector3f;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -129,8 +123,12 @@ public class MachineBlocks {
         .lang("Soul Binder")
         .register();
 
-    public static final BlockEntry<ProgressMachineBlock> POWERED_SPAWNER = progressMachine("powered_spawner", () -> MachineBlockEntities.POWERED_SPAWNER)
+    public static final BlockEntry<ProgressMachineBlock> POWERED_SPAWNER = REGISTRATE
+        .block("powered_spawner", properties -> new ProgressMachineBlock(properties, MachineBlockEntities.POWERED_SPAWNER))
         .loot((l,t) -> MachinesLootTable.copyNBTSingleCap(l, t, "EntityStorage"))
+        .properties(props -> props.strength(2.5f, 8))
+        .blockstate(MachineModelUtil::progressMachineBlock)
+        .tag(BlockTags.MINEABLE_WITH_PICKAXE)
         .item(PoweredSpawnerItem::new)
         .tab(EIOCreativeTabs.MACHINES)
         .build()


### PR DESCRIPTION
# Description

This PR fixes 3 things:
- Range is properly updated on the client
- The powered spawner can once again be found in the creative tab.
- The powered spawner has the same range as a vanilla spawner now (3 -> 4).

Closes #(issue) <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Things that are yet to be completed for this PR to no longer be a draft.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
