### PR TITLE
AE2 conduits crashes server on chunkload

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
@@ -115,22 +115,18 @@ public class ConduitBlockEntity extends EnderBlockEntity {
         updateShape();
         if (level instanceof ServerLevel serverLevel) {
             sync();
-            if (checkConnection.isInitialized()) {
-                for (var entry: lazyNodes.entrySet()) {
-                    NodeIdentifier<?> node = entry.getValue();
-                    IExtendedConduitData<?> data = node.getExtendedConduitData();
-                    data.onCreated(entry.getKey(), level, worldPosition, null);
-                    for (Direction dir : Direction.values()) {
-                        tryConnectTo(dir, entry.getKey(), false, false).ifPresent(otherNode -> Graph.connect(node, otherNode));
-                    }
-                    for (GraphObject<Mergeable.Dummy> object : node.getGraph().getObjects()) {
-                        if (object instanceof NodeIdentifier<?> otherNode) {
-                            node.getExtendedConduitData().onConnectTo(otherNode.getExtendedConduitData().cast());
-                        }
-                    }
-                    ConduitSavedData.addPotentialGraph(entry.getKey(), Objects.requireNonNull(node.getGraph()), serverLevel);
+            bundle.onLoad(level, getBlockPos());
+            for (var entry: lazyNodes.entrySet()) {
+                NodeIdentifier<?> node = entry.getValue();
+                for (Direction dir : Direction.values()) {
+                    tryConnectTo(dir, entry.getKey(), false, false).ifPresent(otherNode -> Graph.connect(node, otherNode));
                 }
-                bundle.onLoad(level, getBlockPos());
+                for (GraphObject<Mergeable.Dummy> object : node.getGraph().getObjects()) {
+                    if (object instanceof NodeIdentifier<?> otherNode) {
+                        node.getExtendedConduitData().onConnectTo(otherNode.getExtendedConduitData().cast());
+                    }
+                }
+                ConduitSavedData.addPotentialGraph(entry.getKey(), Objects.requireNonNull(node.getGraph()), serverLevel);
             }
         }
     }

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
@@ -1,6 +1,5 @@
 package com.enderio.conduits.common.blockentity;
 
-import appeng.api.networking.GridHelper;
 import com.enderio.api.UseOnly;
 import com.enderio.api.conduit.IConduitMenuData;
 import com.enderio.api.conduit.IConduitType;

--- a/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
+++ b/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
@@ -64,7 +64,7 @@ public class AE2InWorldConduitNodeHost implements IInWorldGridNodeHost, IExtende
             if (player != null) {
                 mainNode.setOwningPlayer(player);
             }
-            mainNode.create(level, pos);
+            GridHelper.onFirstTick(level.getBlockEntity(pos), blockEntity -> mainNode.create(level, pos));
         }
     }
 


### PR DESCRIPTION
# Description

If you try to create a IManagedGridNode inside an unloaded chunk, AE2 will throw an IllegalStateException.

The documentation for IManagedGridNode.create() is clear: "This should only be called when the node is in a ticking chunk". The suggested solution is GridHelper.onFirstTick().

The fix: When calling AE2InWorldConduitNodeHost.onCreated(), use 
GridHelper.onFirstTick(). Also implement the review suggestions. 

Closes #434
