### PR TITLE
Remove checkstyle from gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
     id 'net.minecraftforge.gradle' version '[6.0,6.2)'
     id 'org.parchmentmc.librarian.forgegradle' version '1.+'
     id "me.hypherionmc.modutils.modpublisher" version "1.+"
-    id 'checkstyle'
 }
 
 apply plugin: 'org.spongepowered.mixin'


### PR DESCRIPTION
Checkstyle should leave comments on GitHub, but it should never fail a build.