### PR TITLE
Fixes Machine Item Consumption

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
@@ -103,7 +103,7 @@ public abstract class CraftingMachineTask<R extends MachineRecipe<C>, C extends 
             progressRequired = getProgressRequired(recipe);
         }
 
-        // If we can't input or output, cancel the task. However, if for some reason we can't output after the inputs are collected, don't.
+        // If we don't have a recipe match, complete the task and wait for a new one.
         if (!recipe.matches(container, level)) {
             isComplete = true;
             return;

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/CraftingMachineTask.java
@@ -104,7 +104,7 @@ public abstract class CraftingMachineTask<R extends MachineRecipe<C>, C extends 
         }
 
         // If we can't input or output, cancel the task. However, if for some reason we can't output after the inputs are collected, don't.
-        if (!placeOutputs(outputs, true) || !recipe.matches(container, level)) {
+        if (!recipe.matches(container, level)) {
             isComplete = true;
             return;
         }


### PR DESCRIPTION
# Description

Fixes Machine Item consumption, which leads to infinite recipe reloading when the output is full trying to find a recipe that could be placed.

Closes #409  <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Things that are yet to be completed for this PR to no longer be a draft.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
