### PR TITLE
Switch to concurrent hashmap for tracking fire.

### DIFF
--- a/src/main/java/com/enderio/base/common/handler/FireCraftingHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/FireCraftingHandler.java
@@ -30,12 +30,14 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 @SuppressWarnings("unused")
 @Mod.EventBusSubscriber(modid = EnderIO.MODID)
 public class FireCraftingHandler {
     private static final Random RANDOM = new Random();
-    private static final Map<FireIndex, Long> FIRE_TRACKER = new HashMap<>();
+    private static final ConcurrentMap<FireIndex, Long> FIRE_TRACKER = new ConcurrentHashMap<>();
 
     private static List<FireCraftingRecipe> cachedRecipes;
     private static boolean recipesCached = false;


### PR DESCRIPTION
# Description

Uses a concurrent hashmap for the fire tracking map.
This will still need to be tested with railcraft reborn.

Closes #512

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
