### PR TITLE
Pull lightemission to the Block Entity Level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ void exclusiveRepo(RepositoryHandler handler, String url, Consumer<InclusiveRepo
 }
 
 repositories { RepositoryHandler handler ->
-    exclusiveRepo(handler, 'https://maven.tterrag.com/', 'com.tterrag.registrate')
+    exclusiveRepo(handler, 'https://maven.tterrag.com/', 'com.tterrag.registrate', 'com.jozufozu.flywheel')
     exclusiveRepo(handler, 'https://modmaven.dev/', 'mezz.jei', 'mcjty.theoneprobe', 'appeng')
     exclusiveRepo(handler, 'https://cursemaven.com', 'curse.maven')
     exclusiveRepo(handler, 'https://maven.blamejared.com', 'vazkii.patchouli', 'net.darkhax.bookshelf', 'net.darkhax.enchdesc')
@@ -259,6 +259,9 @@ dependencies {
 
     // Jade
     runtimeOnly fg.deobf("curse.maven:jade-324717:${jade_cf_id}")
+
+    //Flywheel
+    compileOnly fg.deobf("com.jozufozu.flywheel:flywheel-forge-1.20.1:0.6.9-5") // REMOVE When crash is fixed
 
     // Patchouli
 //    compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")

--- a/src/core/java/com/enderio/core/common/compat/FlywheelCompat.java
+++ b/src/core/java/com/enderio/core/common/compat/FlywheelCompat.java
@@ -1,0 +1,18 @@
+package com.enderio.core.common.compat;
+
+import com.jozufozu.flywheel.core.virtual.VirtualRenderWorld;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.Nullable;
+
+public class FlywheelCompat {
+
+    @Nullable
+    public static BlockEntity getExistingBlockEntity(BlockGetter level, BlockPos pos) {
+        if (level instanceof VirtualRenderWorld) {
+            return level.getBlockEntity(pos);
+        }
+        return level.getExistingBlockEntity(pos);
+    }
+}

--- a/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
@@ -1,5 +1,6 @@
 package com.enderio.machines.common.block;
 
+import com.enderio.core.common.compat.FlywheelCompat;
 import com.enderio.machines.common.blockentity.base.MachineBlockEntity;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import net.minecraft.core.BlockPos;
@@ -24,6 +25,7 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
 
@@ -124,7 +126,13 @@ public class MachineBlock extends BaseEntityBlock {
 
     @Override
     public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
-        if (level.getExistingBlockEntity(pos) instanceof MachineBlockEntity machineBlock) {
+        BlockEntity existingBlockEntity;
+        if (ModList.get().isLoaded("flywheel")) {
+            existingBlockEntity =  FlywheelCompat.getExistingBlockEntity(level, pos);
+        } else {
+            existingBlockEntity = level.getExistingBlockEntity(pos);
+        }
+        if (existingBlockEntity instanceof MachineBlockEntity machineBlock) {
             return machineBlock.getLightEmission();
         }
         return super.getLightEmission(state, level, pos);

--- a/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
@@ -1,6 +1,5 @@
 package com.enderio.machines.common.block;
 
-import com.enderio.machines.common.blockentity.FluidTankBlockEntity;
 import com.enderio.machines.common.blockentity.base.MachineBlockEntity;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import net.minecraft.core.BlockPos;
@@ -125,8 +124,8 @@ public class MachineBlock extends BaseEntityBlock {
 
     @Override
     public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
-        if (level.getExistingBlockEntity(pos) instanceof FluidTankBlockEntity fluidTank) {
-            return fluidTank.getFluidTank().getFluid().getFluid().getFluidType().getLightLevel();
+        if (level.getExistingBlockEntity(pos) instanceof MachineBlockEntity machineBlock) {
+            return machineBlock.getLightEmission();
         }
         return super.getLightEmission(state, level, pos);
     }

--- a/src/machines/java/com/enderio/machines/common/blockentity/FluidTankBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/FluidTankBlockEntity.java
@@ -284,6 +284,11 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity {
         return new FluidTankMenu(this, pInventory, pContainerId);
     }
 
+    @Override
+    public int getLightEmission() {
+        return getFluidTank().getFluid().getFluid().getFluidType().getLightLevel();
+    }
+    
     // region Serialization
 
     @Override

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -26,7 +26,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
@@ -735,5 +734,9 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
 
     public boolean canOpenMenu() {
         return true;
+    }
+
+    public int getLightEmission() {
+        return getBlockState().getLightEmission();
     }
 }


### PR DESCRIPTION
# Description

Pull light emission to the Block Entity Level, as not to special case it in the MachineBlock class.
Secondly, this currently has an issue with flywheel and create contraptions, as the BE lookup crashes. I would like to wait for a fix on their end, but if this takes too long we should at compact similar to [Framed Blocks](https://github.com/XFactHD/FramedBlocks/blob/1.20/src/main/java/xfacthd/framedblocks/common/util/InternalApiImpl.java#L13-L20)

Closes #(issue) <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [x] Flywheel compat.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
