### PR TITLE
Update Slot on Shift Click

### DIFF
--- a/src/machines/java/com/enderio/machines/common/menu/MachineMenu.java
+++ b/src/machines/java/com/enderio/machines/common/menu/MachineMenu.java
@@ -105,12 +105,12 @@ public abstract class MachineMenu<T extends MachineBlockEntity> extends SyncedMe
                             if (j <= maxSize) {
                                 stack.setCount(0);
                                 itemstack.setCount(j);
-                                slot.setChanged();
+                                slot.set(itemstack);
                                 flag = true;
                             } else if (itemstack.getCount() < maxSize) {
                                 stack.shrink(maxSize - itemstack.getCount());
                                 itemstack.setCount(maxSize);
-                                slot.setChanged();
+                                slot.set(itemstack);
                                 flag = true;
                             }
                         }

--- a/src/machines/java/com/enderio/machines/common/menu/MachineSlot.java
+++ b/src/machines/java/com/enderio/machines/common/menu/MachineSlot.java
@@ -34,9 +34,4 @@ public class MachineSlot extends SlotItemHandler {
     public boolean canQuickInsertStack() {
         return getItemHandler().getLayout().guiCanInsert(getSlotIndex());
     }
-
-    @Override
-    public void setChanged() {
-        getItemHandler().setStackInSlot(this.getSlotIndex(), this.getItem());
-    }
 }

--- a/src/machines/java/com/enderio/machines/common/menu/MachineSlot.java
+++ b/src/machines/java/com/enderio/machines/common/menu/MachineSlot.java
@@ -34,4 +34,9 @@ public class MachineSlot extends SlotItemHandler {
     public boolean canQuickInsertStack() {
         return getItemHandler().getLayout().guiCanInsert(getSlotIndex());
     }
+
+    @Override
+    public void setChanged() {
+        getItemHandler().setStackInSlot(this.getSlotIndex(), this.getItem());
+    }
 }


### PR DESCRIPTION
# Description

Shift Clicking an item calls the slot.setChanged method, however, it does not call onContentChanged as it should as well. This PR solves that by using slot.set instead of directly changing the itemstack.

Closes #445 <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Things that are yet to be completed for this PR to no longer be a draft.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
