### PR TITLE
Delay model update to stop flickering

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/base/PoweredMachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/PoweredMachineBlockEntity.java
@@ -51,6 +51,7 @@ public abstract class PoweredMachineBlockEntity extends MachineBlockEntity imple
 
     private ICapacitorData cachedCapacitorData = DefaultCapacitorData.NONE;
     private boolean capacitorCacheDirty;
+    private boolean updateModel = false;
 
     public PoweredMachineBlockEntity(EnergyIOMode energyIOMode, ICapacitorScalable capacity, ICapacitorScalable usageRate, BlockEntityType<?> type, BlockPos worldPosition, BlockState blockState) {
         super(type, worldPosition, blockState);
@@ -89,7 +90,12 @@ public abstract class PoweredMachineBlockEntity extends MachineBlockEntity imple
         if (level != null) {
             BlockState blockState = getBlockState();
             if (blockState.hasProperty(ProgressMachineBlock.POWERED) && blockState.getValue(ProgressMachineBlock.POWERED) != isActive()) {
-                level.setBlock(getBlockPos(), blockState.setValue(ProgressMachineBlock.POWERED, isActive()), Block.UPDATE_ALL);
+                if (updateModel) {
+                    level.setBlock(getBlockPos(), blockState.setValue(ProgressMachineBlock.POWERED, isActive()), Block.UPDATE_ALL);
+                }
+                updateModel = true;
+            } else {
+                updateModel = false;
             }
         }
 


### PR DESCRIPTION
# Description

Right now when a recipe is done the machine models turns off for a tick. The update is now delayed a tick, making it not flicker if it found a new recipe in the next tick.

Closes #(issue) <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Things that are yet to be completed for this PR to no longer be a draft.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
