### PR TITLE
Feature/short travel staff teleport

### DIFF
--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -142,6 +142,7 @@ public class TravelHandler {
         } else if (bhr.getType() == HitResult.Type.BLOCK) {
             Direction dir = bhr.getDirection();
             if (dir == Direction.UP) {
+                // teleport the player *inside* the target block, then later push them up by the block's height
                 // warning: relies on the fact that isTeleportClear works with heights >= 1
                 target = bhr.getBlockPos();
             } else if (dir == Direction.DOWN) {
@@ -155,12 +156,13 @@ public class TravelHandler {
         }
 
         // if target block is close, also try to teleport through
+        // eventually this distance should become configurable client-side
         if (playerPos.distanceToSqr(bhr.getLocation()) < 9) {
             // add small amount to make sure it starts at the correct block
             Vec3 traverseFrom = bhr.getLocation().add(lookVec.scale(0.01));
 
             // since we can't return null from the fail condition, instead use an invalid position
-            BlockPos failPosition = new BlockPos(Integer.MAX_VALUE, 0, 0);
+            BlockPos failPosition = new BlockPos(0, Integer.MAX_VALUE, 0);
 
             // can reuse same toPos and clipCtx because this traversal should be along the same line
             BlockPos newTarget = BlockGetter.traverseBlocks(traverseFrom, toPos, clipCtx, (traverseCtx, traversePos) -> {

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -166,8 +166,9 @@ public class TravelHandler {
             BlockPos newTarget = BlockGetter.traverseBlocks(traverseFrom, toPos, clipCtx, (traverseCtx, traversePos) -> {
                 // check underneath first, since that's more likely to be where the player wants to teleport
                 BlockPos checkBelow = traversalCheck(level, traversePos.below());
-                if (checkBelow != null)
+                if (checkBelow != null) {
                     return checkBelow;
+                }
 
                 return traversalCheck(level, traversePos);
             }, (failCtx) -> failPosition);
@@ -195,8 +196,9 @@ public class TravelHandler {
     private static BlockPos traversalCheck(Level level, BlockPos traversePos) {
         BlockState blockState = level.getBlockState(traversePos);
         var collision = blockState.getCollisionShape(level, traversePos);
-        if (collision.isEmpty() && isTeleportPositionClear(level, traversePos.below()).isPresent())
+        if (collision.isEmpty() && isTeleportPositionClear(level, traversePos.below()).isPresent()) {
             return traversePos;
+        }
         return null;
     }
 
@@ -261,16 +263,16 @@ public class TravelHandler {
             return Optional.empty();
         }
 
-        if (!level.getBlockState(target.above(2)).canOcclude()) {
-            BlockPos above = target.above();
-            double height = level.getBlockState(above).getCollisionShape(level, above).max(Direction.Axis.Y);
-            if (height > 0.2d && !level.getBlockState(target.above(3)).canOcclude() || height <=0.2d) {
-                if (height == Double.NEGATIVE_INFINITY) {
-                    height = 0;
-                }
+        BlockPos above = target.above();
+        double height = level.getBlockState(above).getCollisionShape(level, above).max(Direction.Axis.Y);
+        if (height <= 0.2d) {
+            return Optional.of(Math.max(height, 0));
+        }
 
-                return Optional.of(height);
-            }
+        above = above.above();
+        boolean noCollisionAbove = level.getBlockState(above).getCollisionShape(level, above).isEmpty();
+        if (noCollisionAbove) {
+            return Optional.of(Math.max(height, 0));
         }
 
         return Optional.empty();

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -17,7 +17,11 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityTeleportEvent;
@@ -120,25 +124,80 @@ public class TravelHandler {
     }
 
     public static Optional<Vec3> teleportPosition(Level level, Player player) {
-        Vec3 targetVec = player.position().add(0, player.getEyeHeight(), 0);
-        Vec3 lookVec = player.getLookAngle().normalize();
         @Nullable BlockPos target = null;
         double floorHeight = 0;
-        for (double i = BaseConfig.COMMON.ITEMS.TRAVELLING_BLINK_RANGE.get(); i >= 2; i -= 0.5) {
-            Vec3 v3d = targetVec.add(lookVec.scale(i));
-            target = new BlockPos((int) Math.round(v3d.x), (int) Math.round(v3d.y), (int) Math.round(v3d.z));
+
+        // inspired by Entity#pick
+        Vec3 playerPos = player.getEyePosition();
+        Vec3 lookVec = player.getLookAngle().normalize();
+        int range = BaseConfig.COMMON.ITEMS.TRAVELLING_BLINK_RANGE.get();
+        Vec3 toPos = playerPos.add(lookVec.scale(range));
+
+        ClipContext clipCtx = new ClipContext(playerPos, toPos, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, null);
+        BlockHitResult bhr = level.clip(clipCtx);
+
+        // process the result
+        if (bhr.getType() == HitResult.Type.MISS) {
+            target = bhr.getBlockPos();
+        } else if (bhr.getType() == HitResult.Type.BLOCK) {
+            Direction dir = bhr.getDirection();
+            if (dir == Direction.UP) {
+                // warning: relies on the fact that isTeleportClear works with heights >= 1
+                target = bhr.getBlockPos();
+            } else if (dir == Direction.DOWN) {
+                target = bhr.getBlockPos().below((int) Math.ceil(player.getBbHeight()));
+            } else {
+                target = bhr.getBlockPos().offset(dir.getStepX(), 0, dir.getStepZ());
+                if (level.getBlockState(target).getCollisionShape(level, target).isEmpty()) {
+                    target = target.below();
+                }
+            }
+        }
+
+        // if target block is close, also try to teleport through
+        if (playerPos.distanceToSqr(bhr.getLocation()) < 9) {
+            // add small amount to make sure it starts at the correct block
+            Vec3 traverseFrom = bhr.getLocation().add(lookVec.scale(0.01));
+
+            // since we can't return null from the fail condition, instead use an invalid position
+            BlockPos failPosition = new BlockPos(Integer.MAX_VALUE, 0, 0);
+
+            // can reuse same toPos and clipCtx because this traversal should be along the same line
+            BlockPos newTarget = BlockGetter.traverseBlocks(traverseFrom, toPos, clipCtx, (traverseCtx, traversePos) -> {
+                // check underneath first, since that's more likely to be where the player wants to teleport
+                BlockPos checkBelow = traversalCheck(level, traversePos.below());
+                if (checkBelow != null)
+                    return checkBelow;
+
+                return traversalCheck(level, traversePos);
+            }, (failCtx) -> failPosition);
+            if (newTarget != failPosition) {
+                target = newTarget.immutable();
+            }
+        }
+
+        if (target != null) {
             Optional<Double> ground = isTeleportPositionClear(level, target.below());
             if (ground.isPresent()) { //to use the same check as the anchors use the position below
                 floorHeight = ground.get();
-                break;
             } else {
                 target = null;
             }
         }
-        if (target == null) {
+
+        if (target == null || player.blockPosition().distManhattan(target) < 2) {
             return Optional.empty();
         }
         return Optional.of(Vec3.atBottomCenterOf(target).add(0, floorHeight, 0));
+    }
+
+    @Nullable
+    private static BlockPos traversalCheck(Level level, BlockPos traversePos) {
+        BlockState blockState = level.getBlockState(traversePos);
+        var collision = blockState.getCollisionShape(level, traversePos);
+        if (collision.isEmpty() && isTeleportPositionClear(level, traversePos.below()).isPresent())
+            return traversePos;
+        return null;
     }
 
     public static Optional<ITravelTarget> getAnchorTarget(Player player) {

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -164,12 +164,16 @@ public class TravelHandler {
             // since we can't return null from the fail condition, instead use an invalid position
             BlockPos failPosition = new BlockPos(0, Integer.MAX_VALUE, 0);
 
+            boolean aimingUp = lookVec.y > 0.5;
+
             // can reuse same toPos and clipCtx because this traversal should be along the same line
             BlockPos newTarget = BlockGetter.traverseBlocks(traverseFrom, toPos, clipCtx, (traverseCtx, traversePos) -> {
-                // check underneath first, since that's more likely to be where the player wants to teleport
-                BlockPos checkBelow = traversalCheck(level, traversePos.below());
-                if (checkBelow != null) {
-                    return checkBelow;
+                if (!aimingUp) {
+                    // check underneath first, since that's more likely to be where the player wants to teleport
+                    BlockPos checkBelow = traversalCheck(level, traversePos.below());
+                    if (checkBelow != null) {
+                        return checkBelow;
+                    }
                 }
 
                 return traversalCheck(level, traversePos);

--- a/src/main/java/com/enderio/base/common/item/tool/TravelStaffItem.java
+++ b/src/main/java/com/enderio/base/common/item/tool/TravelStaffItem.java
@@ -59,9 +59,10 @@ public class TravelStaffItem extends Item implements IMultiCapabilityItem, IAdva
     }
 
     private boolean tryPerformAction(Level level, Player player, ItemStack stack) {
-        if (hasResources(stack)) {
+        boolean isCreative = player.isCreative();
+        if (hasResources(stack) || isCreative) {
             if (performAction(level, player,stack)) {
-                if (!level.isClientSide()) {
+                if (!level.isClientSide() && !isCreative) {
                     consumeResources(stack);
                 }
 


### PR DESCRIPTION
# Description

The short travel feature now makes use of vanilla methods to discover the target block.

The search code is split into two halves:
1. Find which block the player is targeting
2. If that block is too close, step through blocks along the look vector until there's a free spot

Unfortunately this code will miss some edge cases where a teleport *could* be performed, but I believe it will be enough for the vast majority of players.

Resolves #502 <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
