### PR TITLE
Fire crafting adjustments

### DIFF
--- a/src/generated/resources/assets/enderio/lang/en_ud.json
+++ b/src/generated/resources/assets/enderio/lang/en_ud.json
@@ -454,6 +454,8 @@
   "itemGroup.enderio.machines": "sǝuıɥɔɐW OI ɹǝpuƎ",
   "itemGroup.enderio.main": "OI ɹǝpuƎ",
   "itemGroup.enderio.souls": "sןnoS OI ɹǝpuƎ",
+  "jei.enderio.fire_crafting.loot_table": ":ǝןqɐ⟘ ʇooꞀ",
+  "jei.enderio.fire_crafting.max_drops": ":sdoɹᗡ ɯǝʇI xɐW",
   "jei.enderio.fire_crafting.title": "buıʇɟɐɹƆ ǝɹıℲ",
   "jei.enderio.fire_crafting.valid_blocks": ":sʞɔoןᗺ pıןɐΛ",
   "jei.enderio.fire_crafting.valid_dimensions": ":suoısuǝɯıᗡ pıןɐΛ",

--- a/src/generated/resources/assets/enderio/lang/en_us.json
+++ b/src/generated/resources/assets/enderio/lang/en_us.json
@@ -454,6 +454,8 @@
   "itemGroup.enderio.machines": "Ender IO Machines",
   "itemGroup.enderio.main": "Ender IO",
   "itemGroup.enderio.souls": "Ender IO Souls",
+  "jei.enderio.fire_crafting.loot_table": "Loot Table:",
+  "jei.enderio.fire_crafting.max_drops": "Max Item Drops:",
   "jei.enderio.fire_crafting.title": "Fire Crafting",
   "jei.enderio.fire_crafting.valid_blocks": "Valid Blocks:",
   "jei.enderio.fire_crafting.valid_dimensions": "Valid Dimensions:",

--- a/src/generated/resources/data/enderio/recipes/fire_crafting/infinity.json
+++ b/src/generated/resources/data/enderio/recipes/fire_crafting/infinity.json
@@ -8,5 +8,5 @@
   "dimensions": [
     "minecraft:overworld"
   ],
-  "lootTable": "enderio:fire_crafting/infinity"
+  "loot_table": "enderio:fire_crafting/infinity"
 }

--- a/src/generated/resources/data/enderio/recipes/fire_crafting/infinity.json
+++ b/src/generated/resources/data/enderio/recipes/fire_crafting/infinity.json
@@ -8,5 +8,6 @@
   "dimensions": [
     "minecraft:overworld"
   ],
-  "loot_table": "enderio:fire_crafting/infinity"
+  "loot_table": "enderio:fire_crafting/infinity",
+  "max_item_drops": 1
 }

--- a/src/main/java/com/enderio/base/common/handler/FireCraftingHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/FireCraftingHandler.java
@@ -4,6 +4,7 @@ import com.enderio.EnderIO;
 import com.enderio.base.common.config.BaseConfig;
 import com.enderio.base.common.init.EIORecipes;
 import com.enderio.base.common.recipe.FireCraftingRecipe;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -90,21 +91,26 @@ public class FireCraftingHandler {
                 FIRE_TRACKER.putIfAbsent(fireIndex, gameTime + BaseConfig.COMMON.INFINITY.FIRE_MIN_AGE.get());
             } else if (FIRE_TRACKER.containsKey(fireIndex)) {
                 if (level.getBlockState(pos).isAir() && gameTime > FIRE_TRACKER.get(fireIndex)) {
-                    spawnInfinityDrops(level, pos, matchingRecipe.getLootTable());
+                    spawnInfinityDrops(level, pos, matchingRecipe.getLootTable(), matchingRecipe.getMaxItemDrops());
                 }
                 FIRE_TRACKER.remove(fireIndex);
             }
         }
     }
 
-    public static void spawnInfinityDrops(ServerLevel level, BlockPos pos, ResourceLocation lootTable) {
+    public static void spawnInfinityDrops(ServerLevel level, BlockPos pos, ResourceLocation lootTable, int maxItemDrops) {
         LootParams lootparams = (new LootParams.Builder(level)).withParameter(LootContextParams.ORIGIN, pos.getCenter()).create(
             LootContextParamSets.COMMAND);
 
         LootTable table = level.getServer().getLootData().getElement(LootDataType.TABLE, lootTable);
 
         if (table != null && table != LootTable.EMPTY) {
-            for (ItemStack item : table.getRandomItems(lootparams)) {
+            ObjectArrayList<ItemStack> randomItems = table.getRandomItems(lootparams);
+            for (int i = 0; i < randomItems.size(); i++) {
+                if (i >= maxItemDrops)
+                    break;
+                ItemStack item = randomItems.get(i);
+
                 // Get random offset
                 double x = RANDOM.nextFloat() * 0.5f + 0.25f;
                 double y = RANDOM.nextFloat() * 0.5f + 0.25f;

--- a/src/main/java/com/enderio/base/common/integrations/jei/category/FireCraftingCategory.java
+++ b/src/main/java/com/enderio/base/common/integrations/jei/category/FireCraftingCategory.java
@@ -26,6 +26,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -120,7 +121,15 @@ public class FireCraftingCategory implements IRecipeCategory<FireCraftingRecipe>
         block.addIngredients(Ingredient.of(recipe.getBases().toArray(Block[]::new)));
 
         // TODO: Get and display chance
-        IRecipeSlotBuilder output = builder.addSlot(RecipeIngredientRole.OUTPUT, 88, 39);
+        IRecipeSlotBuilder output = builder.addSlot(RecipeIngredientRole.OUTPUT, 88, 39).addTooltipCallback((slowView, tooltip) -> {
+            Component lootTableComponent = MutableComponent.create(EIOLang.JEI_FIRE_CRAFTING_LOOT_TABLE.getContents())
+                .append(Component.literal(" " + recipe.getLootTable()));
+            Component maxDropsComponent = MutableComponent.create(EIOLang.JEI_FIRE_CRAFTING_MAX_DROPS.getContents())
+                .append(Component.literal(" " + recipe.getMaxItemDrops()));
+            tooltip.clear();
+            tooltip.add(lootTableComponent);
+            tooltip.add(maxDropsComponent);
+        });
         output.addItemStack(EIOItems.GRAINS_OF_INFINITY.asStack()); // TODO: Fetch the output from the loot table instead...
 
         IRecipeSlotBuilder catalyst = builder.addSlot(RecipeIngredientRole.CATALYST, 88, 8).setSlotName("catalyst");

--- a/src/main/java/com/enderio/base/common/lang/EIOLang.java
+++ b/src/main/java/com/enderio/base/common/lang/EIOLang.java
@@ -238,6 +238,8 @@ public class EIOLang {
     public static final Component JEI_FIRE_CRAFTING_TITLE = REGISTRATE.addLang("jei", EnderIO.loc("fire_crafting"), "title", "Fire Crafting");
     public static final Component JEI_FIRE_CRAFTING_VALID_BLOCKS = REGISTRATE.addLang("jei", EnderIO.loc("fire_crafting"), "valid_blocks", "Valid Blocks:");
     public static final Component JEI_FIRE_CRAFTING_VALID_DIMENSIONS = REGISTRATE.addLang("jei", EnderIO.loc("fire_crafting"), "valid_dimensions", "Valid Dimensions:");
+    public static final Component JEI_FIRE_CRAFTING_LOOT_TABLE = REGISTRATE.addLang("jei", EnderIO.loc("fire_crafting"), "loot_table", "Loot Table:");
+    public static final Component JEI_FIRE_CRAFTING_MAX_DROPS = REGISTRATE.addLang("jei", EnderIO.loc("fire_crafting"), "max_drops", "Max Item Drops:");
 
     public static final Component JEI_GRINDING_CRAFTING_TITLE = REGISTRATE.addLang("jei", EnderIO.loc("grinding"), "title", "Grinding");
     public static final MutableComponent JEI_GRINDING_CONSUME_CHANCE = REGISTRATE.addLang("jei", EnderIO.loc("grinding"), "consume_chance", "33% chance to be consumed");

--- a/src/main/java/com/enderio/base/common/recipe/FireCraftingRecipe.java
+++ b/src/main/java/com/enderio/base/common/recipe/FireCraftingRecipe.java
@@ -106,7 +106,7 @@ public class FireCraftingRecipe implements EnderRecipe<Container> {
 
         @Override
         public FireCraftingRecipe fromJson(ResourceLocation recipeId, JsonObject serializedRecipe) {
-            ResourceLocation lootTable = new ResourceLocation(serializedRecipe.get("lootTable").getAsString());
+            ResourceLocation lootTable = new ResourceLocation(serializedRecipe.get("loot_table").getAsString());
 
             List<Block> baseBlocks = new ArrayList<>();
             List<TagKey<Block>> baseTags = new ArrayList<>();

--- a/src/main/java/com/enderio/base/data/recipe/FireCraftingRecipeProvider.java
+++ b/src/main/java/com/enderio/base/data/recipe/FireCraftingRecipeProvider.java
@@ -29,6 +29,7 @@ public class FireCraftingRecipeProvider extends EnderRecipeProvider {
         finishedRecipeConsumer.accept(new FinishedFireRecipe(
             EnderIO.loc("fire_crafting/infinity"),
             EnderIO.loc("fire_crafting/infinity"),
+            1,
             List.of(Blocks.BEDROCK),
             List.of(),
             List.of(Level.OVERWORLD.location())));
@@ -37,14 +38,16 @@ public class FireCraftingRecipeProvider extends EnderRecipeProvider {
     protected static class FinishedFireRecipe extends EnderFinishedRecipe {
 
         private final ResourceLocation lootTable;
+        private final int maxItemDrops;
         private final List<Block> bases;
         private final List<TagKey<Block>> baseTags;
         private final List<ResourceLocation> dimensions;
 
-        public FinishedFireRecipe(ResourceLocation id, ResourceLocation lootTable, List<Block> bases, List<TagKey<Block>> baseTags,
+        public FinishedFireRecipe(ResourceLocation id, ResourceLocation lootTable, int maxItemDrops, List<Block> bases, List<TagKey<Block>> baseTags,
             List<ResourceLocation> dimensions) {
             super(id);
             this.lootTable = lootTable;
+            this.maxItemDrops = maxItemDrops;
             this.bases = bases;
             this.baseTags = baseTags;
             this.dimensions = dimensions;
@@ -75,6 +78,7 @@ public class FireCraftingRecipeProvider extends EnderRecipeProvider {
             }
 
             json.addProperty("loot_table", lootTable.toString());
+            json.addProperty("max_item_drops", maxItemDrops);
             json.add("base_blocks", basesJson);
             json.add("dimensions", dimensionsJson);
 

--- a/src/main/java/com/enderio/base/data/recipe/FireCraftingRecipeProvider.java
+++ b/src/main/java/com/enderio/base/data/recipe/FireCraftingRecipeProvider.java
@@ -74,7 +74,7 @@ public class FireCraftingRecipeProvider extends EnderRecipeProvider {
                 dimensionsJson.add(dimension.toString());
             }
 
-            json.addProperty("lootTable", lootTable.toString());
+            json.addProperty("loot_table", lootTable.toString());
             json.add("base_blocks", basesJson);
             json.add("dimensions", dimensionsJson);
 


### PR DESCRIPTION
# Description

- changed the recipe key for the fire crafting loot table from camel case to snake case for consistency
- added a new property to limit item drops from a loot table
  - This is to avoid loot explosions when using large loot tables. An example of what I mean can be seen when using the `minecraft:chests/simple_dungeon` loot table. A preview can be seen below in the video.<br>The new max drops property still ensures item randomness because the list of items always has a different order.
- added tooltips to the JEI fire crafting category to display the used loot table and the item limit
  - Right now, the output is always hardcoded to the Grains of Infinity item because that's the only use case EnderIO has right now. The new tooltip is a temporary workaround when custom recipes define their own loot tables. It will still show the Grains of Infinity in the slot but at least you can see which loot table it will pick.
  - Showing the actual items of the pool would require rolling the loot table on client which is impossible. Instead, you would need a similar approach to Just Enough Resources where you load the resources on the client too, and have something like a view for each vanilla condition.

Loot explosion example when using a huge table:

https://github.com/Team-EnderIO/EnderIO/assets/16513358/d0a1e812-4f4a-4fd3-81fb-2d88e0105537

The new tooltip:
![20230909-1444-6140](https://github.com/Team-EnderIO/EnderIO/assets/16513358/6e797637-fdd8-4a21-803a-9ccc187b18e8)

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
