### PR TITLE
Implement elevator behaviour for travel anchors

### DIFF
--- a/src/machines/java/com/enderio/machines/client/MachinesClientEvents.java
+++ b/src/machines/java/com/enderio/machines/client/MachinesClientEvents.java
@@ -1,0 +1,89 @@
+package com.enderio.machines.client;
+
+import com.enderio.base.common.handler.TravelHandler;
+import net.minecraft.client.player.Input;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.MovementInputUpdateEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(value = Dist.CLIENT)
+public class MachinesClientEvents {
+    private static boolean LAST_JUMPING = false;
+    private static boolean LAST_SNEAKING = false;
+    private static int JUMP_COOLDOWN = 0;
+
+    @SubscribeEvent
+    public static void movementInputUpdate(MovementInputUpdateEvent event) {
+        Input input = event.getInput();
+        Player player = event.getEntity();
+        boolean isNewJump = input.jumping && !LAST_JUMPING;
+        LAST_JUMPING = input.jumping;
+        boolean isNewCrouch = input.shiftKeyDown && !LAST_SNEAKING;
+        LAST_SNEAKING = input.shiftKeyDown;
+
+        if (!TravelHandler.canBlockTeleport(player)) {
+            JUMP_COOLDOWN = 0;
+            return;
+        }
+        if (isNewJump) {
+            boolean success = TravelHandler.blockElevatorTeleport(player.level(), player, Direction.UP, true);
+            if (success) {
+                JUMP_COOLDOWN = 7;
+            } else {
+                JUMP_COOLDOWN = 0;
+            }
+        } else if (isNewCrouch) {
+            TravelHandler.blockElevatorTeleport(player.level(), player, Direction.DOWN, true);
+        }
+
+        if (JUMP_COOLDOWN > 0) {
+            JUMP_COOLDOWN -= 1;
+            input.jumping = false;
+        }
+    }
+
+    @SubscribeEvent
+    public static void emptyClick(PlayerInteractEvent.RightClickEmpty event) {
+        Player player = event.getEntity();
+        // Credit to castcrafter/travel_anchors
+        if (TravelHandler.canBlockTeleport(player) && !player.isShiftKeyDown() && event.getHand() == InteractionHand.MAIN_HAND && event
+            .getEntity()
+            .getItemInHand(InteractionHand.OFF_HAND)
+            .isEmpty() && event.getItemStack().isEmpty()) {
+            if (TravelHandler.blockTeleport(event.getLevel(), event.getEntity(), true)) {
+                player.swing(event.getHand(), true);
+                event.setCancellationResult(InteractionResult.SUCCESS);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void blockClick(PlayerInteractEvent.RightClickBlock event) {
+        Player player = event.getEntity();
+        if (!TravelHandler.canBlockTeleport(player)) {
+            return;
+        }
+        if (TravelHandler.blockTeleport(event.getLevel(), event.getEntity(), true)) {
+            event.setCancellationResult(InteractionResult.SUCCESS);
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void itemClick(PlayerInteractEvent.RightClickItem event) {
+        Player player = event.getEntity();
+        if (!TravelHandler.canBlockTeleport(player)) {
+            return;
+        }
+        if (TravelHandler.blockTeleport(event.getLevel(), event.getEntity(), true)) {
+            event.setCancellationResult(InteractionResult.SUCCESS);
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/machines/java/com/enderio/machines/client/MachinesClientEvents.java
+++ b/src/machines/java/com/enderio/machines/client/MachinesClientEvents.java
@@ -27,19 +27,25 @@ public class MachinesClientEvents {
         boolean isNewCrouch = input.shiftKeyDown && !LAST_SNEAKING;
         LAST_SNEAKING = input.shiftKeyDown;
 
-        if (!TravelHandler.canBlockTeleport(player)) {
+        if (!player.onGround() || !TravelHandler.canBlockTeleport(player)) {
             JUMP_COOLDOWN = 0;
             return;
         }
         if (isNewJump) {
             boolean success = TravelHandler.blockElevatorTeleport(player.level(), player, Direction.UP, true);
+            if (!success) {
+                success = TravelHandler.blockTeleport(player.level(), player, true);
+            }
             if (success) {
                 JUMP_COOLDOWN = 7;
             } else {
                 JUMP_COOLDOWN = 0;
             }
         } else if (isNewCrouch) {
-            TravelHandler.blockElevatorTeleport(player.level(), player, Direction.DOWN, true);
+            boolean success = TravelHandler.blockElevatorTeleport(player.level(), player, Direction.DOWN, true);
+            if (!success) {
+                TravelHandler.blockTeleport(player.level(), player, true);
+            }
         }
 
         if (JUMP_COOLDOWN > 0) {

--- a/src/machines/java/com/enderio/machines/client/MachinesClientSetup.java
+++ b/src/machines/java/com/enderio/machines/client/MachinesClientSetup.java
@@ -4,12 +4,15 @@ import com.enderio.EnderIO;
 import com.enderio.machines.client.rendering.blockentity.CapacitorBankBER;
 import com.enderio.machines.client.rendering.blockentity.FluidTankBER;
 import com.enderio.machines.client.rendering.model.IOOverlayBakedModel;
+import com.enderio.machines.client.rendering.travel.TravelAnchorHud;
 import com.enderio.machines.common.blockentity.capacitorbank.CapacitorBankBlockEntity;
 import com.enderio.machines.common.init.MachineBlockEntities;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.ModelEvent;
+import net.minecraftforge.client.event.RegisterGuiOverlaysEvent;
+import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -28,5 +31,10 @@ public class MachinesClientSetup {
         for (BlockEntityEntry<CapacitorBankBlockEntity> value : MachineBlockEntities.CAPACITOR_BANKS.values()) {
             event.registerBlockEntityRenderer(value.get(), CapacitorBankBER::new);
         }
+    }
+
+    @SubscribeEvent
+    public static void registerOverlays(RegisterGuiOverlaysEvent event) {
+        event.registerAbove(VanillaGuiOverlay.CROSSHAIR.id(), "anchor_hud", TravelAnchorHud.INSTANCE);
     }
 }

--- a/src/machines/java/com/enderio/machines/client/rendering/travel/TravelAnchorHud.java
+++ b/src/machines/java/com/enderio/machines/client/rendering/travel/TravelAnchorHud.java
@@ -27,17 +27,7 @@ public class TravelAnchorHud implements IGuiOverlay {
         Minecraft minecraft = gui.getMinecraft();
         Player player = minecraft.player;
 
-        if (player == null) {
-            return;
-        }
-        if (!TravelHandler.canTeleport(player)) {
-            return;
-        }
-
-        TravelHandler.getAnchorTarget(player)
-            .ifPresent(target -> showElevatorTarget(guiGraphics, minecraft.font, screenWidth, screenHeight, target, Direction.EAST));
-
-        if (!TravelHandler.canBlockTeleport(player)) {
+        if (player == null || !TravelHandler.canBlockTeleport(player)) {
             return;
         }
 

--- a/src/machines/java/com/enderio/machines/client/rendering/travel/TravelAnchorHud.java
+++ b/src/machines/java/com/enderio/machines/client/rendering/travel/TravelAnchorHud.java
@@ -1,0 +1,100 @@
+package com.enderio.machines.client.rendering.travel;
+
+import com.enderio.api.travel.ITravelTarget;
+import com.enderio.base.common.handler.TravelHandler;
+import com.enderio.machines.common.init.MachineBlocks;
+import com.enderio.machines.common.travel.AnchorTravelTarget;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.client.gui.overlay.ForgeGui;
+import net.minecraftforge.client.gui.overlay.IGuiOverlay;
+
+public class TravelAnchorHud implements IGuiOverlay {
+    public static final TravelAnchorHud INSTANCE = new TravelAnchorHud();
+
+    static final int CURSOR_GAP = 20;
+    static final int ITEM_TEXT_GAP = 6;
+    static final int ITEM_SIZE = 16;
+
+    @Override
+    public void render(ForgeGui gui, GuiGraphics guiGraphics, float partialTick, int screenWidth, int screenHeight) {
+        Minecraft minecraft = gui.getMinecraft();
+        Player player = minecraft.player;
+
+        if (player == null) {
+            return;
+        }
+        if (!TravelHandler.canTeleport(player)) {
+            return;
+        }
+
+        TravelHandler.getAnchorTarget(player)
+            .ifPresent(target -> showElevatorTarget(guiGraphics, minecraft.font, screenWidth, screenHeight, target, Direction.EAST));
+
+        if (!TravelHandler.canBlockTeleport(player)) {
+            return;
+        }
+
+        TravelHandler.getElevatorAnchorTarget(player, Direction.UP)
+            .ifPresent(target -> showElevatorTarget(guiGraphics, minecraft.font, screenWidth, screenHeight, target, Direction.UP));
+
+        TravelHandler.getElevatorAnchorTarget(player, Direction.DOWN)
+            .ifPresent(target -> showElevatorTarget(guiGraphics, minecraft.font, screenWidth, screenHeight, target, Direction.DOWN));
+    }
+
+    private static void showElevatorTarget(GuiGraphics guiGraphics, Font font, int screenWidth, int screenHeight, ITravelTarget target, Direction direction) {
+        String txt = switch (direction) {
+            case UP -> "↑";
+            case DOWN -> "↓";
+            case EAST -> "→";
+            case WEST -> "←";
+            default -> "";
+        };
+
+        int centerX = screenWidth / 2;
+        int centerY = screenHeight / 2;
+
+        if (target instanceof AnchorTravelTarget anchorTarget) {
+            String anchorName = anchorTarget.getName();
+            if (!anchorName.isEmpty()) {
+                txt = anchorName + " " + txt;
+            }
+
+            // Draw icon as an item
+            Item icon = anchorTarget.getIcon();
+            if (icon == Blocks.AIR.asItem()) {
+                icon = MachineBlocks.TRAVEL_ANCHOR.asItem();
+            }
+            ItemStack itemStack = icon.getDefaultInstance();
+            int x = centerX + getOffset(CURSOR_GAP, ITEM_SIZE, direction.getStepX());
+            int y = centerY + getOffset(CURSOR_GAP, ITEM_SIZE, -direction.getStepY());
+
+            guiGraphics.renderItem(itemStack, x, y);
+        }
+
+        int textWidth = font.width(txt);
+        int offsetAmount = CURSOR_GAP + ITEM_SIZE + ITEM_TEXT_GAP;
+        int textX = centerX + getOffset(offsetAmount, textWidth, direction.getStepX());
+        int textY = centerY + getOffset(offsetAmount, font.lineHeight, -direction.getStepY());
+
+        // Text background
+        int bgFromX = textX - 2;
+        int bgFromY = textY - 2;
+        int bgToX = bgFromX + textWidth + 3;
+        int bgToY = bgFromY + font.lineHeight + 3;
+        guiGraphics.fill(bgFromX, bgFromY, bgToX, bgToY, 0x87000000);
+
+        // Text
+        guiGraphics.drawString(font, txt, textX, textY, 16777215, false);
+    }
+
+    private static int getOffset(int offsetAmount, int size, int direction) {
+        return (offsetAmount + size / 2) * direction - (size / 2);
+    }
+}

--- a/src/machines/java/com/enderio/machines/common/block/TravelAnchorBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/TravelAnchorBlock.java
@@ -1,29 +1,15 @@
 package com.enderio.machines.common.block;
 
-import com.enderio.base.common.handler.TravelHandler;
 import com.enderio.base.common.travel.TravelSavedData;
 import com.enderio.machines.common.blockentity.TravelAnchorBlockEntity;
 import com.enderio.machines.common.init.MachineBlockEntities;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.event.entity.living.LivingEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
-import java.util.WeakHashMap;
-
-@Mod.EventBusSubscriber
 public class TravelAnchorBlock extends MachineBlock {
-    private static final Map<Player, PlayerSneakJumpEntry> SNEAK_JUMP_CACHE = new WeakHashMap<>();
-
     public TravelAnchorBlock(Properties props) {
         super(props, MachineBlockEntities.TRAVEL_ANCHOR);
     }
@@ -33,39 +19,6 @@ public class TravelAnchorBlock extends MachineBlock {
     public BlockEntity newBlockEntity(BlockPos pPos, BlockState pState) {
         return MachineBlockEntities.TRAVEL_ANCHOR.create(pPos, pState);
     }
-
-    @SubscribeEvent
-    public static void jump(LivingEvent.LivingJumpEvent jumpEvent) {
-        if (!jumpEvent.getEntity().level().isClientSide && jumpEvent.getEntity() instanceof Player player) {
-            if (TravelHandler.canBlockTeleport(player)) {
-                SNEAK_JUMP_CACHE.put(player, new PlayerSneakJumpEntry(player.isShiftKeyDown(), true, player.level().getServer().getTickCount()));
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public static void playerTick(TickEvent.PlayerTickEvent event) {
-        if (event.phase == TickEvent.Phase.END && event.player instanceof ServerPlayer player && player
-            .level()
-            .getBlockState(player.blockPosition().below())
-            .getBlock() instanceof TravelAnchorBlock) {
-
-            PlayerSneakJumpEntry sneakEntry = getLastSneakJumpEntry(player);
-            if ((!sneakEntry.isSneaking() || sneakEntry.atTime() != player.level().getServer().getTickCount() - 1) && player.isShiftKeyDown()) {
-                TravelHandler.blockTeleport(player.level(), player, Direction.DOWN);
-            }
-            if (sneakEntry.isJumping()) {
-                TravelHandler.blockTeleport(player.level(), player, Direction.UP);
-            }
-            SNEAK_JUMP_CACHE.put(player, new PlayerSneakJumpEntry(player.isShiftKeyDown(), false, player.level().getServer().getTickCount()));
-        }
-    }
-
-    private static PlayerSneakJumpEntry getLastSneakJumpEntry(ServerPlayer player){
-        return SNEAK_JUMP_CACHE.getOrDefault(player, new PlayerSneakJumpEntry(false, false, player.level().getServer().getTickCount() - 1));
-    }
-
-    private record PlayerSneakJumpEntry(boolean isSneaking, boolean isJumping, int atTime){}
 
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {

--- a/src/machines/java/com/enderio/machines/common/block/TravelAnchorBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/TravelAnchorBlock.java
@@ -5,6 +5,7 @@ import com.enderio.base.common.travel.TravelSavedData;
 import com.enderio.machines.common.blockentity.TravelAnchorBlockEntity;
 import com.enderio.machines.common.init.MachineBlockEntities;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
@@ -36,8 +37,8 @@ public class TravelAnchorBlock extends MachineBlock {
     @SubscribeEvent
     public static void jump(LivingEvent.LivingJumpEvent jumpEvent) {
         if (!jumpEvent.getEntity().level().isClientSide && jumpEvent.getEntity() instanceof Player player) {
-            if (player.level().getBlockState(player.blockPosition().below()).getBlock() instanceof TravelAnchorBlock) {
-                TravelHandler.blockTeleport(player.level(), player, 1);
+            if (TravelHandler.canBlockTeleport(player)) {
+                TravelHandler.blockTeleport(player.level(), player, Direction.UP);
             }
         }
     }
@@ -51,7 +52,7 @@ public class TravelAnchorBlock extends MachineBlock {
 
             PlayerSneakEntry sneakEntry = getLastSneakEntry(player);
             if ((!sneakEntry.isSneaking() || sneakEntry.atTime() != player.level().getServer().getTickCount() - 1) && player.isShiftKeyDown()) {
-                TravelHandler.blockTeleport(player.level(), player, -1);
+                TravelHandler.blockTeleport(player.level(), player, Direction.DOWN);
             }
             SNEAK_CACHE.put(player, new PlayerSneakEntry(player.isShiftKeyDown(), player.level().getServer().getTickCount()));
         }

--- a/src/machines/java/com/enderio/machines/common/block/TravelAnchorBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/TravelAnchorBlock.java
@@ -37,7 +37,7 @@ public class TravelAnchorBlock extends MachineBlock {
     public static void jump(LivingEvent.LivingJumpEvent jumpEvent) {
         if (!jumpEvent.getEntity().level().isClientSide && jumpEvent.getEntity() instanceof Player player) {
             if (player.level().getBlockState(player.blockPosition().below()).getBlock() instanceof TravelAnchorBlock) {
-                TravelHandler.blockTeleport(player.level(), player);
+                TravelHandler.blockTeleport(player.level(), player, 1);
             }
         }
     }
@@ -51,7 +51,7 @@ public class TravelAnchorBlock extends MachineBlock {
 
             PlayerSneakEntry sneakEntry = getLastSneakEntry(player);
             if ((!sneakEntry.isSneaking() || sneakEntry.atTime() != player.level().getServer().getTickCount() - 1) && player.isShiftKeyDown()) {
-                TravelHandler.blockTeleport(player.level(), player);
+                TravelHandler.blockTeleport(player.level(), player, -1);
             }
             SNEAK_CACHE.put(player, new PlayerSneakEntry(player.isShiftKeyDown(), player.level().getServer().getTickCount()));
         }

--- a/src/main/java/com/enderio/base/client/renderer/travel/RenderTravelTargets.java
+++ b/src/main/java/com/enderio/base/client/renderer/travel/RenderTravelTargets.java
@@ -38,7 +38,9 @@ public class RenderTravelTargets {
         for (ITravelTarget target : data.getTravelTargets()) {
             double range = itemTeleport ? target.getItem2BlockRange() : target.getBlock2BlockRange();
             double distanceSquared = target.getPos().distToCenterSqr(player.position());
-            if (range * range < distanceSquared || distanceSquared < TravelHandler.MIN_TELEPORTATION_DISTANCE_SQUARED) {
+            if (range * range < distanceSquared
+                || distanceSquared < TravelHandler.MIN_TELEPORTATION_DISTANCE_SQUARED
+                || TravelHandler.isTeleportPositionClear(level, target.getPos()).isEmpty()) {
                 continue;
             }
 

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -8,6 +8,7 @@ import com.enderio.base.common.item.darksteel.IDarkSteelItem;
 import com.enderio.base.common.travel.TravelSavedData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -84,7 +85,7 @@ public class TravelHandler {
             target = getElevatorAnchorTarget(player, direction);
         }
         if (target.isPresent()) {
-            if (!player.level().isClientSide) {
+            if (player instanceof ServerPlayer serverPlayer) {
                 Optional<Double> height = isTeleportPositionClear(level, target.get().getPos());
                 if (height.isEmpty()) {
                     return false;
@@ -95,6 +96,8 @@ public class TravelHandler {
                 if (teleportPosition != null) {
                     player.fallDistance = 0;
                     player.teleportTo(teleportPosition.x(), teleportPosition.y(), teleportPosition.z());
+                    // Stop "moved too quickly" warnings
+                    serverPlayer.connection.resetPosition();
                     player.playNotifySound(SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1F, 1F);
                     return true;
                 }

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -75,12 +75,12 @@ public class TravelHandler {
     }
 
     public static boolean blockTeleport(Level level, Player player) {
-        return blockTeleport(level, player, 0);
+        return blockTeleport(level, player, null);
     }
 
-    public static boolean blockTeleport(Level level, Player player, int direction) {
+    public static boolean blockTeleport(Level level, Player player, @Nullable Direction direction) {
         Optional<ITravelTarget> target = getAnchorTarget(player);
-        if (target.isEmpty() && direction != 0) {
+        if (target.isEmpty() && direction != null && direction.getStepY() != 0) {
             target = getElevatorAnchorTarget(player, direction);
         }
         if (target.isPresent()) {
@@ -139,7 +139,7 @@ public class TravelHandler {
             .min(Comparator.comparingDouble(target -> Math.abs(getAngleRadians(positionVec, target.getPos(), player.getYRot(), player.getXRot()))));
     }
 
-    public static Optional<ITravelTarget> getElevatorAnchorTarget(Player player, int direction) {
+    public static Optional<ITravelTarget> getElevatorAnchorTarget(Player player, Direction direction) {
         int anchorRange = BaseConfig.COMMON.ITEMS.TRAVELLING_BLOCK_TO_BLOCK_RANGE.get();
         BlockPos anchorPos = player.blockPosition().below();
 
@@ -150,12 +150,12 @@ public class TravelHandler {
 
         int upperY;
         int lowerY;
-        if (direction > 0) {
-            upperY = anchorY + direction * anchorRange + 1;
+        if (direction == Direction.UP) {
+            upperY = anchorY + anchorRange + 1;
             lowerY = anchorY + 1;
         } else {
             upperY = anchorY - 1;
-            lowerY = anchorY + direction * anchorRange - 1;
+            lowerY = anchorY - anchorRange - 1;
         }
 
         return TravelSavedData

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -74,6 +74,10 @@ public class TravelHandler {
         }
     }
 
+    public static boolean blockTeleport(Level level, Player player) {
+        return blockTeleport(level, player, 0);
+    }
+
     public static boolean blockTeleport(Level level, Player player, int direction) {
         Optional<ITravelTarget> target = getAnchorTarget(player);
         if (target.isEmpty() && direction != 0) {

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -74,10 +74,10 @@ public class TravelHandler {
         }
     }
 
-    public static boolean blockTeleport(Level level, Player player, int elevatorScanDirection) {
+    public static boolean blockTeleport(Level level, Player player, int direction) {
         Optional<ITravelTarget> target = getAnchorTarget(player);
-        if (target.isEmpty() && elevatorScanDirection != 0) {
-            target = getElevatorAnchorTarget(player, elevatorScanDirection);
+        if (target.isEmpty() && direction != 0) {
+            target = getElevatorAnchorTarget(player, direction);
         }
         if (target.isPresent()) {
             if (!player.level().isClientSide) {
@@ -135,21 +135,22 @@ public class TravelHandler {
             .min(Comparator.comparingDouble(target -> Math.abs(getAngleRadians(positionVec, target.getPos(), player.getYRot(), player.getXRot()))));
     }
 
-    public static Optional<ITravelTarget> getElevatorAnchorTarget(Player player, int elevatorScanDirection) {
+    public static Optional<ITravelTarget> getElevatorAnchorTarget(Player player, int direction) {
         int anchorRange = BaseConfig.COMMON.ITEMS.TRAVELLING_BLOCK_TO_BLOCK_RANGE.get();
-        var anchorPos = player.blockPosition().below();
+        BlockPos anchorPos = player.blockPosition().below();
 
-        var anchorX = anchorPos.getX();
-        var anchorY = anchorPos.getY();
-        var anchorZ = anchorPos.getZ();
+
+        int anchorX = anchorPos.getX();
+        int anchorY = anchorPos.getY();
+        int anchorZ = anchorPos.getZ();
 
         int upperY, lowerY;
-        if (elevatorScanDirection > 0) {
-            upperY = anchorY + elevatorScanDirection * anchorRange + 1;
+        if (direction > 0) {
+            upperY = anchorY + direction * anchorRange + 1;
             lowerY = anchorY + 1;
         } else {
             upperY = anchorY - 1;
-            lowerY = anchorY + elevatorScanDirection * anchorRange - 1;
+            lowerY = anchorY + direction * anchorRange - 1;
         }
 
         return TravelSavedData

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -148,8 +148,7 @@ public class TravelHandler {
             .getTravelData(player.level())
             .getTravelTargetsInItemRange(player.blockPosition())
             .filter(target -> target.canTravelTo())
-            .filter(
-                target -> target.getPos().distToLowCornerSqr(player.getX(), player.getY(), player.getZ()) > MIN_TELEPORTATION_DISTANCE_SQUARED)
+            .filter(target -> target.getPos().distToCenterSqr(player.position()) > MIN_TELEPORTATION_DISTANCE_SQUARED)
             .filter(target -> Math.abs(getAngleRadians(positionVec, target.getPos(), player.getYRot(), player.getXRot())) <= Math.toRadians(15))
             .filter(target -> isTeleportPositionClear(player.level(), target.getPos()).isPresent())
             .min(Comparator.comparingDouble(target -> Math.abs(getAngleRadians(positionVec, target.getPos(), player.getYRot(), player.getXRot()))));
@@ -198,7 +197,7 @@ public class TravelHandler {
      * @param target
      * @return Optional.empty if it can't teleport and the height where to place the player. This is so you can tp on top of carpets up to a whole block
      */
-    private static Optional<Double> isTeleportPositionClear(BlockGetter level, BlockPos target) {
+    public static Optional<Double> isTeleportPositionClear(BlockGetter level, BlockPos target) {
         if (level.isOutsideBuildHeight(target)) {
             return Optional.empty();
         }

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -59,10 +59,11 @@ public class TravelHandler {
     public static boolean shortTeleport(Level level, Player player) {
         Optional<Vec3> pos = teleportPosition(level, player);
         if (pos.isPresent()) {
-            if (!level.isClientSide) {
+            if (player instanceof ServerPlayer serverPlayer) {
                 Optional<Vec3> eventPos = teleportEvent(player, pos.get());
                 if (eventPos.isPresent()) {
                     player.teleportTo(eventPos.get().x(), eventPos.get().y(), eventPos.get().z());
+                    serverPlayer.connection.resetPosition();
                     player.fallDistance = 0;
                     player.playNotifySound(SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1F, 1F);
                 } else {

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -148,7 +148,8 @@ public class TravelHandler {
         int anchorY = anchorPos.getY();
         int anchorZ = anchorPos.getZ();
 
-        int upperY, lowerY;
+        int upperY;
+        int lowerY;
         if (direction > 0) {
             upperY = anchorY + direction * anchorRange + 1;
             lowerY = anchorY + 1;

--- a/src/main/java/com/enderio/base/common/init/EIOPackets.java
+++ b/src/main/java/com/enderio/base/common/init/EIOPackets.java
@@ -2,6 +2,7 @@ package com.enderio.base.common.init;
 
 import com.enderio.base.common.network.AddTravelTargetPacket;
 import com.enderio.base.common.network.RemoveTravelTargetPacket;
+import com.enderio.base.common.network.RequestTravelPacket;
 import com.enderio.base.common.network.SyncTravelDataPacket;
 import com.enderio.base.common.network.UpdateCoordinateSelectionNameMenuPacket;
 import com.enderio.core.common.network.ClientToServerMenuPacket;
@@ -16,6 +17,7 @@ public class EIOPackets {
         CoreNetwork.registerPacket(new SyncTravelDataPacket.Handler(), SyncTravelDataPacket.class);
         CoreNetwork.registerPacket(new AddTravelTargetPacket.Handler(), AddTravelTargetPacket.class);
         CoreNetwork.registerPacket(new RemoveTravelTargetPacket.Handler(), RemoveTravelTargetPacket.class);
+        CoreNetwork.registerPacket(new RequestTravelPacket.Handler(), RequestTravelPacket.class);
 
     }
 }

--- a/src/main/java/com/enderio/base/common/item/tool/TravelStaffItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/TravelStaffItem.java
@@ -85,7 +85,7 @@ public class TravelStaffItem extends Item implements IMultiCapabilityItem, IAdva
                 return true;
             }
         } else {
-            if (TravelHandler.blockTeleport(level, player)) {
+            if (TravelHandler.blockTeleport(level, player, 0)) {
                 player.getCooldowns().addCooldown(this, BaseConfig.COMMON.ITEMS.TRAVELLING_BLINK_DISABLED_TIME.get());
                 return true;
             }

--- a/src/main/java/com/enderio/base/common/item/tool/TravelStaffItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/TravelStaffItem.java
@@ -85,7 +85,7 @@ public class TravelStaffItem extends Item implements IMultiCapabilityItem, IAdva
                 return true;
             }
         } else {
-            if (TravelHandler.blockTeleport(level, player, 0)) {
+            if (TravelHandler.blockTeleport(level, player)) {
                 player.getCooldowns().addCooldown(this, BaseConfig.COMMON.ITEMS.TRAVELLING_BLINK_DISABLED_TIME.get());
                 return true;
             }

--- a/src/main/java/com/enderio/base/common/network/RequestTravelPacket.java
+++ b/src/main/java/com/enderio/base/common/network/RequestTravelPacket.java
@@ -1,0 +1,89 @@
+package com.enderio.base.common.network;
+
+import com.enderio.api.travel.ITravelTarget;
+import com.enderio.base.common.handler.TravelHandler;
+import com.enderio.base.common.travel.TravelSavedData;
+import com.enderio.core.common.network.Packet;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.Optional;
+
+public class RequestTravelPacket implements Packet {
+    private final BlockPos pos;
+
+    public RequestTravelPacket(BlockPos pos) {
+        this.pos = pos;
+    }
+
+
+    public RequestTravelPacket(FriendlyByteBuf buf) {
+        pos = buf.readBlockPos();
+    }
+
+    protected void write(FriendlyByteBuf writeInto) {
+        writeInto.writeBlockPos(pos);
+    }
+
+    @Override
+    public boolean isValid(NetworkEvent.Context context) {
+        return context.getDirection() == NetworkDirection.PLAY_TO_SERVER;
+    }
+
+    @Override
+    public void handle(NetworkEvent.Context context) {
+        ServerHandler.handle(context, pos);
+    }
+
+    public static class Handler extends PacketHandler<RequestTravelPacket> {
+
+        @Override
+        public RequestTravelPacket fromNetwork(FriendlyByteBuf buf) {
+            return new RequestTravelPacket(buf);
+        }
+
+        @Override
+        public void toNetwork(RequestTravelPacket packet, FriendlyByteBuf buf) {
+            packet.write(buf);
+        }
+
+        @Override
+        public Optional<NetworkDirection> getDirection() {
+            return Optional.of(NetworkDirection.PLAY_TO_SERVER);
+        }
+    }
+
+    public static class ServerHandler {
+        static void handle(NetworkEvent.Context context, BlockPos pos) {
+            var player = context.getSender();
+
+            if (player == null) {
+                return;
+            }
+
+            TravelSavedData travelData = TravelSavedData.getTravelData(player.level());
+            Optional<ITravelTarget> target = travelData.getTravelTarget(pos);
+
+            // These errors should only ever be triggered if there's some form of desync
+            if (!TravelHandler.canBlockTeleport(player)) {
+                player.displayClientMessage(Component.nullToEmpty("ERROR: Cannot teleport"), true);
+                return;
+            }
+            if (target.isEmpty()) {
+                player.displayClientMessage(Component.nullToEmpty("ERROR: Destination not a valid target"), true);
+                return;
+            }
+            // Eventually change the packet structure to include what teleport method was used so this range can be selected correctly
+            int range = Math.max(target.get().getBlock2BlockRange(), target.get().getItem2BlockRange());
+            if (pos.distSqr(player.getOnPos()) > range * range) {
+                player.displayClientMessage(Component.nullToEmpty("ERROR: Too far"), true);
+                return;
+            }
+
+            TravelHandler.blockTeleportTo(player.level(), player, target.get(), false);
+        }
+    }
+}


### PR DESCRIPTION
Hooks into the jump/sneak events to move up/down, resolves #482

# Description

Please make any changes you see fit, but in particular I wasn't sure whether to make the vertical range infinite, a new config value, or reuse the current block to block range; I ended up choosing the existing config value, but I'm also unsure if the way I'm using it is correct.

This code should only scan for other anchors if there's none currently targeted, and I've tried my best to make the code performant without ruining readability, but I haven't done any extreme tests with a large number of anchors. It also intentionally skips the blocks directly above and below the current travel anchor since there was some strange behaviour where sneaking on a travel anchor with one below it would teleport you to the same anchor, making it impossible to go further down.

While testing I also noticed that travel anchors use the "item to block" config range instead of the "block to block" range, making the "block to block" a visual-only config (until this PR).

I'd also like to add up/down indicators when you're standing on a travel anchor, but I thought I should get some feedback on these changes before proceeding further.

# Todo

- [x] Implement visual indicators for vertical anchors.
- [x] Add/use any configuration that may be required.
    -  Clientside configuration can be added in another PR
- [x] Test edge cases, particularly for unexpected block arrangements.
- ~~Use "block to block" range for travel anchors (optional).~~
- [x] Update documentation for the additional anchor behaviour.
    - No documentation to update

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.