### PR TITLE
Adds overlay on top of Ghost and Preview Slots

### DIFF
--- a/src/machines/java/com/enderio/machines/client/gui/screen/AlloySmelterScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/AlloySmelterScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.ProgressWidget;
@@ -15,7 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class AlloySmelterScreen extends EIOScreen<AlloySmelterMenu> {
+public class AlloySmelterScreen extends MachineScreen<AlloySmelterMenu> {
 
     public static final ResourceLocation BG_TEXTURE_AUTO = EnderIO.loc("textures/gui/alloy_smelter_auto.png");
     private static final ResourceLocation BG_TEXTURE_ALLOY = EnderIO.loc("textures/gui/alloy_smelter_alloy.png");

--- a/src/machines/java/com/enderio/machines/client/gui/screen/CapacitorBankScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/CapacitorBankScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.EnergyWidget;
 import com.enderio.machines.client.gui.widget.ioconfig.IOConfigButton;
@@ -12,7 +11,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class CapacitorBankScreen extends EIOScreen<CapacitorBankMenu> {
+public class CapacitorBankScreen extends MachineScreen<CapacitorBankMenu> {
 
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/capacitor_bank.png");
 

--- a/src/machines/java/com/enderio/machines/client/gui/screen/CrafterScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/CrafterScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.ioconfig.IOConfigButton;
@@ -12,7 +11,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class CrafterScreen extends EIOScreen<CrafterMenu> {
+public class CrafterScreen extends MachineScreen<CrafterMenu> {
 
     private static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/crafter.png");
 

--- a/src/machines/java/com/enderio/machines/client/gui/screen/DrainScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/DrainScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.core.client.gui.widgets.ToggleImageButton;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
@@ -16,7 +15,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class DrainScreen extends EIOScreen<DrainMenu> {
+public class DrainScreen extends MachineScreen<DrainMenu> {
 
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/drain.png");
     private static final ResourceLocation BUTTONS = EnderIO.loc("textures/gui/icons/buttons.png");

--- a/src/machines/java/com/enderio/machines/client/gui/screen/EnchanterScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/EnchanterScreen.java
@@ -2,7 +2,6 @@ package com.enderio.machines.client.gui.screen;
 
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.machines.common.menu.EnchanterMenu;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -11,7 +10,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class EnchanterScreen extends EIOScreen<EnchanterMenu> {
+public class EnchanterScreen extends MachineScreen<EnchanterMenu> {
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/enchanter.png");
 
     public EnchanterScreen(EnchanterMenu pMenu, Inventory pPlayerInventory, Component pTitle) {

--- a/src/machines/java/com/enderio/machines/client/gui/screen/FluidTankScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/FluidTankScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.FluidStackWidget;
 import com.enderio.machines.client.gui.widget.ioconfig.IOConfigButton;
@@ -12,7 +11,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class FluidTankScreen extends EIOScreen<FluidTankMenu> {
+public class FluidTankScreen extends MachineScreen<FluidTankMenu> {
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/tank.png");
     public FluidTankScreen(FluidTankMenu pMenu, Inventory pPlayerInventory, Component pTitle) {
         super(pMenu, pPlayerInventory, pTitle);

--- a/src/machines/java/com/enderio/machines/client/gui/screen/ImpulseHopperScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/ImpulseHopperScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.ioconfig.IOConfigButton;
@@ -13,7 +12,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class ImpulseHopperScreen extends EIOScreen<ImpulseHopperMenu> {
+public class ImpulseHopperScreen extends MachineScreen<ImpulseHopperMenu> {
     private static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/impulse_hopper.png");
 
     public ImpulseHopperScreen(ImpulseHopperMenu pMenu, Inventory pPlayerInventory, Component pTitle) {

--- a/src/machines/java/com/enderio/machines/client/gui/screen/MachineScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/MachineScreen.java
@@ -1,0 +1,17 @@
+package com.enderio.machines.client.gui.screen;
+
+import com.enderio.core.client.gui.screen.EIOScreen;
+import com.enderio.machines.common.menu.MachineMenu;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+
+public abstract class MachineScreen<T extends MachineMenu> extends EIOScreen<T> {
+    protected MachineScreen(T pMenu, Inventory pPlayerInventory, Component pTitle) {
+        super(pMenu, pPlayerInventory, pTitle);
+    }
+
+    protected MachineScreen(T pMenu, Inventory pPlayerInventory, Component pTitle, boolean renderLabels) {
+        super(pMenu, pPlayerInventory, pTitle, renderLabels);
+    }
+
+}

--- a/src/machines/java/com/enderio/machines/client/gui/screen/MachineScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/MachineScreen.java
@@ -1,9 +1,13 @@
 package com.enderio.machines.client.gui.screen;
 
 import com.enderio.core.client.gui.screen.EIOScreen;
+import com.enderio.machines.common.menu.GhostMachineSlot;
 import com.enderio.machines.common.menu.MachineMenu;
+import com.enderio.machines.common.menu.PreviewMachineSlot;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.Slot;
 
 public abstract class MachineScreen<T extends MachineMenu> extends EIOScreen<T> {
     protected MachineScreen(T pMenu, Inventory pPlayerInventory, Component pTitle) {
@@ -14,4 +18,17 @@ public abstract class MachineScreen<T extends MachineMenu> extends EIOScreen<T> 
         super(pMenu, pPlayerInventory, pTitle, renderLabels);
     }
 
+    @Override
+    public void renderSlot(GuiGraphics guiGraphics, Slot slot) {
+        super.renderSlot(guiGraphics, slot);
+
+        if (slot instanceof GhostMachineSlot || slot instanceof PreviewMachineSlot) {
+            if (slot.hasItem()) {
+                guiGraphics.pose().pushPose();
+                guiGraphics.pose().translate(0.0F, 0.0F, 300F);
+                guiGraphics.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, -2130706433);
+                guiGraphics.pose().popPose();
+            }
+        }
+    }
 }

--- a/src/machines/java/com/enderio/machines/client/gui/screen/MachineScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/MachineScreen.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 
 public abstract class MachineScreen<T extends MachineMenu> extends EIOScreen<T> {
+    public static final int SLOT_COLOR = -2130706433;
     protected MachineScreen(T pMenu, Inventory pPlayerInventory, Component pTitle) {
         super(pMenu, pPlayerInventory, pTitle);
     }
@@ -26,7 +27,7 @@ public abstract class MachineScreen<T extends MachineMenu> extends EIOScreen<T> 
             if (slot.hasItem()) {
                 guiGraphics.pose().pushPose();
                 guiGraphics.pose().translate(0.0F, 0.0F, 300F);
-                guiGraphics.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, -2130706433);
+                guiGraphics.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, SLOT_COLOR);
                 guiGraphics.pose().popPose();
             }
         }

--- a/src/machines/java/com/enderio/machines/client/gui/screen/PaintingMachineScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/PaintingMachineScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.ProgressWidget;
@@ -12,7 +11,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class PaintingMachineScreen extends EIOScreen<PaintingMachineMenu> {
+public class PaintingMachineScreen extends MachineScreen<PaintingMachineMenu> {
 
     private static final ResourceLocation PAINTING_MACHINE_BG = EnderIO.loc("textures/gui/painting_machine.png");
 

--- a/src/machines/java/com/enderio/machines/client/gui/screen/PoweredSpawnerScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/PoweredSpawnerScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.core.client.gui.widgets.ToggleImageButton;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
@@ -19,7 +18,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.Optional;
 
-public class PoweredSpawnerScreen extends EIOScreen<PoweredSpawnerMenu> {
+public class PoweredSpawnerScreen extends MachineScreen<PoweredSpawnerMenu> {
 
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/powered_spawner_spawn.png");
     private static final ResourceLocation RANGE_BUTTON_TEXTURE = EnderIO.loc("textures/gui/icons/range_buttons.png");

--- a/src/machines/java/com/enderio/machines/client/gui/screen/PrimitiveAlloySmelterScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/PrimitiveAlloySmelterScreen.java
@@ -2,14 +2,13 @@ package com.enderio.machines.client.gui.screen;
 
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.machines.client.gui.widget.ProgressWidget;
 import com.enderio.machines.common.menu.PrimitiveAlloySmelterMenu;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class PrimitiveAlloySmelterScreen extends EIOScreen<PrimitiveAlloySmelterMenu> {
+public class PrimitiveAlloySmelterScreen extends MachineScreen<PrimitiveAlloySmelterMenu> {
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/primitive_alloy_smelter.png");
 
     public PrimitiveAlloySmelterScreen(PrimitiveAlloySmelterMenu pMenu, Inventory pPlayerInventory, Component pTitle) {

--- a/src/machines/java/com/enderio/machines/client/gui/screen/SagMillScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/SagMillScreen.java
@@ -4,7 +4,6 @@ import com.enderio.EnderIO;
 import com.enderio.api.grindingball.IGrindingBallData;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.core.common.util.TooltipUtil;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
@@ -27,7 +26,7 @@ import net.minecraft.world.entity.player.Inventory;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class SagMillScreen extends EIOScreen<SagMillMenu> {
+public class SagMillScreen extends MachineScreen<SagMillMenu> {
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/sag_mill.png");
 
     public SagMillScreen(SagMillMenu pMenu, Inventory pPlayerInventory, Component pTitle) {

--- a/src/machines/java/com/enderio/machines/client/gui/screen/SlicerScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/SlicerScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.ProgressWidget;
@@ -13,7 +12,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class SlicerScreen extends EIOScreen<SlicerMenu> {
+public class SlicerScreen extends MachineScreen<SlicerMenu> {
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/slice_and_splice.png");
 
     public SlicerScreen(SlicerMenu pMenu, Inventory pPlayerInventory, Component pTitle) {

--- a/src/machines/java/com/enderio/machines/client/gui/screen/SoulBinderScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/SoulBinderScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.ExperienceCraftingWidget;
@@ -14,7 +13,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class SoulBinderScreen extends EIOScreen<SoulBinderMenu> {
+public class SoulBinderScreen extends MachineScreen<SoulBinderMenu> {
 
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/soul_binder.png");
 

--- a/src/machines/java/com/enderio/machines/client/gui/screen/SoulEngineScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/SoulEngineScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.FluidStackWidget;
@@ -19,7 +18,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.Optional;
 
-public class SoulEngineScreen extends EIOScreen<SoulEngineMenu>{
+public class SoulEngineScreen extends MachineScreen<SoulEngineMenu> {
 
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/soul_engine.png");
 

--- a/src/machines/java/com/enderio/machines/client/gui/screen/StirlingGeneratorScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/StirlingGeneratorScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
 import com.enderio.machines.client.gui.widget.ProgressWidget;
@@ -13,7 +12,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class StirlingGeneratorScreen extends EIOScreen<StirlingGeneratorMenu> {
+public class StirlingGeneratorScreen extends MachineScreen<StirlingGeneratorMenu> {
     public static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/stirling_generator.png");
 
     public StirlingGeneratorScreen(StirlingGeneratorMenu pMenu, Inventory pPlayerInventory, Component pTitle) {

--- a/src/machines/java/com/enderio/machines/client/gui/screen/TravelAnchorScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/TravelAnchorScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.ToggleImageButton;
 import com.enderio.machines.common.menu.TravelAnchorMenu;
 import net.minecraft.client.gui.components.EditBox;
@@ -11,7 +10,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class TravelAnchorScreen extends EIOScreen<TravelAnchorMenu> {
+public class TravelAnchorScreen extends MachineScreen<TravelAnchorMenu> {
 
     private static final ResourceLocation TRAVEL_ANCHOR_BG = EnderIO.loc("textures/gui/travel_anchor.png");
     private static final ResourceLocation VISIBILITY_BTNS = EnderIO.loc("textures/gui/icons/visibility_buttons.png");

--- a/src/machines/java/com/enderio/machines/client/gui/screen/VacuumChestScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/VacuumChestScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.core.client.gui.widgets.ToggleImageButton;
 import com.enderio.machines.common.menu.VacuumChestMenu;
@@ -13,7 +12,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class VacuumChestScreen extends EIOScreen<VacuumChestMenu> {
+public class VacuumChestScreen extends MachineScreen<VacuumChestMenu> {
 
     private static final ResourceLocation VACUUM_CHEST_BG = EnderIO.loc("textures/gui/vacuum_chest.png");
     private static final ResourceLocation BUTTONS = EnderIO.loc("textures/gui/icons/buttons.png");

--- a/src/machines/java/com/enderio/machines/client/gui/screen/WiredChargerScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/WiredChargerScreen.java
@@ -3,10 +3,8 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.CapacitorEnergyWidget;
-import com.enderio.machines.client.gui.widget.EnergyWidget;
 import com.enderio.machines.client.gui.widget.ProgressWidget;
 import com.enderio.machines.client.gui.widget.ioconfig.IOConfigButton;
 import com.enderio.machines.common.menu.WiredChargerMenu;
@@ -14,7 +12,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class WiredChargerScreen extends EIOScreen<WiredChargerMenu> {
+public class WiredChargerScreen extends MachineScreen<WiredChargerMenu> {
 
     private static final ResourceLocation BG_TEXTURE = EnderIO.loc("textures/gui/wired_charger.png");
     public WiredChargerScreen(WiredChargerMenu pMenu, Inventory pPlayerInventory, Component pTitle) {

--- a/src/machines/java/com/enderio/machines/client/gui/screen/XPObeliskScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/XPObeliskScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.machines.client.gui.widget.ExperienceWidget;
 import com.enderio.machines.client.gui.widget.ioconfig.IOConfigButton;
@@ -15,7 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class XPObeliskScreen extends EIOScreen<XPObeliskMenu> {
+public class XPObeliskScreen extends MachineScreen<XPObeliskMenu> {
     private static final ResourceLocation BG = EnderIO.loc("textures/gui/xp_obelisk.png");
     private static final ResourceLocation XP_BTNS = EnderIO.loc("textures/gui/icons/xp_obelisk.png");
 

--- a/src/machines/java/com/enderio/machines/client/gui/screen/XPVacuumScreen.java
+++ b/src/machines/java/com/enderio/machines/client/gui/screen/XPVacuumScreen.java
@@ -3,7 +3,6 @@ package com.enderio.machines.client.gui.screen;
 import com.enderio.EnderIO;
 import com.enderio.api.misc.Vector2i;
 import com.enderio.base.common.lang.EIOLang;
-import com.enderio.core.client.gui.screen.EIOScreen;
 import com.enderio.core.client.gui.widgets.EnumIconWidget;
 import com.enderio.core.client.gui.widgets.ToggleImageButton;
 import com.enderio.machines.client.gui.widget.FluidStackStaticWidget;
@@ -14,7 +13,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
-public class XPVacuumScreen extends EIOScreen<XPVacuumMenu> {
+public class XPVacuumScreen extends MachineScreen<XPVacuumMenu> {
 
     private static final ResourceLocation XP_VACUUM_BG = EnderIO.loc("textures/gui/xp_vacuum.png");
     private static final ResourceLocation BUTTONS = EnderIO.loc("textures/gui/icons/buttons.png");

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -42,3 +42,5 @@ public net.minecraft.client.renderer.RenderStateShard f_110133_ # name
 
 # GhostSlotBehaviour for AbstractContainerMenu
 public net.minecraft.world.inventory.AbstractContainerMenu m_150430_(IILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V # doClick
+# GhostSlot rendering for AbstractContainerScreen
+public net.minecraft.client.gui.screens.inventory.AbstractContainerScreen m_280092_(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/world/inventory/Slot;)V # renderSlot


### PR DESCRIPTION
# Description

Adds overlay on top of slots that make them looks faded indicated that they arent proper slots in which player can 
put and extract normal items
Also adds a wrapper `MachineScreen` class so that functionality can be shared across all machines.

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have performed a self-review of my own code.
- [X] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.

