### PR TITLE
Fluid conduit crashes game if it has non-existant fluid

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/types/FluidExtendedData.java
+++ b/src/conduits/java/com/enderio/conduits/common/types/FluidExtendedData.java
@@ -6,6 +6,7 @@ import com.enderio.conduits.ConduitNBTKeys;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,7 +71,7 @@ public class FluidExtendedData implements IExtendedConduitData<FluidExtendedData
     public void deserializeNBT(CompoundTag nbt) {
         if (nbt.contains(ConduitNBTKeys.FLUID) && !isMultiFluid) {
             String fluid = nbt.getString(ConduitNBTKeys.FLUID);
-            if (fluid.equals("null")) {
+            if (fluid.equals("null") || ForgeRegistries.FLUIDS.getValue(new ResourceLocation(fluid)) == Fluids.EMPTY) {
                 setLockedFluid(null);
             } else {
                 setLockedFluid(ForgeRegistries.FLUIDS.getValue(new ResourceLocation(fluid)));


### PR DESCRIPTION
# Description

Fluid conduit crashes game if it has non-existant fluid

If a fluid is removed from the game, minecraft / forge will assign 
the fluid to the instance "Fluids.EMPTY".

The nbt fluid string will still be kept (to the non-existant fluid) 
initially, but if you lookup the fluid string in the registries, 
it will return "Fluids.EMPTY".

The fix is to set the lockedFluid to null on deserialization, 
if the fluid, after lookup, is equal to "Fluids.EMPTY".

closes #382
