### PR TITLE
replace slicer recipe cache with a slot aware recipe cache

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/SlicerBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SlicerBlockEntity.java
@@ -104,7 +104,7 @@ public class SlicerBlockEntity extends PoweredMachineBlockEntity {
     }
 
     private boolean isValidInput(int index, ItemStack stack) {
-        return RecipeCaches.SLICING.hasRecipe(List.of(stack));
+        return SlicerRecipeManager.isSlicerValid(stack, index);
     }
 
     private boolean validAxe(int slot, ItemStack stack) {

--- a/src/machines/java/com/enderio/machines/common/blockentity/SlicerRecipeManager.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SlicerRecipeManager.java
@@ -1,0 +1,88 @@
+package com.enderio.machines.common.blockentity;
+
+import com.enderio.machines.common.init.MachineRecipes;
+import com.enderio.machines.common.recipe.SlicingRecipe;
+import net.minecraft.Util;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraftforge.client.event.RecipesUpdatedEvent;
+import net.minecraftforge.event.AddReloadListenerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.util.thread.EffectiveSide;
+import net.minecraftforge.server.ServerLifecycleHooks;
+
+import java.util.*;
+
+@Mod.EventBusSubscriber
+public class SlicerRecipeManager {
+    private static final List<Set<Item>> items = Util.make(() -> {
+        List<Set<Item>> tempList = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            tempList.add(new HashSet<>());
+        }
+        return tempList;
+    });
+    private static final List<Set<Ingredient>> nonoptimizableingredients = Util.make(() -> {
+        List<Set<Ingredient>> tempList = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            tempList.add(new HashSet<>());
+        }
+        return tempList;
+    });
+
+    private static boolean clearCache = false;
+
+    public static boolean isSlicerValid(ItemStack stack, int slot) {
+        checkCacheRebuild();
+        if (items.get(slot).contains(stack.getItem()))
+            return true;
+        for (Ingredient ingredient : nonoptimizableingredients.get(slot)) {
+            if (ingredient.test(stack))
+                return true;
+        }
+        return false;
+    }
+
+    @SubscribeEvent
+    public static void registerReloadListener(AddReloadListenerEvent event) {
+        //Fired on datapack reload
+        clearCache = true;
+    }
+    @SubscribeEvent
+    public static void onRecipesUpdated(RecipesUpdatedEvent event) {
+        rebuildCache(event.getRecipeManager());
+    }
+
+    private static void checkCacheRebuild() {
+        if (clearCache && EffectiveSide.get().isServer()) {
+            rebuildCache(ServerLifecycleHooks.getCurrentServer().getRecipeManager());
+            clearCache = false;
+        }
+    }
+
+    private static void rebuildCache(RecipeManager manager) {
+
+        // Wipe the lookup table
+        for (Set<Item> item : items) {
+            item.clear();
+        }
+        for (Set<Ingredient> nonoptimizableingredient : nonoptimizableingredients) {
+            nonoptimizableingredient.clear();
+        }
+
+        for (SlicingRecipe slicingRecipe : manager.getAllRecipesFor(MachineRecipes.SLICING.type().get())) {
+            for (int i = 0; i < 6; i++) {
+                Ingredient ingredient = slicingRecipe.getInputs().get(i);
+                if (ingredient.getClass() == Ingredient.class) {
+                    Set<Item> itemset = items.get(i);
+                    Arrays.stream(ingredient.getItems()).map(ItemStack::getItem).forEach(itemset::add);
+                } else {
+                    nonoptimizableingredients.get(i).add(ingredient);
+                }
+            }
+        }
+    }
+}

--- a/src/machines/java/com/enderio/machines/common/blockentity/SlicerRecipeManager.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SlicerRecipeManager.java
@@ -76,7 +76,7 @@ public class SlicerRecipeManager {
         for (SlicingRecipe slicingRecipe : manager.getAllRecipesFor(MachineRecipes.SLICING.type().get())) {
             for (int i = 0; i < 6; i++) {
                 Ingredient ingredient = slicingRecipe.getInputs().get(i);
-                if (ingredient.getClass() == Ingredient.class) {
+                if (ingredient.isSimple()) {
                     Set<Item> itemset = items.get(i);
                     Arrays.stream(ingredient.getItems()).map(ItemStack::getItem).forEach(itemset::add);
                 } else {

--- a/src/machines/java/com/enderio/machines/common/recipe/RecipeCaches.java
+++ b/src/machines/java/com/enderio/machines/common/recipe/RecipeCaches.java
@@ -1,11 +1,8 @@
 package com.enderio.machines.common.recipe;
 
 import com.enderio.machines.common.init.MachineRecipes;
-import com.enderio.machines.common.integrations.vanilla.VanillaAlloySmeltingRecipe;
 import com.enderio.machines.common.utility.RecipeInputCache;
 import net.minecraft.world.Container;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.SmeltingRecipe;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
@@ -14,8 +11,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.wrapper.RecipeWrapper;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Mod.EventBusSubscriber
 public class RecipeCaches {
@@ -31,9 +26,6 @@ public class RecipeCaches {
     public static final RecipeInputCache<SagMillingRecipe.Container, SagMillingRecipe> SAGMILLING
         = new RecipeInputCache<>(MachineRecipes.SAGMILLING.type());
 
-    public static final RecipeInputCache<Container, SlicingRecipe> SLICING
-        = new RecipeInputCache<>(MachineRecipes.SLICING.type());
-
     public static final RecipeInputCache<SoulBindingRecipe.Container, SoulBindingRecipe> SOUL_BINDING
         = new RecipeInputCache<>(MachineRecipes.SOUL_BINDING.type());
 
@@ -43,7 +35,6 @@ public class RecipeCaches {
         SMELTING.markCacheDirty();
         PAINTING.markCacheDirty();
         SAGMILLING.markCacheDirty();
-        SLICING.markCacheDirty();
         SOUL_BINDING.markCacheDirty();
     }
 
@@ -53,7 +44,6 @@ public class RecipeCaches {
         SMELTING.rebuildCache(event.getRecipeManager());
         PAINTING.rebuildCache(event.getRecipeManager());
         SAGMILLING.rebuildCache(event.getRecipeManager());
-        SLICING.rebuildCache(event.getRecipeManager());
         SOUL_BINDING.rebuildCache(event.getRecipeManager());
     }
 }

--- a/src/machines/java/com/enderio/machines/common/utility/RecipeInputCache.java
+++ b/src/machines/java/com/enderio/machines/common/utility/RecipeInputCache.java
@@ -2,7 +2,6 @@ package com.enderio.machines.common.utility;
 
 import com.enderio.machines.common.io.item.MachineInventory;
 import com.enderio.machines.common.io.item.MultiSlotAccess;
-import com.enderio.machines.common.recipe.MachineRecipe;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -69,7 +68,7 @@ public class RecipeInputCache<C extends Container, T extends Recipe<C>> {
                     .collect(Collectors.toSet());
             }
 
-            if (possibleMatches.size() == 0) {
+            if (possibleMatches.isEmpty()) {
                 return false;
             }
 
@@ -119,9 +118,7 @@ public class RecipeInputCache<C extends Container, T extends Recipe<C>> {
     public void rebuildCache(RecipeManager recipeManager) {
         itemToRecipesCache.clear();
         recipeToIngredientCache.clear();
-
-        var recipeType = this.recipeType.get();
-        recipeManager.getAllRecipesFor(recipeType)
+        recipeManager.getAllRecipesFor(recipeType.get())
             .forEach(recipe -> {
                 var items = recipe.getIngredients().stream()
                     .flatMap(ingredient -> Arrays.stream(ingredient.getItems()))


### PR DESCRIPTION
# Description

Swap out the recipe cache for the slicer to one that cares about slot indices
Closes #384 

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
