### PR TITLE
Added Conduit to the commonly used forge:relocation_not_supported tag

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/tag/ConduitTags.java
+++ b/src/conduits/java/com/enderio/conduits/common/tag/ConduitTags.java
@@ -7,6 +7,7 @@ import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
+import net.minecraftforge.common.ForgeMod;
 
 public class ConduitTags {
 
@@ -30,5 +31,6 @@ public class ConduitTags {
 
         public static final TagKey<Block> REDSTONE_CONNECTABLE = BlockTags.create(EnderIO.loc("redstone_connectable"));
         public static final TagKey<Block> ENERGY_CABLE = BlockTags.create(EnderIO.loc("energy_cable"));
+        public static final TagKey<Block> RELOCATION_NOT_SUPPORTED = BlockTags.create(new ResourceLocation("forge", "relocation_not_supported"));
     }
 }

--- a/src/conduits/java/com/enderio/conduits/data/ConduitTagProvider.java
+++ b/src/conduits/java/com/enderio/conduits/data/ConduitTagProvider.java
@@ -1,6 +1,7 @@
 package com.enderio.conduits.data;
 
 import com.enderio.EnderIO;
+import com.enderio.conduits.common.init.ConduitBlocks;
 import com.enderio.conduits.common.tag.ConduitTags;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
@@ -32,5 +33,7 @@ public class ConduitTagProvider extends BlockTagsProvider {
             .addOptional(new ResourceLocation("mekanism", "ultimate_universal_cable"))
             .addOptional(new ResourceLocation("pipez", "energy_pipe"))
             .addOptional(new ResourceLocation("pipez", "universal_pipe"));
+
+        tag(ConduitTags.Blocks.RELOCATION_NOT_SUPPORTED).add(ConduitBlocks.CONDUIT.get());
     }
 }

--- a/src/generated/resources/data/forge/tags/blocks/relocation_not_supported.json
+++ b/src/generated/resources/data/forge/tags/blocks/relocation_not_supported.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "enderio:conduit"
+  ]
+}


### PR DESCRIPTION
# Description

The conduit block should've been in this tag from the beginning, I thought I did that, but I guess I forgot


- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
