### PR TITLE
Disallow buckets in the Stirling generator

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/StirlingGeneratorBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/StirlingGeneratorBlockEntity.java
@@ -88,11 +88,7 @@ public class StirlingGeneratorBlockEntity extends PoweredMachineBlockEntity {
                         burnDuration = burnTime;
 
                         // Remove the fuel
-                        if (fuel.hasCraftingRemainingItem()) {
-                            FUEL.setStackInSlot(this, fuel.getCraftingRemainingItem());
-                        } else {
-                            fuel.shrink(1);
-                        }
+                        fuel.shrink(1);
                     }
                 }
             }

--- a/src/machines/java/com/enderio/machines/common/blockentity/StirlingGeneratorBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/StirlingGeneratorBlockEntity.java
@@ -57,7 +57,7 @@ public class StirlingGeneratorBlockEntity extends PoweredMachineBlockEntity {
     @Override
     public MachineInventoryLayout getInventoryLayout() {
         return MachineInventoryLayout.builder()
-            .inputSlot((slot, stack) -> ForgeHooks.getBurnTime(stack, RecipeType.SMELTING) > 0)
+            .inputSlot((slot, stack) -> ForgeHooks.getBurnTime(stack, RecipeType.SMELTING) > 0 && stack.getCraftingRemainingItem().isEmpty())
             .slotAccess(FUEL)
             .capacitor()
             .build();


### PR DESCRIPTION
# Description

Disallow buckets (and other items that aren't fully consumed) in the Stirling generator.

Closes #(issue) <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Things that are yet to be completed for this PR to no longer be a draft.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
