### PR TITLE
Update nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: nightly-build
-          path: build/libs/*.jar
+          path: |
+            build/libs/*.jar
+            !build/libs/*-partial.jar
 
       - name: Discord Notification Success
         uses: tsickert/discord-webhook@v5.3.0
@@ -51,7 +53,7 @@ jobs:
           avatar-url: https://raw.githubusercontent.com/Team-EnderIO/EnderIO/dev/1.20.1/doc/img/enderface.png
           username: Ender IO Nightowl
           embed-footer-text: Build number ${{ github.run_number }}
-          embed-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          embed-url: https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/nightly-build.zip # NOTE: Must match "name" of the artifact as set above.
           embed-color: 5763719
 
       - name: Discord Notification Failure


### PR DESCRIPTION
Uses nightly.link in the webhook message to let not logged in users get the artifact.