### PR TITLE
Fixed where all mobs that are not explicitly registered have dropped …

### DIFF
--- a/src/main/java/com/enderio/base/common/item/darksteel/DarkSteelSwordItem.java
+++ b/src/main/java/com/enderio/base/common/item/darksteel/DarkSteelSwordItem.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.SwordItem;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 public class DarkSteelSwordItem extends SwordItem implements IAdvancedTooltipProvider {
     public DarkSteelSwordItem(Properties pProperties) {
@@ -27,42 +28,45 @@ public class DarkSteelSwordItem extends SwordItem implements IAdvancedTooltipPro
     @Override
     public boolean hurtEnemy(ItemStack pStack, LivingEntity pTarget, LivingEntity pAttacker) {
         if (pTarget.isDeadOrDying() && pTarget.level().random.nextFloat() < 0.07) {
-            ItemStack skull = getSkull(pTarget);
-            Containers.dropItemStack(pAttacker.level(), pAttacker.position().x, pAttacker.position().y, pAttacker.position().z, skull);
+            Optional<ItemStack> skull = getSkull(pTarget);
+            skull.ifPresent(itemStack ->
+                Containers.dropItemStack(pAttacker.level(), pAttacker.position().x,
+                    pAttacker.position().y, pAttacker.position().z, itemStack)
+            );
         }
         return super.hurtEnemy(pStack, pTarget, pAttacker);
     }
 
     //TODO Quick and dirty. Not using instanceof cause of possible mod oddities
-    public static ItemStack getSkull(LivingEntity pTarget) {
-        ItemStack stack = new ItemStack(Items.SKELETON_SKULL);
+    public static Optional<ItemStack> getSkull(LivingEntity pTarget) {
         if (pTarget.getType() == EntityType.SKELETON || pTarget.getType() == EntityType.STRAY) {
-            stack = new ItemStack(Items.SKELETON_SKULL);
+            return Optional.of(new ItemStack(Items.SKELETON_SKULL));
         }
         if (pTarget.getType() == EntityType.ZOMBIE || pTarget.getType() == EntityType.DROWNED || pTarget.getType() == EntityType.HUSK || pTarget.getType() == EntityType.ZOMBIE_VILLAGER) {
-            stack = new ItemStack(Items.ZOMBIE_HEAD);
+            return Optional.of(new ItemStack(Items.ZOMBIE_HEAD));
         }
         if (pTarget.getType() == EntityType.WITHER_SKELETON) {
-            stack = new ItemStack(Items.WITHER_SKELETON_SKULL);
+            return Optional.of(new ItemStack(Items.WITHER_SKELETON_SKULL));
         }
         if (pTarget.getType() == EntityType.CREEPER) {
-            stack = new ItemStack(Items.CREEPER_HEAD);
+            return Optional.of(new ItemStack(Items.CREEPER_HEAD));
         }
         if (pTarget.getType() == EntityType.ENDER_DRAGON) {
-            stack = new ItemStack(Items.DRAGON_HEAD);
+            return Optional.of(new ItemStack(Items.DRAGON_HEAD));
         }
         if (pTarget.getType() == EntityType.ENDERMAN) {
-            stack = new ItemStack(EIOBlocks.ENDERMAN_HEAD);
+            return Optional.of(new ItemStack(EIOBlocks.ENDERMAN_HEAD));
         }
         if (pTarget.getType() == EntityType.PIGLIN || pTarget.getType() == EntityType.PIGLIN_BRUTE || pTarget.getType() == EntityType.ZOMBIFIED_PIGLIN) {
-            stack = new ItemStack(Items.PIGLIN_HEAD);
+            return Optional.of(new ItemStack(Items.PIGLIN_HEAD));
         }
         if (pTarget instanceof Player player) {
-            stack = new ItemStack(Items.PLAYER_HEAD);
+            ItemStack stack = new ItemStack(Items.PLAYER_HEAD);
             CompoundTag compoundtag = stack.getOrCreateTag();
             compoundtag.putString(PlayerHeadItem.TAG_SKULL_OWNER, player.getDisplayName().getString());
+            return Optional.of(stack);
         }
-        return stack;
+        return Optional.empty();
     }
 
     //TODO remove when doing tools


### PR DESCRIPTION

# Description
I have fixed the error where all mobs that were not registered were dropping a skeleton head. This was because the skeleton head was the default value, and if it wasn't overwritten, the skeleton head would be dropped. Since the methods shouldn't return null, I used optionals. This avoids a situation where an unregistered creature, such as a pig, drops a skeleton head.
Closes #426 
# Checklist
- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

