### PR TITLE
Api/addalloysmeltersmeltinghook

### DIFF
--- a/src/api/java/com/enderio/api/integration/Integration.java
+++ b/src/api/java/com/enderio/api/integration/Integration.java
@@ -4,6 +4,8 @@ import com.enderio.api.glider.GliderMovementInfo;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.SmeltingRecipe;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -78,5 +80,14 @@ public interface Integration {
      */
     default boolean canBlockTeleport(Player player) {
         return false;
+    }
+
+    /**
+     * Usage intended for kubejs io, tell us if you need it for something else
+     * @param recipe The smelting recipe that is tried to be used in the AlloySmelter.
+     * @return true if this recipe can be used
+     */
+    default boolean acceptSmeltingRecipe(SmeltingRecipe recipe) {
+        return true;
     }
 }

--- a/src/api/java/com/enderio/api/integration/Integration.java
+++ b/src/api/java/com/enderio/api/integration/Integration.java
@@ -5,7 +5,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.SmeltingRecipe;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.IEventBus;

--- a/src/machines/java/com/enderio/machines/common/blockentity/AlloySmelterBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/AlloySmelterBlockEntity.java
@@ -3,6 +3,7 @@ package com.enderio.machines.common.blockentity;
 import com.enderio.EnderIO;
 import com.enderio.api.capacitor.CapacitorModifier;
 import com.enderio.api.capacitor.QuadraticScalable;
+import com.enderio.api.integration.IntegrationManager;
 import com.enderio.api.io.energy.EnergyIOMode;
 import com.enderio.core.common.blockentity.EnderBlockEntity;
 import com.enderio.core.common.network.slot.EnumNetworkDataSlot;
@@ -323,7 +324,7 @@ public class AlloySmelterBlockEntity extends PoweredMachineBlockEntity {
                 for (int i = 0; i < AlloySmelterBlockEntity.INPUTS.size(); i++) {
                     var recipe = level.getRecipeManager()
                         .getRecipeFor(RecipeType.SMELTING, new ContainerSubWrapper(getContainer(), i), level);
-                    if (recipe.isPresent())
+                    if (recipe.isPresent() && IntegrationManager.allMatch(integration -> integration.acceptSmeltingRecipe(recipe.get())))
                         return Optional.of(new VanillaAlloySmeltingRecipe(recipe.get()));
                 }
             }


### PR DESCRIPTION
# Description

add api to smelting recipe to be used for the kubejs enderio addon to disable vanilla recipes in enderio

Closes #520 (partially, would remove the mixin from the addon once used)

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
