### PR TITLE
Fixes a duping bug caused by Ghost Slots

### DIFF
--- a/src/machines/java/com/enderio/machines/common/menu/MachineMenu.java
+++ b/src/machines/java/com/enderio/machines/common/menu/MachineMenu.java
@@ -4,6 +4,7 @@ import com.enderio.core.common.menu.SyncedMenu;
 import com.enderio.machines.common.blockentity.base.MachineBlockEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
@@ -170,5 +171,23 @@ public abstract class MachineMenu<T extends MachineBlockEntity> extends SyncedMe
         }
 
         return flag;
+    }
+
+    // Overrides the swapping behaviour. Required for ghost slots to prevent duping
+    @Override
+    public void doClick(int slotId, int button, ClickType clickType, Player player) {
+        if(slotId > 0 && clickType == ClickType.PICKUP && this.slots.get(slotId) instanceof GhostMachineSlot ghostSlot) {
+            ItemStack slotItem = ghostSlot.getItem();
+            ItemStack carriedItem = this.getCarried();
+            if(!slotItem.isEmpty() && !carriedItem.isEmpty() && ghostSlot.mayPlace(carriedItem)){
+                if(!ItemStack.isSameItemSameTags(slotItem, carriedItem)){
+                    int count = Math.min(carriedItem.getCount(), ghostSlot.getMaxStackSize(carriedItem));
+                    ghostSlot.setByPlayer(carriedItem.copyWithCount(count));
+                    ghostSlot.setChanged();
+                    return;
+                }
+            }
+        }
+        super.doClick(slotId, button, clickType, player);
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -39,3 +39,6 @@ public net.minecraft.client.particle.Particle f_107226_ # gravity
 # RenderTypes
 public net.minecraft.client.renderer.RenderType f_110393_ # sortOnUpload
 public net.minecraft.client.renderer.RenderStateShard f_110133_ # name
+
+# GhostSlotBehaviour for AbstractContainerMenu
+public net.minecraft.world.inventory.AbstractContainerMenu m_150430_(IILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V # doClick


### PR DESCRIPTION
# Description

The default item swap mouse behavior swaps can lead to item duplication. This PR fixes it by manually checking for ghostSlot and override its mouse click behaviour

# Checklist:

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have performed a self-review of my own code.
- [X] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
