### PR TITLE
Fix fluid tank rendering

### DIFF
--- a/src/core/java/com/enderio/core/client/RenderUtil.java
+++ b/src/core/java/com/enderio/core/client/RenderUtil.java
@@ -23,26 +23,27 @@ public class RenderUtil {
         renderFace(face, pose, normal, consumer, texture, x, y, z, w, h, color, LightTexture.FULL_BRIGHT);
     }
     public static void renderFace(Direction face, Matrix4f pose, Matrix3f normal, VertexConsumer consumer, TextureAtlasSprite texture, float x, float y, float z, float w, float h, int color, int light) {
+        // Normals are taken from Direction enum. They are necessary for proper lighting and block breaking textures
         switch (face) {
-            case DOWN -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, 1.0f - z, 1.0f - z, y, y, y + h, y + h, x, x + w, y, y + h);
-            case UP -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, z, z, y + h, y + h, y, y, x, x + w, y, y + h);
-            case NORTH -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, y + h, y, z, z, z, z, x, x + w, y, y + h);
-            case SOUTH -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, y, y + h, 1.0f - z, 1.0f - z, 1.0f - z, 1.0f - z, x + w, x, y + h, y);
-            case EAST -> renderFace(pose, normal, consumer, texture, color, light, 1.0f - z, 1.0f - z, y + h, y, x, x + w, x + w, x, x, x + w, y, y + h);
-            case WEST -> renderFace(pose, normal, consumer, texture, color, light, z, z, y, y + h, x, x + w, x + w, x, x + w, x, y + h, y);
+            case DOWN -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, 1.0f - z, 1.0f - z, y, y, y + h, y + h, x, x + w, y, y + h, 0, -1, 0);
+            case UP -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, z, z, y + h, y + h, y, y, x, x + w, y, y + h, 0, 1, 0);
+            case NORTH -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, y + h, y, z, z, z, z, x, x + w, y, y + h, 0, 0, -1);
+            case SOUTH -> renderFace(pose, normal, consumer, texture, color, light, x, x + w, y, y + h, 1.0f - z, 1.0f - z, 1.0f - z, 1.0f - z, x + w, x, y + h, y, 0, 0, 1);
+            case EAST -> renderFace(pose, normal, consumer, texture, color, light, 1.0f - z, 1.0f - z, y + h, y, x, x + w, x + w, x, x, x + w, y, y + h, 1, 0, 0);
+            case WEST -> renderFace(pose, normal, consumer, texture, color, light, z, z, y, y + h, x, x + w, x + w, x, x + w, x, y + h, y, -1, 0, 0);
         }
     }
 
-    private static void renderFace(Matrix4f pose, Matrix3f normal, VertexConsumer consumer, TextureAtlasSprite texture, int color, int light, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3, float u0, float u1, float v0, float v1) {
+    private static void renderFace(Matrix4f pose, Matrix3f normal, VertexConsumer consumer, TextureAtlasSprite texture, int color, int light, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3, float u0, float u1, float v0, float v1, float normalX, float normalY, float normalZ) {
         float minU = u0 * texture.contents().width();
         float maxU = u1 * texture.contents().width();
         float minV = v0 * texture.contents().height();
         float maxV = v1 * texture.contents().height();
 
-        consumer.vertex(pose, x0, y0, z0).color(color).uv(texture.getU(minU), texture.getV(minV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, 0.0f, 0.0f, 0.0f).endVertex();
-        consumer.vertex(pose, x1, y0, z1).color(color).uv(texture.getU(maxU), texture.getV(minV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, 0.0f, 0.0f, 0.0f).endVertex();
-        consumer.vertex(pose, x1, y1, z2).color(color).uv(texture.getU(maxU), texture.getV(maxV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, 0.0f, 0.0f, 0.0f).endVertex();
-        consumer.vertex(pose, x0, y1, z3).color(color).uv(texture.getU(minU), texture.getV(maxV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, 0.0f, 0.0f, 0.0f).endVertex();
+        consumer.vertex(pose, x0, y0, z0).color(color).uv(texture.getU(minU), texture.getV(minV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, normalX, normalY, normalZ).endVertex();
+        consumer.vertex(pose, x1, y0, z1).color(color).uv(texture.getU(maxU), texture.getV(minV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, normalX, normalY, normalZ).endVertex();
+        consumer.vertex(pose, x1, y1, z2).color(color).uv(texture.getU(maxU), texture.getV(maxV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, normalX, normalY, normalZ).endVertex();
+        consumer.vertex(pose, x0, y1, z3).color(color).uv(texture.getU(minU), texture.getV(maxV)).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(normal, normalX, normalY, normalZ).endVertex();
     }
 
     public static float[] unpackVertices(int[] vertices, int vertexIndex, int position, int count) {

--- a/src/machines/java/com/enderio/machines/client/rendering/blockentity/FluidTankBER.java
+++ b/src/machines/java/com/enderio/machines/client/rendering/blockentity/FluidTankBER.java
@@ -6,7 +6,9 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -35,21 +37,22 @@ public class FluidTankBER implements BlockEntityRenderer<FluidTankBlockEntity> {
         if (tank.getFluidAmount() > 0) {
             FluidStack fluidStack = tank.getFluid();
 
-            // Get the preferred render buffer
-            VertexConsumer buffer = bufferSource.getBuffer(ItemBlockRenderTypes.getRenderLayer(fluidStack.getFluid().defaultFluidState()));
+            // Use entity translucent cull sheet so fluid renders in Fabulous
+            VertexConsumer buffer = bufferSource.getBuffer(Sheets.translucentCullBlockSheet());
 
             // Render the fluid
             PoseStack.Pose last = poseStack.last();
-            renderFluid(last.pose(), last.normal(), buffer, blockEntity, fluidStack.getFluid(), tank.getFluidAmount() / (float) tank.getCapacity());
+            renderFluid(last.pose(), last.normal(), buffer, blockEntity, fluidStack.getFluid(), tank.getFluidAmount() / (float) tank.getCapacity(), packedLight);
         }
     }
 
-    private static void renderFluid(Matrix4f pose, Matrix3f normal, VertexConsumer consumer, BlockEntity entity, Fluid fluid, float fillAmount) {
-        IClientFluidTypeExtensions props = IClientFluidTypeExtensions.of(fluid);
-        renderFluid(pose, normal, consumer, fluid, fillAmount, props.getTintColor(null, entity.getLevel(), entity.getBlockPos()));
+    private static void renderFluid(Matrix4f pose, Matrix3f normal, VertexConsumer consumer, BlockEntity entity, Fluid fluid, float fillAmount, int packedLight) {
+        int color = IClientFluidTypeExtensions.of(fluid).getTintColor(fluid.defaultFluidState(), entity.getLevel(), entity.getBlockPos());
+        //if (color == -1) color = 0xffffff;
+        renderFluid(pose, normal, consumer, fluid, fillAmount, color, packedLight);
     }
 
-    public static void renderFluid(Matrix4f pose, Matrix3f normal, VertexConsumer consumer, Fluid fluid, float fillAmount, int color) {
+    public static void renderFluid(Matrix4f pose, Matrix3f normal, VertexConsumer consumer, Fluid fluid, float fillAmount, int color, int packedLight) {
         // Get fluid texture
         IClientFluidTypeExtensions props = IClientFluidTypeExtensions.of(fluid);
         TextureAtlasSprite texture = Minecraft.getInstance().getTextureAtlas(InventoryMenu.BLOCK_ATLAS).apply(props.getStillTexture());
@@ -61,12 +64,12 @@ public class FluidTankBER implements BlockEntityRenderer<FluidTankBlockEntity> {
 
 
         // Top
-        RenderUtil.renderFace(Direction.UP, pose, normal, consumer, texture, inset, inset, inset + fluidHeight, faceSize, faceSize, color);
+        RenderUtil.renderFace(Direction.UP, pose, normal, consumer, texture, inset, inset, inset + fluidHeight, faceSize, faceSize, color, packedLight);
 
         // Sides
-        RenderUtil.renderFace(Direction.SOUTH, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color);
-        RenderUtil.renderFace(Direction.NORTH, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color);
-        RenderUtil.renderFace(Direction.EAST, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color);
-        RenderUtil.renderFace(Direction.WEST, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color);
+        RenderUtil.renderFace(Direction.SOUTH, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color, packedLight);
+        RenderUtil.renderFace(Direction.NORTH, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color, packedLight);
+        RenderUtil.renderFace(Direction.EAST, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color, packedLight);
+        RenderUtil.renderFace(Direction.WEST, pose, normal, consumer, texture, inset, inset, inset, faceSize, fluidHeight, color, packedLight);
     }
 }

--- a/src/machines/java/com/enderio/machines/client/rendering/blockentity/FluidTankBER.java
+++ b/src/machines/java/com/enderio/machines/client/rendering/blockentity/FluidTankBER.java
@@ -5,8 +5,6 @@ import com.enderio.machines.common.blockentity.FluidTankBlockEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;

--- a/src/machines/java/com/enderio/machines/client/rendering/item/FluidTankBEWLR.java
+++ b/src/machines/java/com/enderio/machines/client/rendering/item/FluidTankBEWLR.java
@@ -8,10 +8,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.geom.EntityModelSet;
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelResourceLocation;
@@ -54,7 +51,7 @@ public class FluidTankBEWLR extends BlockEntityWithoutLevelRenderer {
 
                     if (fluid != null && amount > 0) {
                         // Get the preferred render buffer
-                        VertexConsumer fluidBuffer = buffer.getBuffer(ItemBlockRenderTypes.getRenderLayer(fluid.defaultFluidState()));
+                        VertexConsumer fluidBuffer = buffer.getBuffer(Sheets.translucentCullBlockSheet());
 
                         // Determine capacity.
                         int capacity = FluidTankBlockEntity.Standard.CAPACITY;

--- a/src/machines/java/com/enderio/machines/client/rendering/item/FluidTankBEWLR.java
+++ b/src/machines/java/com/enderio/machines/client/rendering/item/FluidTankBEWLR.java
@@ -64,7 +64,7 @@ public class FluidTankBEWLR extends BlockEntityWithoutLevelRenderer {
 
                         PoseStack.Pose pose = poseStack.last();
                         IClientFluidTypeExtensions props = IClientFluidTypeExtensions.of(fluid);
-                        FluidTankBER.renderFluid(pose.pose(), pose.normal(), fluidBuffer, fluid, amount / (float) capacity, props.getTintColor());
+                        FluidTankBER.renderFluid(pose.pose(), pose.normal(), fluidBuffer, fluid, amount / (float) capacity, props.getTintColor(), packedLight);
                     }
                 }
             }

--- a/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
@@ -125,7 +125,7 @@ public class MachineBlock extends BaseEntityBlock {
 
     @Override
     public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
-        if (level.getBlockEntity(pos) instanceof FluidTankBlockEntity fluidTank) {
+        if (level.getExistingBlockEntity(pos) instanceof FluidTankBlockEntity fluidTank) {
             return fluidTank.getFluidTank().getFluid().getFluid().getFluidType().getLightLevel();
         }
         return super.getLightEmission(state, level, pos);

--- a/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
@@ -1,5 +1,6 @@
 package com.enderio.machines.common.block;
 
+import com.enderio.machines.common.blockentity.FluidTankBlockEntity;
 import com.enderio.machines.common.blockentity.base.MachineBlockEntity;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import net.minecraft.core.BlockPos;
@@ -120,5 +121,13 @@ public class MachineBlock extends BaseEntityBlock {
             return machineBlock.supportsRedstoneControl();
         }
         return super.canConnectRedstone(state, level, pos, direction);
+    }
+
+    @Override
+    public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
+        if (level.getBlockEntity(pos) instanceof FluidTankBlockEntity fluidTank) {
+            return fluidTank.getFluidTank().getFluid().getFluid().getFluidType().getLightLevel();
+        }
+        return super.getLightEmission(state, level, pos);
     }
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/FluidTankBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/FluidTankBlockEntity.java
@@ -275,6 +275,7 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity {
             if (!level.isClientSide()) {
                 currentRecipe = level.getRecipeManager().getRecipeFor(MachineRecipes.TANK.type().get(), container, level);
             }
+            level.getLightEngine().checkBlock(worldPosition);
         }
     }
 

--- a/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
+++ b/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
@@ -41,7 +41,7 @@ public class MachineBlocks {
 
     public static final BlockEntry<MachineBlock> FLUID_TANK = REGISTRATE
         .block("fluid_tank", props -> new MachineBlock(props, MachineBlockEntities.FLUID_TANK))
-        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion().lightLevel(state -> 1))
+        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion())
         .loot(MachinesLootTable::copyNBT)
         .tag(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
         .blockstate((ctx, prov) -> prov.horizontalBlock(ctx.get(), prov.models()
@@ -60,7 +60,7 @@ public class MachineBlocks {
 
     public static final BlockEntry<MachineBlock> PRESSURIZED_FLUID_TANK = REGISTRATE
         .block("pressurized_fluid_tank", props -> new MachineBlock(props, MachineBlockEntities.PRESSURIZED_FLUID_TANK))
-        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion().lightLevel(state -> 1))
+        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion())
         .loot(MachinesLootTable::copyNBT)
         .tag(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
         .blockstate((ctx, prov) -> prov.horizontalBlock(ctx.get(), prov.models()

--- a/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
+++ b/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
@@ -41,7 +41,7 @@ public class MachineBlocks {
 
     public static final BlockEntry<MachineBlock> FLUID_TANK = REGISTRATE
         .block("fluid_tank", props -> new MachineBlock(props, MachineBlockEntities.FLUID_TANK))
-        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion())
+        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion().lightLevel(state -> 1))
         .loot(MachinesLootTable::copyNBT)
         .tag(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
         .blockstate((ctx, prov) -> prov.horizontalBlock(ctx.get(), prov.models()
@@ -60,7 +60,7 @@ public class MachineBlocks {
 
     public static final BlockEntry<MachineBlock> PRESSURIZED_FLUID_TANK = REGISTRATE
         .block("pressurized_fluid_tank", props -> new MachineBlock(props, MachineBlockEntities.PRESSURIZED_FLUID_TANK))
-        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion())
+        .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion().lightLevel(state -> 1))
         .loot(MachinesLootTable::copyNBT)
         .tag(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
         .blockstate((ctx, prov) -> prov.horizontalBlock(ctx.get(), prov.models()


### PR DESCRIPTION
# Description
This PR fixes three issues with the fluid tank rendering. First, it fixes certain fluids like Water not rendering in Fabulous graphics by using the `Sheets.translucentCullBlockSheet` render type, which renders correctly in Fabulous graphics. Second, rendered fluids now take light level into account, which fixes fluids like water glowing in the dark. Third, tanks now emit a light level based on their contents, so tanks filled with Lava will light up their surroundings like regular lava.

Closes #427 <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->
