### PR TITLE
let energy conduits figure out default IO mode by themselves

### DIFF
--- a/src/api/java/com/enderio/api/conduit/IConduitType.java
+++ b/src/api/java/com/enderio/api/conduit/IConduitType.java
@@ -2,7 +2,7 @@ package com.enderio.api.conduit;
 
 import com.enderio.api.UseOnly;
 import com.enderio.api.conduit.ticker.IConduitTicker;
-import com.enderio.api.misc.ColorControl;
+import com.enderio.api.misc.RedstoneControl;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
@@ -49,9 +49,15 @@ public interface IConduitType<T extends IExtendedConduitData<T>> {
         return Optional.empty();
     }
 
-    default ConduitConnectionData getDefaultConnection() {
-        return new ConduitConnectionData(false, true);
+    /**
+     * @param level the level
+     * @param pos conduit position
+     * @param direction direction the conduit connects to
+     * @return the connectiondata that should be set on connection based on context
+     */
+    default ConduitConnectionData getDefaultConnection(Level level, BlockPos pos, Direction direction) {
+        return new ConduitConnectionData(false, true, RedstoneControl.NEVER_ACTIVE);
     }
 
-    record ConduitConnectionData(boolean isInsert, boolean isExtract) {}
+    record ConduitConnectionData(boolean isInsert, boolean isExtract, RedstoneControl control) {}
 }

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
@@ -424,12 +424,12 @@ public class ConduitBlockEntity extends EnderBlockEntity {
     }
 
     private void connect(Direction direction, IConduitType<?> type) {
-        bundle.connectTo(direction, type, false);
+        bundle.connectTo(level, worldPosition, direction, type, false);
         updateClient();
     }
 
     private void connectEnd(Direction direction, IConduitType<?> type) {
-        bundle.connectTo(direction, type, true);
+        bundle.connectTo(level, worldPosition, direction, type, true);
         updateClient();
     }
 

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBundle.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBundle.java
@@ -281,8 +281,8 @@ public final class ConduitBundle implements INBTSerializable<CompoundTag> {
         facadeTextures.put(direction, facade);
     }
 
-    public void connectTo(Direction direction, IConduitType<?> type, boolean end) {
-        getConnection(direction).connectTo(getNodeFor(type), direction, type, getTypeIndex(type), end);
+    public void connectTo(Level level, BlockPos pos, Direction direction, IConduitType<?> type, boolean end) {
+        getConnection(direction).connectTo(level, pos, getNodeFor(type), direction, type, getTypeIndex(type), end);
         scheduleSync.run();
     }
 

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitConnection.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitConnection.java
@@ -8,9 +8,11 @@ import com.enderio.conduits.common.blockentity.connection.DynamicConnectionState
 import com.enderio.conduits.common.blockentity.connection.IConnectionState;
 import com.enderio.conduits.common.blockentity.connection.StaticConnectionStates;
 import net.minecraft.Util;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.common.util.INBTSerializable;
 
 import java.util.ArrayList;
@@ -45,9 +47,9 @@ public class ConduitConnection implements INBTSerializable<CompoundTag> {
         connectionStates[index] = StaticConnectionStates.DISCONNECTED;
     }
 
-    public void connectTo(NodeIdentifier<?> nodeIdentifier, Direction direction, IConduitType<?> type, int typeIndex, boolean end) {
+    public void connectTo(Level level, BlockPos pos, NodeIdentifier<?> nodeIdentifier, Direction direction, IConduitType<?> type, int typeIndex, boolean end) {
         if (end) {
-            var state = DynamicConnectionState.defaultConnection(type);
+            var state = DynamicConnectionState.defaultConnection(level, pos, direction, type);
             connectionStates[typeIndex] = state;
             ConduitBlockEntity.pushIOState(direction, nodeIdentifier, state);
         } else {

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/connection/DynamicConnectionState.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/connection/DynamicConnectionState.java
@@ -5,8 +5,11 @@ import com.enderio.api.conduit.IConduitType;
 import com.enderio.api.misc.ColorControl;
 import com.enderio.api.misc.RedstoneControl;
 import com.enderio.conduits.common.blockentity.SlotType;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.fml.LogicalSide;
 
 import java.util.HashMap;
@@ -14,9 +17,9 @@ import java.util.Map;
 
 public record DynamicConnectionState(boolean isInsert, ColorControl insert, boolean isExtract, ColorControl extract, RedstoneControl control, ColorControl redstoneChannel, @UseOnly(LogicalSide.SERVER) ItemStack filterInsert, @UseOnly(LogicalSide.SERVER) ItemStack filterExtract, @UseOnly(LogicalSide.SERVER) ItemStack upgradeExtract) implements IConnectionState {
 
-    public static DynamicConnectionState defaultConnection(IConduitType<?> type) {
-        IConduitType.ConduitConnectionData defaultConnection = type.getDefaultConnection();
-        return new DynamicConnectionState(defaultConnection.isInsert(), ColorControl.GREEN, defaultConnection.isExtract(), ColorControl.GREEN, RedstoneControl.NEVER_ACTIVE, ColorControl.RED, ItemStack.EMPTY, ItemStack.EMPTY, ItemStack.EMPTY);
+    public static DynamicConnectionState defaultConnection(Level level, BlockPos pos, Direction direction, IConduitType<?> type) {
+        IConduitType.ConduitConnectionData defaultConnection = type.getDefaultConnection(level, pos, direction);
+        return new DynamicConnectionState(defaultConnection.isInsert(), ColorControl.GREEN, defaultConnection.isExtract(), ColorControl.GREEN, defaultConnection.control(), ColorControl.RED, ItemStack.EMPTY, ItemStack.EMPTY, ItemStack.EMPTY);
     }
 
     @Override

--- a/src/conduits/java/com/enderio/conduits/common/init/EnderConduitTypes.java
+++ b/src/conduits/java/com/enderio/conduits/common/init/EnderConduitTypes.java
@@ -11,9 +11,7 @@ public class EnderConduitTypes {
 
     public static final ResourceLocation ICON_TEXTURE = EnderIO.loc("textures/gui/conduit_icon.png");
     public static final RegistryObject<? extends IConduitType<?>> ENERGY = ConduitTypes.CONDUIT_TYPES.register(
-        "energy_conduit",
-        () -> new SimpleConduitType<>(EnderIO.loc("block/conduit/energy"), new EnergyConduitTicker(), EnergyExtendedData::new,
-            new IClientConduitData.Simple<>(ICON_TEXTURE, new Vector2i(0, 24)), IConduitMenuData.ENERGY));
+        "energy_conduit", EnergyConduitType::new);
 
     public static final RegistryObject<FluidConduitType> FLUID = fluidConduit("fluid_conduit", 50, false, new Vector2i(0, 120));
 

--- a/src/conduits/java/com/enderio/conduits/common/types/EnergyConduitType.java
+++ b/src/conduits/java/com/enderio/conduits/common/types/EnergyConduitType.java
@@ -1,0 +1,36 @@
+package com.enderio.conduits.common.types;
+
+import com.enderio.EnderIO;
+import com.enderio.api.conduit.IClientConduitData;
+import com.enderio.api.conduit.IConduitMenuData;
+import com.enderio.api.misc.RedstoneControl;
+import com.enderio.api.misc.Vector2i;
+import com.enderio.conduits.common.init.EnderConduitTypes;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.energy.IEnergyStorage;
+
+public class EnergyConduitType extends SimpleConduitType<EnergyExtendedData> {
+    public EnergyConduitType() {
+        super(EnderIO.loc("block/conduit/energy"), new EnergyConduitTicker(), EnergyExtendedData::new,
+            new IClientConduitData.Simple<>(EnderConduitTypes.ICON_TEXTURE, new Vector2i(0, 24)), IConduitMenuData.ENERGY);
+    }
+
+    @Override
+    public ConduitConnectionData getDefaultConnection(Level level, BlockPos pos, Direction direction) {
+        BlockEntity blockEntity = level.getBlockEntity(pos.relative(direction));
+        if (blockEntity != null) {
+            LazyOptional<IEnergyStorage> capability = blockEntity.getCapability(ForgeCapabilities.ENERGY, direction.getOpposite());
+            if (capability.isPresent()) {
+                IEnergyStorage storage = capability.orElseThrow(() -> new RuntimeException("present capability was not found"));
+                return new ConduitConnectionData(storage.canReceive(), storage.canExtract(), RedstoneControl.ALWAYS_ACTIVE);
+
+            }
+        }
+        return super.getDefaultConnection(level, pos, direction);
+    }
+}


### PR DESCRIPTION
# Description

Energy conduits now figure out the default connection logic, this is an api breaking change, but we are in alpha, so it's okay

Closes #309 

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor
