### PR TITLE
Avoid crashes caused by ME conduits

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
+++ b/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
@@ -37,13 +37,11 @@ public class AE2InWorldConduitNodeHost implements IInWorldGridNodeHost, IExtende
             .setInWorldNode(true)
             .setTagName("conduit");
 
-        assert mainNode != null;
+        mainNode.setIdlePowerUsage(type.isDense() ? 0.4d : 0.1d);
 
         if (type.isDense()) {
             mainNode.setFlags(GridFlags.DENSE_CAPACITY);
         }
-
-        mainNode.setIdlePowerUsage(type.isDense() ? 0.4d : 0.1d);
     }
 
     @Nullable

--- a/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
+++ b/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
@@ -21,25 +21,37 @@ import java.util.Set;
 public class AE2InWorldConduitNodeHost implements IInWorldGridNodeHost, IExtendedConduitData<AE2InWorldConduitNodeHost> {
 
     private final AE2ConduitType type;
-    private final IManagedGridNode mainNode;
+    @Nullable
+    private IManagedGridNode mainNode = null;
 
     final LazyOptional<AE2InWorldConduitNodeHost> selfCap = LazyOptional.of(() -> this);
 
     public AE2InWorldConduitNodeHost(AE2ConduitType type) {
         this.type = type;
+        initMainNode();
+    }
+
+    private void initMainNode() {
         mainNode = GridHelper.createManagedNode(this, new GridNodeListener())
             .setVisualRepresentation(type.getConduitItem())
             .setInWorldNode(true)
             .setTagName("conduit");
+
+        assert mainNode != null;
+
         if (type.isDense()) {
             mainNode.setFlags(GridFlags.DENSE_CAPACITY);
         }
+
         mainNode.setIdlePowerUsage(type.isDense() ? 0.4d : 0.1d);
     }
 
     @Nullable
     @Override
     public IGridNode getGridNode(Direction dir) {
+        if (mainNode == null) {
+            initMainNode();
+        }
         return mainNode.getNode();
     }
 
@@ -55,33 +67,56 @@ public class AE2InWorldConduitNodeHost implements IInWorldGridNodeHost, IExtende
     @Override
     public CompoundTag serializeNBT() {
         CompoundTag nbt = new CompoundTag();
-        mainNode.saveToNBT(nbt);
+        if (mainNode != null) {
+            mainNode.saveToNBT(nbt);
+        }
         return nbt;
     }
 
     @Override
     public void deserializeNBT(CompoundTag nbt) {
+        if (mainNode == null) {
+            initMainNode();
+        }
+
         mainNode.loadFromNBT(nbt);
     }
 
     @Override
     public void onCreated(IConduitType<?> type, Level level, BlockPos pos, @Nullable Player player) {
-        if (!mainNode.isReady()) {
-            if (player != null) {
-                mainNode.setOwningPlayer(player);
-            }
-            GridHelper.onFirstTick(level.getBlockEntity(pos), blockEntity -> mainNode.create(level, pos));
+        if (mainNode == null) {
+            // required because onCreated() can be called after onRemoved()
+            initMainNode();
         }
+
+        if (mainNode.isReady()) {
+            return;
+        }
+
+        if (player != null) {
+            mainNode.setOwningPlayer(player);
+        }
+
+        GridHelper.onFirstTick(level.getBlockEntity(pos), blockEntity -> mainNode.create(level, pos));
     }
 
     @Override
     public void updateConnection(Set<Direction> connectedSides) {
+        if (mainNode == null) {
+            return;
+        }
+
         mainNode.setExposedOnSides(connectedSides);
     }
 
     @Override
     public void onRemoved(IConduitType<?> type, Level level, BlockPos pos) {
-        mainNode.destroy();
+        if (mainNode != null) {
+            mainNode.destroy();
+
+            // required because onCreated() can be called after onRemoved()
+            mainNode = null;
+        }
         selfCap.invalidate();
     }
 


### PR DESCRIPTION
# Description

This is a quick change to prevent crashes, and should probably be undone if/when the conduit interface changes.


Fixes #505 <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->
Fixes #530
Fixes #560

Steps to reproduce the crash this commit fixes:

1. Move somewhere that can be unloaded, e.g. `/tp 5000 200 0`
2. Place an ME conduit
3. Unload it by leaving the area, `/tp 0 200 0`
4. Load chunk containing the conduit, `/tp 5000 200 0`

The issue seems to be that conduits objects are reused after `onRemoved` is called, changing that should also fix the crash.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
