### PR TITLE
Ignore sides when using experience rod.

### DIFF
--- a/src/main/java/com/enderio/base/common/item/tool/ExperienceRodItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/ExperienceRodItem.java
@@ -36,13 +36,12 @@ public class ExperienceRodItem extends Item {
 
         Player player = context.getPlayer();
         BlockPos pos = context.getClickedPos();
-        Direction side = context.getClickedFace();
 
-        boolean wasSuccess = false;
+        boolean wasSuccess;
         if (player.isShiftKeyDown()) {
-            wasSuccess = transferFromPlayerToBlock(player, level, pos, side);
+            wasSuccess = transferFromPlayerToBlock(player, level, pos);
         } else {
-            wasSuccess = transferFromBlockToPlayer(player, level, pos, side);
+            wasSuccess = transferFromBlockToPlayer(player, level, pos);
         }
 
         if (wasSuccess) {
@@ -60,11 +59,11 @@ public class ExperienceRodItem extends Item {
         return false;
     }
 
-    private static boolean transferFromBlockToPlayer(Player player, Level level, BlockPos pos, Direction side) {
+    private static boolean transferFromBlockToPlayer(Player player, Level level, BlockPos pos) {
         try {
             BlockEntity blockEntity = level.getBlockEntity(pos);
             if (blockEntity != null) {
-                return blockEntity.getCapability(ForgeCapabilities.FLUID_HANDLER, side).map(fluidHandler -> {
+                return blockEntity.getCapability(ForgeCapabilities.FLUID_HANDLER).map(fluidHandler -> {
 
                     FluidStack availableFluid = fluidHandler.getFluidInTank(0);
                     if (availableFluid.getFluid().is(EIOTags.Fluids.EXPERIENCE) && availableFluid.getAmount() > 0) {
@@ -89,7 +88,7 @@ public class ExperienceRodItem extends Item {
         return false;
     }
 
-    private static boolean transferFromPlayerToBlock(Player player, Level level, BlockPos pos, Direction side) {
+    private static boolean transferFromPlayerToBlock(Player player, Level level, BlockPos pos) {
         try {
             if (player.experienceLevel <= 0 && player.experienceProgress <= 0.0f) {
                 return false;
@@ -97,7 +96,7 @@ public class ExperienceRodItem extends Item {
 
             BlockEntity blockEntity = level.getBlockEntity(pos);
             if (blockEntity != null) {
-                return blockEntity.getCapability(ForgeCapabilities.FLUID_HANDLER, side).map(fluidHandler -> {
+                return blockEntity.getCapability(ForgeCapabilities.FLUID_HANDLER).map(fluidHandler -> {
                     int fluidVolume = ExperienceUtil.getPlayerTotalXp(player) * ExperienceUtil.EXP_TO_FLUID;
                     FluidStack fs = new FluidStack(EIOFluids.XP_JUICE.getSource(), fluidVolume);
                     int takenVolume = fluidHandler.fill(fs, IFluidHandler.FluidAction.EXECUTE);


### PR DESCRIPTION
# Description

Ignore the direction of use with the experience rod as suggested in #375 

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
