### PR TITLE
Fix ME conduit crash on NeoForge

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
+++ b/src/conduits/java/com/enderio/conduits/common/integrations/ae2/AE2InWorldConduitNodeHost.java
@@ -28,7 +28,6 @@ public class AE2InWorldConduitNodeHost implements IInWorldGridNodeHost, IExtende
 
     public AE2InWorldConduitNodeHost(AE2ConduitType type) {
         this.type = type;
-        initMainNode();
     }
 
     private void initMainNode() {
@@ -48,7 +47,7 @@ public class AE2InWorldConduitNodeHost implements IInWorldGridNodeHost, IExtende
     @Override
     public IGridNode getGridNode(Direction dir) {
         if (mainNode == null) {
-            initMainNode();
+            return null;
         }
         return mainNode.getNode();
     }
@@ -82,14 +81,12 @@ public class AE2InWorldConduitNodeHost implements IInWorldGridNodeHost, IExtende
 
     @Override
     public void onCreated(IConduitType<?> type, Level level, BlockPos pos, @Nullable Player player) {
-        if (mainNode == null) {
-            // required because onCreated() can be called after onRemoved()
-            initMainNode();
-        }
-
-        if (mainNode.isReady()) {
+        if (mainNode != null) {
+            // node is already valid
             return;
         }
+
+        initMainNode();
 
         if (player != null) {
             mainNode.setOwningPlayer(player);


### PR DESCRIPTION
# Description

Due to a bug, older versions of NeoForge never called `onCreated`, so we had to do it manually. Now that the bug is fixed, the code is instead calling `onCreated` twice. This PR just ignores further calls to `onCreated` if `onRemoved` hasn't been called.

Details on the crash are in the linked issue:
Resolves #569

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
