### PR TITLE
Registrate at home

### DIFF
--- a/src/core/java/com/enderio/core/common/registry/EnderBlockEntityRegistry.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderBlockEntityRegistry.java
@@ -1,0 +1,36 @@
+package com.enderio.core.common.registry;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class EnderBlockEntityRegistry extends DeferredRegister<BlockEntityType<?>> {
+    protected EnderBlockEntityRegistry(String namespace) {
+        super(BuiltInRegistries.BLOCK_ENTITY_TYPE.key(), namespace);
+    }
+
+    public <T extends BlockEntity> EnderDeferredBlockEntity<T> registerBlockEntity(String name, BlockEntityType.BlockEntitySupplier<T> sup, Block... blocks) {
+        DeferredHolder<BlockEntityType<?>, BlockEntityType<T>> holder = this.register(name, () -> BlockEntityType.Builder.of(sup, blocks).build(null));
+        return EnderDeferredBlockEntity.createBlockEntity(holder);
+    }
+
+    @SafeVarargs
+    public final <T extends BlockEntity> EnderDeferredBlockEntity<T> registerBlockEntity(String name, BlockEntityType.BlockEntitySupplier<T> sup,
+        Supplier<? extends Block>... blocks) {
+        List<? extends Block> blockList = Arrays.stream(blocks).map(Supplier::get).toList();
+        DeferredHolder<BlockEntityType<?>, BlockEntityType<T>> holder = this.register(name, () -> BlockEntityType.Builder.of(sup, blockList.toArray(new Block[] {})).build(null));
+        return EnderDeferredBlockEntity.createBlockEntity(holder);
+    }
+
+    public static EnderBlockEntityRegistry create(String modid) {
+        return new EnderBlockEntityRegistry(modid);
+    }
+
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderBlockRegistry.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderBlockRegistry.java
@@ -1,0 +1,125 @@
+package com.enderio.core.common.registry;
+
+import com.enderio.core.data.EnderDataProvider;
+import com.enderio.core.data.lang.EnderLangProvider;
+import com.enderio.core.data.loot.EnderBlockLootProvider;
+import com.enderio.core.data.model.EnderBlockStateProvider;
+import com.enderio.core.data.model.EnderItemModelProvider;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.loot.LootTableProvider;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class EnderBlockRegistry extends DeferredRegister.Blocks {
+    private final EnderItemRegistry ItemRegistry;
+    protected EnderBlockRegistry(String namespace) {
+        super(namespace);
+        ItemRegistry = new EnderItemRegistry(namespace);
+    }
+
+    /**
+     * Adds a new block to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+     *
+     * @param name The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param func A factory for the new block. The factory should not cache the created block.
+     * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <B extends Block> EnderDeferredBlock<B> register(String name, Function<ResourceLocation, ? extends B> func) {
+        return (EnderDeferredBlock<B>) super.register(name, func);
+    }
+
+    /**
+     * Adds a new block to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+     *
+     * @param name The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param sup  A factory for the new block. The factory should not cache the created block.
+     * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+     */
+    @Override
+    public <B extends Block> EnderDeferredBlock<B> register(String name, Supplier<? extends B> sup) {
+        return this.register(name, key -> sup.get());
+    }
+
+    /**
+     * Adds a new block to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+     *
+     * @param name  The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param func  A factory for the new block. The factory should not cache the created block.
+     * @param props The properties for the created block.
+     * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+     * @see #registerBlock(String, BlockBehaviour.Properties)
+     */
+    public <B extends Block> EnderDeferredBlock<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, BlockBehaviour.Properties props) {
+        return this.register(name, () -> func.apply(props));
+    }
+
+    /**
+     * Adds a new block to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+     *
+     * @param name  The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param props The properties for the created block.
+     * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+     * @see #registerBlock(String, Function, BlockBehaviour.Properties)
+     */
+    public EnderDeferredBlock<Block> registerBlock(String name, BlockBehaviour.Properties props) {
+        return this.registerBlock(name, Block::new, props);
+    }
+
+    @Override
+    protected <I extends Block> DeferredBlock<I> createHolder(ResourceKey<? extends Registry<Block>> registryKey, ResourceLocation key) {
+        return EnderDeferredBlock.createBlock(ResourceKey.create(registryKey, key));
+    }
+
+    public EnderItemRegistry getItemRegistry() {
+        return ItemRegistry;
+    }
+
+    public static EnderBlockRegistry createRegistry(String modid) {
+        return new EnderBlockRegistry(modid);
+    }
+
+    @Override
+    public void register(IEventBus bus) {
+        super.register(bus);
+        ItemRegistry.register(bus);
+        bus.addListener(EventPriority.LOWEST, this::onGatherData);
+    }
+
+    private void onGatherData(GatherDataEvent event) {
+        DataGenerator generator = event.getGenerator();
+        PackOutput packOutput = event.getGenerator().getPackOutput();
+        CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+        ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
+
+        EnderDataProvider provider = new EnderDataProvider(getNamespace());
+
+        provider.addSubProvider(event.includeServer(), new EnderBlockStateProvider(packOutput, getNamespace(), existingFileHelper, this));
+        provider.addSubProvider(event.includeServer(), new EnderItemModelProvider(packOutput, getNamespace(), existingFileHelper, this.ItemRegistry));
+        provider.addSubProvider(event.includeServer(), new EnderLangProvider(packOutput,getNamespace(), "en_us", this ));
+        provider.addSubProvider(event.includeServer(), new LootTableProvider(packOutput, Collections.emptySet(),
+            List.of(new LootTableProvider.SubProviderEntry(() -> new EnderBlockLootProvider(Set.of(), this), LootContextParamSets.BLOCK))));
+        generator.addProvider(true, provider);
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredBlock.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredBlock.java
@@ -1,0 +1,99 @@
+package com.enderio.core.common.registry;
+
+import com.enderio.core.data.loot.EnderBlockLootProvider;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+public class EnderDeferredBlock<T extends Block> extends DeferredBlock<T> {
+    private String translation = "";
+    private Set<TagKey<Block>> blockTags = Set.of();
+    @Nullable
+    private BiConsumer<EnderBlockLootProvider, T>  lootTable;
+    @Nullable
+    private BiConsumer<BlockStateProvider, T> blockStateProvider;
+    @Nullable
+    private EnderItemRegistry registry;
+    protected EnderDeferredBlock(ResourceKey<Block> key) {
+        super(key);
+    }
+
+    public EnderDeferredBlock<T> setTranslation(String translation) {
+        this.translation = translation;
+        return this;
+    }
+
+    public String getTranslation() {
+        return translation.isEmpty() ? StringUtils.capitalize(getId().getPath().replace('_', ' ')) : translation;
+    }
+
+    @SafeVarargs
+    public final EnderDeferredBlock<T> addBlockTags(TagKey<Block>... tags) {
+        blockTags = Set.of(tags);
+        return this;
+    }
+
+    public Set<TagKey<Block>> getBlockTags() {
+        return blockTags;
+    }
+
+    public EnderDeferredBlock<T> setLootTable(BiConsumer<EnderBlockLootProvider, T> lootTable) {
+        this.lootTable = lootTable;
+        return this;
+    }
+
+    @Nullable
+    public BiConsumer<EnderBlockLootProvider, T> getLootTable() {
+        return lootTable;
+    }
+
+    public EnderDeferredBlock<T> setBlockStateProvider(BiConsumer<BlockStateProvider, T> blockStateProvider) {
+        this.blockStateProvider = blockStateProvider;
+        return this;
+    }
+
+    @Nullable
+    public BiConsumer<BlockStateProvider, T> getBlockStateProvider() {
+        return blockStateProvider;
+    }
+
+    public void setRegistry(@Nullable EnderItemRegistry registry) {
+        this.registry = registry;
+    }
+
+    public EnderDeferredBlockItem<? extends BlockItem, T> createBlockItem() {
+        EnderDeferredItem<BlockItem> item = registry.registerBlockItem(this);
+        return EnderDeferredBlockItem.create(this, item);
+    }
+
+    public EnderDeferredBlockItem<? extends BlockItem, T> createItem(Supplier<? extends BlockItem> sup) {
+        EnderDeferredItem<BlockItem> item = registry.register(getId().getPath(), sup);
+        return EnderDeferredBlockItem.create(this, item);
+    }
+
+    public static <T extends Block> EnderDeferredBlock<T> createBlock(ResourceLocation key) {
+        return createBlock(ResourceKey.create(Registries.BLOCK, key));
+    }
+
+    /**
+     * Creates a new {@link DeferredHolder} targeting the specified {@link Block}.
+     *
+     * @param <T> The type of the target {@link Block}.
+     * @param key The resource key of the target {@link Block}.
+     */
+    public static <T extends Block> EnderDeferredBlock<T> createBlock(ResourceKey<Block> key) {
+        return new EnderDeferredBlock<>(key);
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredBlock.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredBlock.java
@@ -15,15 +15,15 @@ import org.apache.commons.lang3.StringUtils;
 import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
-public class EnderDeferredBlock<T extends Block> extends DeferredBlock<T> {
-    private String translation = "";
+public class EnderDeferredBlock<T extends Block> extends DeferredBlock<T> implements ITranslatable{
+    private String translation = StringUtils.capitalize(getId().getPath().replace('_', ' '));
     private Set<TagKey<Block>> blockTags = Set.of();
     @Nullable
-    private BiConsumer<EnderBlockLootProvider, T>  lootTable;
+    private BiConsumer<EnderBlockLootProvider, T>  lootTable = EnderBlockLootProvider::dropSelf;
     @Nullable
-    private BiConsumer<BlockStateProvider, T> blockStateProvider;
+    private BiConsumer<BlockStateProvider, T> blockStateProvider = BlockStateProvider::simpleBlock;
     @Nullable
     private EnderItemRegistry registry;
     protected EnderDeferredBlock(ResourceKey<Block> key) {
@@ -35,8 +35,9 @@ public class EnderDeferredBlock<T extends Block> extends DeferredBlock<T> {
         return this;
     }
 
+    @Override
     public String getTranslation() {
-        return translation.isEmpty() ? StringUtils.capitalize(getId().getPath().replace('_', ' ')) : translation;
+        return translation;
     }
 
     @SafeVarargs
@@ -78,8 +79,8 @@ public class EnderDeferredBlock<T extends Block> extends DeferredBlock<T> {
         return EnderDeferredBlockItem.create(this, item);
     }
 
-    public EnderDeferredBlockItem<? extends BlockItem, T> createItem(Supplier<? extends BlockItem> sup) {
-        EnderDeferredItem<BlockItem> item = registry.register(getId().getPath(), sup);
+    public EnderDeferredBlockItem<? extends BlockItem, T> createBlockItem(Function<T, ? extends BlockItem> function) {
+        EnderDeferredItem<? extends BlockItem> item = registry.register(getId().getPath(), () -> function.apply(this.get()));
         return EnderDeferredBlockItem.create(this, item);
     }
 

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredBlockEntity.java
@@ -1,0 +1,38 @@
+package com.enderio.core.common.registry;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import javax.annotation.Nullable;
+
+public class EnderDeferredBlockEntity<T extends BlockEntity> extends DeferredHolder<BlockEntityType<? extends BlockEntity>, BlockEntityType<T>> {
+
+    /**
+     * Creates a new DeferredHolder with a ResourceKey.
+     *
+     * <p>Attempts to bind immediately if possible.
+     *
+     * @param key The resource key of the target object.
+     * @see #create(ResourceKey, ResourceLocation)
+     * @see #create(ResourceLocation, ResourceLocation)
+     * @see #create(ResourceKey)
+     */
+    protected EnderDeferredBlockEntity(ResourceKey<BlockEntityType<? extends BlockEntity>> key) {
+        super(key);
+    }
+
+    public static <T extends BlockEntity> EnderDeferredBlockEntity<T> createBlockEntity(DeferredHolder<BlockEntityType<?>, BlockEntityType<T>> holder)
+    {
+        return new EnderDeferredBlockEntity<>(holder.getKey());
+    }
+
+    @Nullable
+    public T create(BlockPos pos, BlockState state) {
+        return this.get().create(pos, state);
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredBlockItem.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredBlockItem.java
@@ -1,0 +1,53 @@
+package com.enderio.core.common.registry;
+
+import com.enderio.core.data.model.EnderItemModelProvider;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+public class EnderDeferredBlockItem<T extends BlockItem, U extends Block> extends EnderDeferredItem<T>{
+    private EnderDeferredBlock<U> block;
+    protected EnderDeferredBlockItem(ResourceKey<Item> key) {
+        super(key);
+    }
+
+    public static <U extends Block,T extends BlockItem> EnderDeferredBlockItem<T,U> create(EnderDeferredBlock<U> block, EnderDeferredItem<T> item) {
+        EnderDeferredBlockItem<T,U> blockitem = new EnderDeferredBlockItem<>(item.getKey());
+        blockitem.block = block;
+        return blockitem;
+    }
+
+    public EnderDeferredBlock<U> finishBlockItem() {
+        return block;
+    }
+
+    @Override
+    public EnderDeferredBlockItem<T,U> setTab(ResourceKey<CreativeModeTab> tab) {
+        this.tab = tab;
+        return this;
+    }
+
+    @SafeVarargs
+    public final EnderDeferredBlockItem<T,U> addBlockItemTags(TagKey<Item>... tags) {
+        this.ItemTags = Set.of(tags);
+        return this;
+    }
+
+    @Override
+    public EnderDeferredBlockItem<T,U> setTranslation(String translation) {
+        this.translation = translation;
+        return this;
+    }
+
+    @Override
+    public EnderDeferredBlockItem<T,U> setModelProvider(BiConsumer<EnderItemModelProvider, Item> modelProvider) {
+        this.modelProvider = modelProvider;
+        return this;
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredItem.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredItem.java
@@ -14,14 +14,16 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredItem;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
-public class EnderDeferredItem<T extends Item> extends DeferredItem<T> {
-    protected String translation = "";
+public class EnderDeferredItem<T extends Item> extends DeferredItem<T> implements ITranslatable{
+    protected String translation = StringUtils.capitalize(getId().getPath().replace('_', ' '));
     protected Set<TagKey<Item>> ItemTags = Set.of();
     protected ResourceKey<CreativeModeTab> tab;
-    protected BiConsumer<EnderItemModelProvider, Item> modelProvider;
+    @Nullable
+    protected BiConsumer<EnderItemModelProvider, Item> modelProvider = EnderItemModelProvider::basicItem;
 
     protected EnderDeferredItem(ResourceKey<Item> key) {
         super(key);
@@ -33,7 +35,7 @@ public class EnderDeferredItem<T extends Item> extends DeferredItem<T> {
     }
 
     public String getTranslation() {
-        return translation.isEmpty() ? StringUtils.capitalize(getId().getPath().replace('_', ' ')) : translation;
+        return translation;
     }
 
     @SafeVarargs

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredItem.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredItem.java
@@ -1,0 +1,79 @@
+package com.enderio.core.common.registry;
+
+import com.enderio.core.data.model.EnderItemModelProvider;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.models.ModelProvider;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredItem;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+public class EnderDeferredItem<T extends Item> extends DeferredItem<T> {
+    protected String translation = "";
+    protected Set<TagKey<Item>> ItemTags = Set.of();
+    protected ResourceKey<CreativeModeTab> tab;
+    protected BiConsumer<EnderItemModelProvider, Item> modelProvider;
+
+    protected EnderDeferredItem(ResourceKey<Item> key) {
+        super(key);
+    }
+
+    public EnderDeferredItem<T> setTranslation(String translation) {
+        this.translation = translation;
+        return this;
+    }
+
+    public String getTranslation() {
+        return translation.isEmpty() ? StringUtils.capitalize(getId().getPath().replace('_', ' ')) : translation;
+    }
+
+    @SafeVarargs
+    public final EnderDeferredItem<T> addItemTags(TagKey<Item>... tags) {
+        ItemTags = Set.of(tags);
+        return this;
+    }
+
+    public Set<TagKey<Item>> getItemTags() {
+        return ItemTags;
+    }
+    public EnderDeferredItem<T> setTab(ResourceKey<CreativeModeTab> tab) {
+        this.tab = tab;
+        return this;
+    }
+
+    public ResourceKey<CreativeModeTab> getTab() {
+        return tab;
+    }
+
+    public EnderDeferredItem<T> setModelProvider(BiConsumer<EnderItemModelProvider, Item> modelProvider) {
+        this.modelProvider = modelProvider;
+        return this;
+    }
+
+    public BiConsumer<EnderItemModelProvider, Item> getModelProvider() {
+        return modelProvider;
+    }
+
+    public static <T extends Item> EnderDeferredItem<T> createItem(ResourceLocation key) {
+        return createItem(ResourceKey.create(Registries.ITEM, key));
+    }
+
+    /**
+     * Creates a new {@link DeferredHolder} targeting the specified {@link Item}.
+     *
+     * @param <T> The type of the target {@link Item}.
+     * @param key The resource key of the target {@link Item}.
+     */
+    public static <T extends Item> EnderDeferredItem<T> createItem(ResourceKey<Item> key) {
+        return new EnderDeferredItem<>(key);
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredMenu.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredMenu.java
@@ -1,0 +1,38 @@
+package com.enderio.core.common.registry;
+
+import net.minecraft.client.gui.screens.MenuScreens;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.function.Supplier;
+
+public class EnderDeferredMenu<T extends AbstractContainerMenu> extends EnderDeferredObject<MenuType<? extends AbstractContainerMenu>, MenuType<T>> {
+
+    private Supplier<MenuScreens.ScreenConstructor<T, ? extends AbstractContainerScreen<T>>> screenConstructor;
+
+    protected EnderDeferredMenu(ResourceKey<MenuType<? extends AbstractContainerMenu>> key) {
+        super(key);
+    }
+
+    public EnderDeferredMenu<T> setScreenConstructor(Supplier<MenuScreens.ScreenConstructor<T, ? extends AbstractContainerScreen<T>>> screenConstructor) {
+        this.screenConstructor = screenConstructor;
+        return this;
+    }
+
+    public Supplier<MenuScreens.ScreenConstructor<T, ? extends AbstractContainerScreen<T>>> getScreenConstructor() {
+        return screenConstructor;
+    }
+
+    @Override
+    public EnderDeferredMenu<T> setTranslation(String translation) {
+        this.translation = translation;
+        return this;
+    }
+
+    public static <T extends AbstractContainerMenu> EnderDeferredMenu<T> createMenu(EnderDeferredObject<MenuType<?>, MenuType<T>> holder) {
+        return new EnderDeferredMenu<>(holder.getKey());
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderDeferredObject.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderDeferredObject.java
@@ -1,0 +1,23 @@
+package com.enderio.core.common.registry;
+
+import net.minecraft.resources.ResourceKey;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import org.apache.commons.lang3.StringUtils;
+
+public class EnderDeferredObject<R, T extends R> extends DeferredHolder<R, T> implements ITranslatable {
+    protected String translation = StringUtils.capitalize(getId().getPath().replace('_', ' '));
+
+    protected EnderDeferredObject(ResourceKey<R> key) {
+        super(key);
+    }
+
+    @Override
+    public String getTranslation() {
+        return translation;
+    }
+
+    public EnderDeferredObject<R, T> setTranslation(String translation) {
+        this.translation = translation;
+        return this;
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderItemRegistry.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderItemRegistry.java
@@ -1,0 +1,180 @@
+package com.enderio.core.common.registry;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredItem;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class EnderItemRegistry extends DeferredRegister.Items {
+    protected EnderItemRegistry(String namespace) {
+        super(namespace);
+    }
+
+    /**
+     * Adds a new item to the list of entries to be registered and returns a {@link DeferredItem} that will be populated with the created item automatically.
+     *
+     * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param func A factory for the new item. The factory should not cache the created item.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #register(String, Supplier)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <I extends Item> EnderDeferredItem<I> register(String name, Function<ResourceLocation, ? extends I> func) {
+        return (EnderDeferredItem<I>) super.register(name, func);
+    }
+
+    /**
+     * Adds a new item to the list of entries to be registered and returns a {@link DeferredItem} that will be populated with the created item automatically.
+     *
+     * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param sup  A factory for the new item. The factory should not cache the created item.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #register(String, Function)
+     */
+    @Override
+    public <I extends Item> EnderDeferredItem<I> register(String name, Supplier<? extends I> sup) {
+        return this.register(name, key -> sup.get());
+    }
+
+    /**
+     * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+     * returns a {@link DeferredItem} that will be populated with the created item automatically.
+     *
+     * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param block      The supplier for the block to create a {@link BlockItem} for.
+     * @param properties The properties for the created {@link BlockItem}.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerBlockItem(String, Supplier)
+     * @see #registerBlockItem(Holder, Item.Properties)
+     * @see #registerBlockItem(Holder)
+     */
+    public EnderDeferredItem<BlockItem> registerBlockItem(String name, Supplier<? extends Block> block, Item.Properties properties) {
+        return this.register(name, key -> new BlockItem(block.get(), properties));
+    }
+
+    /**
+     * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+     * returns a {@link DeferredItem} that will be populated with the created item automatically.
+     * This method uses the default {@link Item.Properties}.
+     *
+     * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param block The supplier for the block to create a {@link BlockItem} for.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerBlockItem(String, Supplier, Item.Properties)
+     * @see #registerBlockItem(Holder, Item.Properties)
+     * @see #registerBlockItem(Holder)
+     */
+    public EnderDeferredItem<BlockItem> registerBlockItem(String name, Supplier<? extends Block> block) {
+        return this.registerBlockItem(name, block, new Item.Properties());
+    }
+
+    /**
+     * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+     * returns a {@link DeferredItem} that will be populated with the created item automatically.
+     * Where the name is determined by the name of the given block.
+     *
+     * @param block      The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
+     * @param properties The properties for the created {@link BlockItem}.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerBlockItem(String, Supplier, Item.Properties)
+     * @see #registerBlockItem(String, Supplier)
+     * @see #registerBlockItem(Holder)
+     */
+    public EnderDeferredItem<BlockItem> registerBlockItem(Holder<Block> block, Item.Properties properties) {
+        return this.registerBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
+    }
+
+    /**
+     * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+     * returns a {@link DeferredItem} that will be populated with the created item automatically.
+     * Where the name is determined by the name of the given block and uses the default {@link Item.Properties}.
+     *
+     * @param block The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerBlockItem(String, Supplier, Item.Properties)
+     * @see #registerBlockItem(String, Supplier)
+     * @see #registerBlockItem(Holder, Item.Properties)
+     */
+    public EnderDeferredItem<BlockItem> registerBlockItem(Holder<Block> block) {
+        return this.registerBlockItem(block, new Item.Properties());
+    }
+
+    /**
+     * Adds a new item to the list of entries to be registered and returns a {@link DeferredItem} that will be populated with the created item automatically.
+     *
+     * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param func  A factory for the new item. The factory should not cache the created item.
+     * @param props The properties for the created item.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerItem(String, Function)
+     * @see #registerItem(String, Item.Properties)
+     * @see #registerItem(String)
+     */
+    public <I extends Item> EnderDeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Item.Properties props) {
+        return this.register(name, () -> func.apply(props));
+    }
+
+    /**
+     * Adds a new item to the list of entries to be registered and returns a {@link DeferredItem} that will be populated with the created item automatically.
+     * This method uses the default {@link Item.Properties}.
+     *
+     * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param func A factory for the new item. The factory should not cache the created item.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerItem(String, Function, Item.Properties)
+     * @see #registerItem(String, Item.Properties)
+     * @see #registerItem(String)
+     */
+    public <I extends Item> EnderDeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func) {
+        return this.registerItem(name, func, new Item.Properties());
+    }
+
+    /**
+     * Adds a new {@link Item} with the given {@link Item.Properties properties} to the list of entries to be registered and
+     * returns a {@link DeferredItem} that will be populated with the created item automatically.
+     *
+     * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @param props A factory for the new item. The factory should not cache the created item.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerItem(String, Function, Item.Properties)
+     * @see #registerItem(String, Function)
+     * @see #registerItem(String)
+     */
+    public EnderDeferredItem<Item> registerItem(String name, Item.Properties props) {
+        return this.registerItem(name, Item::new, props);
+    }
+
+    /**
+     * Adds a new {@link Item} with the default {@link Item.Properties properties} to the list of entries to be registered and
+     * returns a {@link DeferredItem} that will be populated with the created item automatically.
+     *
+     * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+     * @return A {@link DeferredItem} that will track updates from the registry for this item.
+     * @see #registerItem(String, Function, Item.Properties)
+     * @see #registerItem(String, Function)
+     * @see #registerItem(String, Item.Properties)
+     */
+    public EnderDeferredItem<Item> registerItem(String name) {
+        return this.registerItem(name, Item::new, new Item.Properties());
+    }
+
+    @Override
+    protected <I extends Item> EnderDeferredItem<I> createHolder(ResourceKey<? extends Registry<Item>> registryKey, ResourceLocation key) {
+        return EnderDeferredItem.createItem(ResourceKey.create(registryKey, key));
+    }
+
+    public static EnderItemRegistry createRegistry(String modid) {
+        return new EnderItemRegistry(modid);
+    }
+
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderMenuRegistry.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderMenuRegistry.java
@@ -1,0 +1,30 @@
+package com.enderio.core.common.registry;
+
+import net.minecraft.client.gui.screens.MenuScreens;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.flag.FeatureFlagRegistry;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.neoforged.neoforge.common.extensions.IMenuTypeExtension;
+import net.neoforged.neoforge.network.IContainerFactory;
+
+import java.util.function.Supplier;
+
+public class EnderMenuRegistry extends EnderRegistry<MenuType<?>>{
+
+    protected EnderMenuRegistry(String namespace) {
+        super(BuiltInRegistries.MENU.key(), namespace);
+    }
+
+    public static EnderMenuRegistry create(String modid) {
+        return new EnderMenuRegistry(modid);
+    }
+
+    public <T extends AbstractContainerMenu> EnderDeferredMenu<T> registerMenu(String name, IContainerFactory<T> factory, Supplier<MenuScreens.ScreenConstructor<T, ? extends AbstractContainerScreen<T>>> screenConstructor) {
+        EnderDeferredObject<MenuType<?>, MenuType<T>> holder = this.register(name, () -> IMenuTypeExtension.create(factory));
+        return EnderDeferredMenu.createMenu(holder).setScreenConstructor(screenConstructor);
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/EnderRegistry.java
+++ b/src/core/java/com/enderio/core/common/registry/EnderRegistry.java
@@ -1,0 +1,35 @@
+package com.enderio.core.common.registry;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class EnderRegistry<T> extends DeferredRegister<T> {
+    protected EnderRegistry(ResourceKey<? extends Registry<T>> registryKey, String namespace) {
+        super(registryKey, namespace);
+    }
+
+    @Override
+    public <I extends T> EnderDeferredObject<T, I> register(String name, Supplier<? extends I> sup) {
+        return this.register(name, key -> sup.get());
+    }
+
+    @Override
+    public <I extends T> EnderDeferredObject<T, I> register(String name, Function<ResourceLocation, ? extends I> func) {
+        return (EnderDeferredObject<T, I>) super.register(name, func);
+    }
+
+    public static <T> EnderRegistry<T> createRegistry(Registry<T> registry, String namespace) {
+        return new EnderRegistry<>(registry.key(), namespace);
+    }
+
+    @Override
+    protected <I extends T> DeferredHolder<T, I> createHolder(ResourceKey<? extends Registry<T>> registryKey, ResourceLocation key) {
+        return EnderDeferredObject.create(ResourceKey.create(registryKey, key));
+    }
+}

--- a/src/core/java/com/enderio/core/common/registry/ITranslatable.java
+++ b/src/core/java/com/enderio/core/common/registry/ITranslatable.java
@@ -1,0 +1,5 @@
+package com.enderio.core.common.registry;
+
+public interface ITranslatable {
+    String getTranslation();
+}

--- a/src/core/java/com/enderio/core/common/registry/package-info.java
+++ b/src/core/java/com/enderio/core/common/registry/package-info.java
@@ -1,0 +1,4 @@
+@javax.annotation.ParametersAreNonnullByDefault
+@net.minecraft.MethodsReturnNonnullByDefault
+
+package com.enderio.core.common.registry;

--- a/src/core/java/com/enderio/core/data/EnderDataProvider.java
+++ b/src/core/java/com/enderio/core/data/EnderDataProvider.java
@@ -1,0 +1,37 @@
+package com.enderio.core.data;
+
+import net.minecraft.data.CachedOutput;
+import net.minecraft.data.DataProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class EnderDataProvider implements DataProvider {
+    private final String modid;
+    private final List<DataProvider> subProviders = new ArrayList<>();
+
+    public EnderDataProvider(String modid) {
+        this.modid = modid;
+    }
+
+    public void addSubProvider(boolean include, DataProvider provider) {
+        if (include) {
+            subProviders.add(provider);
+        }
+    }
+
+    @Override
+    public CompletableFuture<?> run(CachedOutput pOutput) {
+        List<CompletableFuture<?>> list = new ArrayList<>();
+        for (DataProvider provider : subProviders) {
+            list.add(provider.run(pOutput));
+        }
+        return CompletableFuture.allOf(list.toArray(CompletableFuture[]::new));
+    }
+
+    @Override
+    public String getName() {
+        return "Ender IO Data (" + modid + ")";
+    }
+}

--- a/src/core/java/com/enderio/core/data/lang/EnderLangProvider.java
+++ b/src/core/java/com/enderio/core/data/lang/EnderLangProvider.java
@@ -1,0 +1,27 @@
+package com.enderio.core.data.lang;
+
+import com.enderio.core.common.registry.EnderBlockRegistry;
+import com.enderio.core.common.registry.EnderDeferredBlock;
+import com.enderio.core.data.loot.EnderBlockLootProvider;
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.common.data.LanguageProvider;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.function.BiConsumer;
+
+public class EnderLangProvider extends LanguageProvider {
+    private final EnderBlockRegistry registry;
+
+    public EnderLangProvider(PackOutput output, String modid, String locale, EnderBlockRegistry registry) {
+        super(output, modid, locale);
+        this.registry = registry;
+    }
+
+    @Override
+    protected void addTranslations() {
+        for (DeferredHolder<Block, ? extends Block> block : registry.getEntries()) {
+            this.add(block.get(), ((EnderDeferredBlock<Block>) block).getTranslation());
+        }
+    }
+}

--- a/src/core/java/com/enderio/core/data/loot/EnderBlockLootProvider.java
+++ b/src/core/java/com/enderio/core/data/loot/EnderBlockLootProvider.java
@@ -1,0 +1,41 @@
+package com.enderio.core.data.loot;
+
+import com.enderio.core.common.registry.EnderBlockRegistry;
+import com.enderio.core.common.registry.EnderDeferredBlock;
+import net.minecraft.data.loot.BlockLootSubProvider;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+public class EnderBlockLootProvider extends BlockLootSubProvider {
+
+    private final EnderBlockRegistry registry;
+
+    public EnderBlockLootProvider(Set<Item> explosionResistant, EnderBlockRegistry registry) {
+        super(explosionResistant, FeatureFlags.REGISTRY.allFlags());
+        this.registry = registry;
+    }
+
+    @Override
+    protected void generate() {
+        for (DeferredHolder<Block, ? extends Block> block : registry.getEntries()) {
+            BiConsumer<EnderBlockLootProvider, Block> lootTable = ((EnderDeferredBlock<Block>) block).getLootTable();
+            if (lootTable != null) {
+                lootTable.accept(this, block.get());
+            }
+        }
+    }
+
+    @Override
+    public void dropSelf(Block block) {
+        super.dropSelf(block);
+    }
+
+    public void createDoor(Block block) {
+        this.add(block, super::createDoorTable);
+    }
+}

--- a/src/core/java/com/enderio/core/data/loot/EnderBlockLootProvider.java
+++ b/src/core/java/com/enderio/core/data/loot/EnderBlockLootProvider.java
@@ -6,6 +6,7 @@ import net.minecraft.data.loot.BlockLootSubProvider;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.storage.loot.LootTable;
 import net.neoforged.neoforge.registries.DeferredHolder;
 
 import java.util.Set;
@@ -37,5 +38,10 @@ public class EnderBlockLootProvider extends BlockLootSubProvider {
 
     public void createDoor(Block block) {
         this.add(block, super::createDoorTable);
+    }
+
+    @Override
+    public void add(Block p_250610_, LootTable.Builder p_249817_) {
+        super.add(p_250610_, p_249817_);
     }
 }

--- a/src/core/java/com/enderio/core/data/model/EIOModel.java
+++ b/src/core/java/com/enderio/core/data/model/EIOModel.java
@@ -1,11 +1,13 @@
 package com.enderio.core.data.model;
 
+import com.enderio.core.common.registry.EnderDeferredItem;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.RegistrateItemModelProvider;
 import com.tterrag.registrate.util.entry.ItemEntry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.item.Item;
@@ -22,12 +24,12 @@ public class EIOModel {
 
     // region Item
 
-    public static ItemModelBuilder fakeBlockModel(DataGenContext<Item, ? extends Item> ctx, RegistrateItemModelProvider prov) {
-        return prov.withExistingParent(prov.name(ctx), prov.mcLoc("block/cube_all")).texture("all", prov.itemTexture(ctx));
+    public static ItemModelBuilder fakeBlockModel(EnderItemModelProvider prov, Item item) {
+        return prov.withExistingParent(BuiltInRegistries.ITEM.getKey(item).getPath(), prov.mcLoc("block/cube_all")).texture("all", prov.itemTexture(item));
     }
 
-    public static ItemModelBuilder mimicItem(DataGenContext<Item, ? extends Item> ctx, ItemEntry<? extends Item> item, RegistrateItemModelProvider prov) {
-        return prov.generated(ctx, prov.itemTexture(item));
+    public static ItemModelBuilder mimicItem(Item item, EnderDeferredItem<? extends Item> from, EnderItemModelProvider prov) {
+        return prov.basicItem(item, prov.itemTexture(from));
     }
 
     // endregion

--- a/src/core/java/com/enderio/core/data/model/EnderBlockStateProvider.java
+++ b/src/core/java/com/enderio/core/data/model/EnderBlockStateProvider.java
@@ -1,0 +1,31 @@
+package com.enderio.core.data.model;
+
+import com.enderio.core.common.registry.EnderBlockRegistry;
+import com.enderio.core.common.registry.EnderDeferredBlock;
+import com.enderio.core.data.loot.EnderBlockLootProvider;
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.function.BiConsumer;
+
+public class EnderBlockStateProvider extends BlockStateProvider {
+    private final EnderBlockRegistry registry;
+
+    public EnderBlockStateProvider(PackOutput output, String modid, ExistingFileHelper exFileHelper, EnderBlockRegistry registry) {
+        super(output, modid, exFileHelper);
+        this.registry = registry;
+    }
+
+    @Override
+    protected void registerStatesAndModels() {
+        for (DeferredHolder<Block, ? extends Block> block : registry.getEntries()) {
+            BiConsumer<BlockStateProvider, Block> blockstate = ((EnderDeferredBlock<Block>) block).getBlockStateProvider();
+            if (blockstate != null) {
+                blockstate.accept(this, block.get());
+            }
+        }
+    }
+}

--- a/src/core/java/com/enderio/core/data/model/EnderItemModelProvider.java
+++ b/src/core/java/com/enderio/core/data/model/EnderItemModelProvider.java
@@ -6,6 +6,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.ItemLike;
 import net.neoforged.neoforge.client.model.generators.ItemModelBuilder;
 import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
 import net.neoforged.neoforge.client.model.generators.ModelFile;
@@ -42,5 +43,17 @@ public class EnderItemModelProvider extends ItemModelProvider {
             .parent(new ModelFile.UncheckedModelFile("item/generated"))
             .texture("layer0", new ResourceLocation(item.getNamespace(), "block/" + item.getPath()));
     }
+
+    public ItemModelBuilder basicItem(Item item, ResourceLocation texture) {
+        return getBuilder(BuiltInRegistries.ITEM.getKey(item).toString())
+            .parent(new ModelFile.UncheckedModelFile("item/generated"))
+            .texture("layer0", new ResourceLocation(texture.getNamespace(), "item/" + texture.getPath()));
+    }
+
+    public ResourceLocation itemTexture(ItemLike item) {
+        return Objects.requireNonNull(BuiltInRegistries.ITEM.getKey(item.asItem()));
+    }
+
+
 }
 

--- a/src/core/java/com/enderio/core/data/model/EnderItemModelProvider.java
+++ b/src/core/java/com/enderio/core/data/model/EnderItemModelProvider.java
@@ -1,0 +1,46 @@
+package com.enderio.core.data.model;
+
+import com.enderio.core.common.registry.EnderDeferredItem;
+import com.enderio.core.common.registry.EnderItemRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.neoforged.neoforge.client.model.generators.ItemModelBuilder;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
+import net.neoforged.neoforge.client.model.generators.ModelFile;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+public class EnderItemModelProvider extends ItemModelProvider {
+    private final EnderItemRegistry registry;
+
+    public EnderItemModelProvider(PackOutput output, String modid, ExistingFileHelper existingFileHelper, EnderItemRegistry itemRegistry) {
+        super(output, modid, existingFileHelper);
+        this.registry = itemRegistry;
+    }
+
+    @Override
+    protected void registerModels() {
+        for (DeferredHolder<Item, ? extends Item> item : registry.getEntries()) {
+            BiConsumer<EnderItemModelProvider, Item> modelProvider = ((EnderDeferredItem<? extends Item>) item).getModelProvider();
+            if (modelProvider != null) {
+                modelProvider.accept(this, item.get());
+            }
+        }
+    }
+
+    public ItemModelBuilder basicBlock(Item item) {
+        return basicBlock(Objects.requireNonNull(BuiltInRegistries.ITEM.getKey(item)));
+    }
+
+    public ItemModelBuilder basicBlock(ResourceLocation item) {
+        return getBuilder(item.toString())
+            .parent(new ModelFile.UncheckedModelFile("item/generated"))
+            .texture("layer0", new ResourceLocation(item.getNamespace(), "block/" + item.getPath()));
+    }
+}
+

--- a/src/main/java/com/enderio/base/common/blockentity/DoublePaintedBlockEntity.java
+++ b/src/main/java/com/enderio/base/common/blockentity/DoublePaintedBlockEntity.java
@@ -1,8 +1,10 @@
 package com.enderio.base.common.blockentity;
 
 import com.enderio.base.EIONBTKeys;
+import com.enderio.base.common.init.EIOBlockEntities;
 import com.enderio.base.common.util.PaintUtils;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -11,7 +13,6 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
-import net.neoforged.neoforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -35,6 +36,10 @@ public class DoublePaintedBlockEntity extends SinglePaintedBlockEntity {
 
     public DoublePaintedBlockEntity(BlockEntityType<?> pType, BlockPos pWorldPosition, BlockState pBlockState) {
         super(pType, pWorldPosition, pBlockState);
+    }
+
+    public DoublePaintedBlockEntity(BlockPos pWorldPosition, BlockState pBlockState) {
+        super(EIOBlockEntities.DOUBLE_PAINTED.get(), pWorldPosition, pBlockState);
     }
 
     @Override
@@ -79,7 +84,7 @@ public class DoublePaintedBlockEntity extends SinglePaintedBlockEntity {
     protected void writePaint(CompoundTag tag) {
         super.writePaint(tag);
         if (paint2 != null) {
-            tag.putString(EIONBTKeys.PAINT_2, Objects.requireNonNull(ForgeRegistries.BLOCKS.getKey(paint2)).toString());
+            tag.putString(EIONBTKeys.PAINT_2, Objects.requireNonNull(BuiltInRegistries.BLOCK.getKey(paint2)).toString());
         }
     }
 }

--- a/src/main/java/com/enderio/base/common/blockentity/EnderSkullBlockEntity.java
+++ b/src/main/java/com/enderio/base/common/blockentity/EnderSkullBlockEntity.java
@@ -12,7 +12,7 @@ import net.neoforged.fml.LogicalSide;
 public class EnderSkullBlockEntity extends BlockEntity {
     private float animationticks = 0;
 
-    public EnderSkullBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
+    public EnderSkullBlockEntity(BlockPos pos, BlockState blockState) {
         super(EIOBlockEntities.ENDER_SKULL.get(), pos, blockState);
     }
 

--- a/src/main/java/com/enderio/base/common/blockentity/LightNodeBlockEntity.java
+++ b/src/main/java/com/enderio/base/common/blockentity/LightNodeBlockEntity.java
@@ -2,6 +2,7 @@ package com.enderio.base.common.blockentity;
 
 import com.enderio.base.EIONBTKeys;
 import com.enderio.base.common.block.light.LightNode;
+import com.enderio.base.common.init.EIOBlockEntities;
 import com.enderio.base.common.network.EIONetwork;
 import com.enderio.base.common.network.ServerToClientLightUpdate;
 import net.minecraft.core.BlockPos;
@@ -24,6 +25,10 @@ public class LightNodeBlockEntity extends BlockEntity {
 	public LightNodeBlockEntity(BlockEntityType<?> type, BlockPos worldPosition, BlockState blockState) {
 		super(type, worldPosition, blockState);
 	}
+
+    public LightNodeBlockEntity(BlockPos worldPosition, BlockState blockState) {
+        super(EIOBlockEntities.LIGHT_NODE.get(), worldPosition, blockState);
+    }
 	
 	public void setMaster(PoweredLightBlockEntity master) {
 		this.masterpos = master.getBlockPos();
@@ -31,7 +36,7 @@ public class LightNodeBlockEntity extends BlockEntity {
 	}
 	
 	/**
-	 * called in {@link LightNode.neighborChanged} when a neighbor changes serverside.
+	 * called in { LightNode.neighborChanged} when a neighbor changes serverside.
 	 * Checks if the this block still has a {@code PoweredLight}, if not it removes itself.
 	 * Checks if the {@code PoweredLight} is still active, if not it removes itself.
 	 * If the block changed inside the range, call the {@code PoweredLightBlockEntity} to update. //TODO make smarter? 

--- a/src/main/java/com/enderio/base/common/blockentity/PoweredLightBlockEntity.java
+++ b/src/main/java/com/enderio/base/common/blockentity/PoweredLightBlockEntity.java
@@ -3,6 +3,7 @@ package com.enderio.base.common.blockentity;
 import com.enderio.base.EIONBTKeys;
 import com.enderio.base.common.block.light.Light;
 import com.enderio.base.common.block.light.PoweredLight;
+import com.enderio.base.common.init.EIOBlockEntities;
 import com.enderio.base.common.init.EIOBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -16,7 +17,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.neoforge.common.capabilities.ForgeCapabilities;
+import net.neoforged.neoforge.common.capabilities.Capabilities;
 import net.neoforged.neoforge.common.util.LazyOptional;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 
@@ -33,6 +34,10 @@ public class PoweredLightBlockEntity extends BlockEntity{
 	public PoweredLightBlockEntity(BlockEntityType<?> type, BlockPos worldPosition, BlockState blockState) {
 		super(type, worldPosition, blockState);
 	}
+
+    public PoweredLightBlockEntity(BlockPos worldPosition, BlockState blockState) {
+        super(EIOBlockEntities.POWERED_LIGHT.get(), worldPosition, blockState);
+    }
 	
 	public static void tick(Level level, BlockPos pos, BlockState state, PoweredLightBlockEntity e) {
 		if(((PoweredLight) state.getBlock()).isWireless()){ //check if wireless
@@ -155,7 +160,7 @@ public class PoweredLightBlockEntity extends BlockEntity{
 	private static void consumePower(Level level, BlockPos pos, BlockState state, PoweredLightBlockEntity e) {
 		BlockEntity be = level.getBlockEntity(pos.relative(state.getValue(Light.FACING).getOpposite()));
 		if (be != null) {
-			LazyOptional<IEnergyStorage> energy = be.getCapability(ForgeCapabilities.ENERGY, state.getValue(Light.FACING));
+			LazyOptional<IEnergyStorage> energy = be.getCapability(Capabilities.ENERGY, state.getValue(Light.FACING));
 			if (energy.isPresent()) {
 				if (energy.resolve().get().extractEnergy(RF_USE_TICK, true) == RF_USE_TICK) {
 					boolean powered = level.hasNeighborSignal(pos);

--- a/src/main/java/com/enderio/base/common/blockentity/SinglePaintedBlockEntity.java
+++ b/src/main/java/com/enderio/base/common/blockentity/SinglePaintedBlockEntity.java
@@ -1,8 +1,10 @@
 package com.enderio.base.common.blockentity;
 
 import com.enderio.base.EIONBTKeys;
+import com.enderio.base.common.init.EIOBlockEntities;
 import com.enderio.base.common.util.PaintUtils;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -12,7 +14,6 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
-import net.neoforged.neoforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -31,6 +32,10 @@ public class SinglePaintedBlockEntity extends BlockEntity implements IPaintableB
 
     public SinglePaintedBlockEntity(BlockEntityType<?> pType, BlockPos pWorldPosition, BlockState pBlockState) {
         super(pType, pWorldPosition, pBlockState);
+    }
+
+    public SinglePaintedBlockEntity(BlockPos pWorldPosition, BlockState pBlockState) {
+        super(EIOBlockEntities.SINGLE_PAINTED.get(), pWorldPosition, pBlockState);
     }
 
     @Override
@@ -96,7 +101,7 @@ public class SinglePaintedBlockEntity extends BlockEntity implements IPaintableB
 
     protected void writePaint(CompoundTag tag) {
         if (paint != null) {
-            tag.putString(EIONBTKeys.PAINT, Objects.requireNonNull(ForgeRegistries.BLOCKS.getKey(paint)).toString());
+            tag.putString(EIONBTKeys.PAINT, Objects.requireNonNull(BuiltInRegistries.BLOCK.getKey(paint)).toString());
         }
     }
 }

--- a/src/main/java/com/enderio/base/common/entity/PaintedSandEntity.java
+++ b/src/main/java/com/enderio/base/common/entity/PaintedSandEntity.java
@@ -3,6 +3,7 @@ package com.enderio.base.common.entity;
 import com.enderio.base.EIONBTKeys;
 import com.enderio.base.common.init.EIOEntities;
 import com.enderio.base.common.util.PaintUtils;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
@@ -18,7 +19,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.entity.IEntityAdditionalSpawnData;
 import net.neoforged.neoforge.network.NetworkHooks;
-import net.neoforged.neoforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -56,19 +56,19 @@ public class PaintedSandEntity extends FallingBlockEntity implements IEntityAddi
             blockData = new CompoundTag();
         }
 
-        blockData.putString(EIONBTKeys.PAINT, Objects.requireNonNull(ForgeRegistries.BLOCKS.getKey(block)).toString());
+        blockData.putString(EIONBTKeys.PAINT, Objects.requireNonNull(BuiltInRegistries.BLOCK.getKey(block)).toString());
     }
 
     @Override
     public void writeSpawnData(FriendlyByteBuf buffer) {
         Block block = getPaint();
-        buffer.writeResourceLocation(block != null ? Objects.requireNonNull(ForgeRegistries.BLOCKS.getKey(block)) : new ResourceLocation(""));
+        buffer.writeResourceLocation(block != null ? Objects.requireNonNull(BuiltInRegistries.BLOCK.getKey(block)) : new ResourceLocation(""));
     }
 
     @Override
     public void readSpawnData(FriendlyByteBuf additionalData) {
         ResourceLocation rl = additionalData.readResourceLocation();
-        Block block = ForgeRegistries.BLOCKS.getValue(rl);
+        Block block = BuiltInRegistries.BLOCK.get(rl);
         if (block != null && block != Blocks.AIR) {
             setPaint(block);
         }

--- a/src/main/java/com/enderio/base/common/init/EIOBlockEntities.java
+++ b/src/main/java/com/enderio/base/common/init/EIOBlockEntities.java
@@ -6,16 +6,15 @@ import com.enderio.base.common.blockentity.EnderSkullBlockEntity;
 import com.enderio.base.common.blockentity.LightNodeBlockEntity;
 import com.enderio.base.common.blockentity.PoweredLightBlockEntity;
 import com.enderio.base.common.blockentity.SinglePaintedBlockEntity;
-import com.tterrag.registrate.Registrate;
-import com.tterrag.registrate.util.entry.BlockEntityEntry;
+import com.enderio.core.common.registry.EnderBlockEntityRegistry;
+import com.enderio.core.common.registry.EnderDeferredBlockEntity;
+import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
 
 public class EIOBlockEntities {
-    private static final Registrate REGISTRATE = EnderIO.registrate();
+    private static final EnderBlockEntityRegistry BLOCK_ENTITIES = EnderBlockEntityRegistry.create(EnderIO.MODID);
 
-    public static final BlockEntityEntry<SinglePaintedBlockEntity> SINGLE_PAINTED = REGISTRATE
-        .blockEntity("single_painted", SinglePaintedBlockEntity::new)
-        .validBlocks(
-            EIOBlocks.PAINTED_FENCE,
+    public static final EnderDeferredBlockEntity<SinglePaintedBlockEntity> SINGLE_PAINTED = BLOCK_ENTITIES
+        .registerBlockEntity("single_painted", SinglePaintedBlockEntity::new, EIOBlocks.PAINTED_FENCE,
             EIOBlocks.PAINTED_FENCE_GATE,
             EIOBlocks.PAINTED_SAND,
             EIOBlocks.PAINTED_STAIRS,
@@ -23,28 +22,24 @@ public class EIOBlockEntities {
             EIOBlocks.PAINTED_REDSTONE_BLOCK,
             EIOBlocks.PAINTED_TRAPDOOR,
             EIOBlocks.PAINTED_WOODEN_PRESSURE_PLATE,
-            EIOBlocks.PAINTED_GLOWSTONE
-        )
-        .register();
+            EIOBlocks.PAINTED_GLOWSTONE);
 
-    public static final BlockEntityEntry<DoublePaintedBlockEntity> DOUBLE_PAINTED = REGISTRATE
-        .blockEntity("double_painted", DoublePaintedBlockEntity::new)
-        .validBlocks(EIOBlocks.PAINTED_SLAB)
-        .register();
+    public static final EnderDeferredBlockEntity<DoublePaintedBlockEntity> DOUBLE_PAINTED = BLOCK_ENTITIES
+        .registerBlockEntity("double_painted", DoublePaintedBlockEntity::new, EIOBlocks.PAINTED_SLAB);
 
-    public static final BlockEntityEntry<PoweredLightBlockEntity> POWERED_LIGHT = REGISTRATE
-        .blockEntity("powered_light", PoweredLightBlockEntity::new)
-        .validBlocks(EIOBlocks.POWERED_LIGHT, EIOBlocks.POWERED_LIGHT_INVERTED, EIOBlocks.POWERED_LIGHT_WIRELESS, EIOBlocks.POWERED_LIGHT_INVERTED_WIRELESS)
-        .register();
+    public static final EnderDeferredBlockEntity<PoweredLightBlockEntity> POWERED_LIGHT = BLOCK_ENTITIES
+        .registerBlockEntity("powered_light", PoweredLightBlockEntity::new, EIOBlocks.POWERED_LIGHT,
+            EIOBlocks.POWERED_LIGHT_INVERTED,
+            EIOBlocks.POWERED_LIGHT_WIRELESS,
+            EIOBlocks.POWERED_LIGHT_INVERTED_WIRELESS);
 
-    public static final BlockEntityEntry<LightNodeBlockEntity> LIGHT_NODE = REGISTRATE
-        .blockEntity("light_node", LightNodeBlockEntity::new)
-        .validBlock(EIOBlocks.LIGHT_NODE)
-        .register();
+    public static final EnderDeferredBlockEntity<LightNodeBlockEntity> LIGHT_NODE = BLOCK_ENTITIES
+        .registerBlockEntity("light_node", LightNodeBlockEntity::new, EIOBlocks.LIGHT_NODE);
 
-    public static final BlockEntityEntry<EnderSkullBlockEntity> ENDER_SKULL = REGISTRATE
-        .blockEntity("ender_skull", EnderSkullBlockEntity::new)
-        .validBlocks(EIOBlocks.WALL_ENDERMAN_HEAD, EIOBlocks.ENDERMAN_HEAD)
-        .register();
-    public static void register() {}
+    public static final EnderDeferredBlockEntity<EnderSkullBlockEntity> ENDER_SKULL = BLOCK_ENTITIES
+        .registerBlockEntity("ender_skull", EnderSkullBlockEntity::new, EIOBlocks.WALL_ENDERMAN_HEAD,
+            EIOBlocks.ENDERMAN_HEAD);
+    public static void register() {
+        BLOCK_ENTITIES.register(FMLJavaModLoadingContext.get().getModEventBus());
+    }
 }

--- a/src/main/java/com/enderio/base/common/init/EIOBlocks.java
+++ b/src/main/java/com/enderio/base/common/init/EIOBlocks.java
@@ -35,6 +35,11 @@ import com.enderio.base.common.item.misc.EnderSkullBlockItem;
 import com.enderio.base.common.tag.EIOTags;
 import com.enderio.base.data.loot.DecorLootTable;
 import com.enderio.base.data.model.block.EIOBlockState;
+import com.enderio.core.common.registry.EnderBlockRegistry;
+import com.enderio.core.common.registry.EnderDeferredBlock;
+import com.enderio.core.common.registry.EnderItemRegistry;
+import com.enderio.core.data.loot.EnderBlockLootProvider;
+import com.enderio.core.data.model.EnderItemModelProvider;
 import com.tterrag.registrate.Registrate;
 import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.util.entry.BlockEntry;
@@ -42,6 +47,7 @@ import com.tterrag.registrate.util.nullness.NonNullBiFunction;
 import com.tterrag.registrate.util.nullness.NonNullFunction;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
@@ -64,9 +70,12 @@ import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
 import net.neoforged.neoforge.client.model.generators.BlockModelProvider;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
 import net.neoforged.neoforge.client.model.generators.ConfiguredModel;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
 import net.neoforged.neoforge.client.model.generators.ModelFile;
 import net.neoforged.neoforge.client.model.generators.VariantBlockStateBuilder;
+import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
@@ -83,39 +92,42 @@ import static com.tterrag.registrate.util.nullness.NonNullBiConsumer.noop;
 public class EIOBlocks {
     private static final Registrate REGISTRATE = EnderIO.registrate();
 
+    public static final EnderBlockRegistry BLOCKS = EnderBlockRegistry.createRegistry(EnderIO.MODID);
+    public static final EnderItemRegistry ITEMS = BLOCKS.getItemRegistry();
+
     // region Alloy Blocks
 
-    public static final BlockEntry<Block> COPPER_ALLOY_BLOCK = metalBlock("copper_alloy_block", EIOTags.Blocks.BLOCKS_COPPER_ALLOY,
-        EIOTags.Items.BLOCKS_COPPER_ALLOY).register();
-    public static final BlockEntry<Block> ENERGETIC_ALLOY_BLOCK = metalBlock("energetic_alloy_block", EIOTags.Blocks.BLOCKS_ENERGETIC_ALLOY,
-        EIOTags.Items.BLOCKS_ENERGETIC_ALLOY).register();
-    public static final BlockEntry<Block> VIBRANT_ALLOY_BLOCK = metalBlock("vibrant_alloy_block", EIOTags.Blocks.BLOCKS_VIBRANT_ALLOY,
-        EIOTags.Items.BLOCKS_VIBRANT_ALLOY).register();
-    public static final BlockEntry<Block> REDSTONE_ALLOY_BLOCK = metalBlock("redstone_alloy_block", EIOTags.Blocks.BLOCKS_REDSTONE_ALLOY,
-        EIOTags.Items.BLOCKS_REDSTONE_ALLOY).register();
-    public static final BlockEntry<Block> CONDUCTIVE_ALLOY_BLOCK = metalBlock("conductive_alloy_block", EIOTags.Blocks.BLOCKS_CONDUCTIVE_ALLOY,
-        EIOTags.Items.BLOCKS_CONDUCTIVE_ALLOY).register();
-    public static final BlockEntry<Block> PULSATING_ALLOY_BLOCK = metalBlock("pulsating_alloy_block", EIOTags.Blocks.BLOCKS_PULSATING_ALLOY,
-        EIOTags.Items.BLOCKS_PULSATING_ALLOY).register();
-    public static final BlockEntry<Block> DARK_STEEL_BLOCK = metalBlock("dark_steel_block", EIOTags.Blocks.BLOCKS_DARK_STEEL,
-        EIOTags.Items.BLOCKS_DARK_STEEL).register();
-    public static final BlockEntry<Block> SOULARIUM_BLOCK = metalBlock("soularium_block", EIOTags.Blocks.BLOCKS_SOULARIUM,
-        EIOTags.Items.BLOCKS_SOULARIUM).register();
-    public static final BlockEntry<Block> END_STEEL_BLOCK = metalBlock("end_steel_block", EIOTags.Blocks.BLOCKS_END_STEEL,
-        EIOTags.Items.BLOCKS_END_STEEL).register();
+    public static final EnderDeferredBlock<? extends Block> COPPER_ALLOY_BLOCK = metalBlock("copper_alloy_block", EIOTags.Blocks.BLOCKS_COPPER_ALLOY,
+        EIOTags.Items.BLOCKS_COPPER_ALLOY);
+    public static final EnderDeferredBlock<? extends Block> ENERGETIC_ALLOY_BLOCK = metalBlock("energetic_alloy_block", EIOTags.Blocks.BLOCKS_ENERGETIC_ALLOY,
+        EIOTags.Items.BLOCKS_ENERGETIC_ALLOY);
+    public static final EnderDeferredBlock<? extends Block> VIBRANT_ALLOY_BLOCK = metalBlock("vibrant_alloy_block", EIOTags.Blocks.BLOCKS_VIBRANT_ALLOY,
+        EIOTags.Items.BLOCKS_VIBRANT_ALLOY);
+    public static final EnderDeferredBlock<? extends Block> REDSTONE_ALLOY_BLOCK = metalBlock("redstone_alloy_block", EIOTags.Blocks.BLOCKS_REDSTONE_ALLOY,
+        EIOTags.Items.BLOCKS_REDSTONE_ALLOY);
+    public static final EnderDeferredBlock<? extends Block> CONDUCTIVE_ALLOY_BLOCK = metalBlock("conductive_alloy_block", EIOTags.Blocks.BLOCKS_CONDUCTIVE_ALLOY,
+        EIOTags.Items.BLOCKS_CONDUCTIVE_ALLOY);
+    public static final EnderDeferredBlock<? extends Block> PULSATING_ALLOY_BLOCK = metalBlock("pulsating_alloy_block", EIOTags.Blocks.BLOCKS_PULSATING_ALLOY,
+        EIOTags.Items.BLOCKS_PULSATING_ALLOY);
+    public static final EnderDeferredBlock<? extends Block> DARK_STEEL_BLOCK = metalBlock("dark_steel_block", EIOTags.Blocks.BLOCKS_DARK_STEEL,
+        EIOTags.Items.BLOCKS_DARK_STEEL);
+    public static final EnderDeferredBlock<? extends Block> SOULARIUM_BLOCK = metalBlock("soularium_block", EIOTags.Blocks.BLOCKS_SOULARIUM,
+        EIOTags.Items.BLOCKS_SOULARIUM);
+    public static final EnderDeferredBlock<? extends Block> END_STEEL_BLOCK = metalBlock("end_steel_block", EIOTags.Blocks.BLOCKS_END_STEEL,
+        EIOTags.Items.BLOCKS_END_STEEL);
 
     // endregion
 
     // region Chassis
 
     // Iron tier
-    public static final BlockEntry<Block> VOID_CHASSIS = chassisBlock("void_chassis").register();
+    public static final EnderDeferredBlock<? extends Block> VOID_CHASSIS = chassisBlock("void_chassis");
 
     // Void chassis + some kind of dragons breath derrived process
     //    public static final BlockEntry<Block> REKINDLED_VOID_CHASSIS = chassisBlock("rekindled_void_chassis").register();
 
     // Soularium + soul/nether
-    public static final BlockEntry<Block> ENSOULED_CHASSIS = chassisBlock("ensouled_chassis").register();
+    public static final EnderDeferredBlock<? extends Block> ENSOULED_CHASSIS = chassisBlock("ensouled_chassis");
 
     // Ensnared + Some kind of other material
     // This is for machines that require a bound soul
@@ -130,86 +142,69 @@ public class EIOBlocks {
 
     // region Dark Steel Building Blocks
 
-    public static final BlockEntry<DarkSteelLadderBlock> DARK_STEEL_LADDER = REGISTRATE
-        .block("dark_steel_ladder", DarkSteelLadderBlock::new)
-        .properties(props -> props.strength(0.4f).requiresCorrectToolForDrops().sound(SoundType.METAL).mapColor(MapColor.METAL).noOcclusion())
-        .blockstate((ctx, prov) -> prov.horizontalBlock(ctx.get(), prov
+    public static final EnderDeferredBlock<DarkSteelLadderBlock> DARK_STEEL_LADDER = BLOCKS
+        .register("dark_steel_ladder", () -> new DarkSteelLadderBlock(BlockBehaviour.Properties.of().strength(0.4f).requiresCorrectToolForDrops().sound(SoundType.METAL).mapColor(MapColor.METAL).noOcclusion()))
+        .setBlockStateProvider((blockStateProvider, block) -> blockStateProvider.horizontalBlock(block, blockStateProvider
             .models()
-            .withExistingParent(ctx.getName(), prov.mcLoc("block/ladder"))
-            .renderType(prov.mcLoc("cutout_mipped"))
-            .texture("particle", prov.blockTexture(ctx.get()))
-            .texture("texture", prov.blockTexture(ctx.get()))))
-        .tag(BlockTags.CLIMBABLE, BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
-        .item()
-        .model((ctx, prov) -> prov.generated(ctx, prov.modLoc("block/dark_steel_ladder")))
-        .tab(EIOCreativeTabs.BLOCKS)
-        .build()
-        .register();
+            .withExistingParent("dark_steel_ladder", blockStateProvider.mcLoc("block/ladder"))
+            .renderType(blockStateProvider.mcLoc("cutout_mipped"))
+            .texture("particle", blockStateProvider.blockTexture(block))
+            .texture("texture", blockStateProvider.blockTexture(block))))
+        .addBlockTags(BlockTags.CLIMBABLE, BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
+        .setLootTable(EnderBlockLootProvider::dropSelf)
+        .createBlockItem()
+        .setModelProvider(EnderItemModelProvider::basicBlock)
+        .setTab(EIOCreativeTabs.BLOCKS)
+        .finishBlockItem();
 
-    public static final BlockEntry<IronBarsBlock> DARK_STEEL_BARS = REGISTRATE
-        .block("dark_steel_bars", IronBarsBlock::new)
-        .properties(props -> props.strength(5.0f, 1000.0f).requiresCorrectToolForDrops().sound(SoundType.METAL).noOcclusion())
-        .blockstate(EIOBlockState::paneBlock)
-        .tag(BlockTags.NEEDS_IRON_TOOL)
-        .tag(BlockTags.MINEABLE_WITH_PICKAXE)
-        .item()
-        .tab(EIOCreativeTabs.BLOCKS)
-        .model((ctx, prov) -> prov.generated(ctx, prov.modLoc("block/dark_steel_bars")))
-        .build()
-        .register();
+    public static final EnderDeferredBlock<IronBarsBlock> DARK_STEEL_BARS = BLOCKS
+        .register("dark_steel_bars", () -> new IronBarsBlock(BlockBehaviour.Properties.of().strength(5.0f, 1000.0f).requiresCorrectToolForDrops().sound(SoundType.METAL).noOcclusion()))
+        .setBlockStateProvider((blockStateProvider, block) -> EIOBlockState.paneBlock(block, blockStateProvider, "dark_steel_bars"))
+        .addBlockTags(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
+        .setLootTable(EnderBlockLootProvider::dropSelf)
+        .createBlockItem()
+        .setTab(EIOCreativeTabs.BLOCKS)
+        .setModelProvider(EnderItemModelProvider::basicBlock)
+        .finishBlockItem();
 
-    public static final BlockEntry<DoorBlock> DARK_STEEL_DOOR = REGISTRATE
-        .block("dark_steel_door", props -> new DoorBlock(props, BlockSetType.IRON))
-        .properties(props -> props.strength(5.0f, 2000.0f).sound(SoundType.METAL).mapColor(MapColor.METAL).noOcclusion())
-        .loot((registrateBlockLootTables, doorBlock) -> registrateBlockLootTables.add(doorBlock, registrateBlockLootTables.createDoorTable(doorBlock)))
-        .blockstate(
-            (ctx, prov) -> prov.doorBlockWithRenderType(ctx.get(), prov.modLoc("block/dark_steel_door_bottom"), prov.modLoc("block/dark_steel_door_top"),
-                prov.mcLoc("cutout")))
-        .tag(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.NEEDS_IRON_TOOL, BlockTags.DOORS)
-        .item()
-        .model((ctx, prov) -> prov.generated(ctx))
-        .tab(EIOCreativeTabs.BLOCKS)
-        .build()
-        .register();
+    public static final EnderDeferredBlock<DoorBlock> DARK_STEEL_DOOR = BLOCKS
+        .register("dark_steel_door", () -> new DoorBlock(BlockBehaviour.Properties.of().strength(5.0f, 2000.0f).sound(SoundType.METAL).mapColor(MapColor.METAL).noOcclusion(), BlockSetType.IRON))
+        .setLootTable(EnderBlockLootProvider::createDoor)
+        .setBlockStateProvider((blockStateProvider, doorBlock) -> blockStateProvider.doorBlockWithRenderType(doorBlock, blockStateProvider.mcLoc("block/dark_steel_door_bottom"), blockStateProvider.mcLoc("block/dark_steel_door_top"), blockStateProvider.mcLoc("cutout")))
+        .addBlockTags(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.NEEDS_IRON_TOOL, BlockTags.DOORS)
+        .createBlockItem()
+        .setModelProvider(ItemModelProvider::basicItem)
+        .setTab(EIOCreativeTabs.BLOCKS)
+        .finishBlockItem();
 
-    public static final BlockEntry<TrapDoorBlock> DARK_STEEL_TRAPDOOR = REGISTRATE
-        .block("dark_steel_trapdoor", props -> new TrapDoorBlock(props, BlockSetType.IRON))
-        .properties(props -> props.strength(5.0f, 2000.0f).sound(SoundType.METAL).mapColor(MapColor.METAL).noOcclusion())
-        .blockstate((ctx, prov) -> prov.trapdoorBlockWithRenderType(ctx.get(), prov.modLoc("block/dark_steel_trapdoor"), true, prov.mcLoc("cutout")))
-        .tag(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.NEEDS_IRON_TOOL, BlockTags.TRAPDOORS)
-        .item()
-        .model((ctx, prov) -> prov.withExistingParent(ctx.getName(), prov.modLoc("block/dark_steel_trapdoor_bottom")))
-        .tab(EIOCreativeTabs.BLOCKS)
-        .build()
-        .register();
+    public static final EnderDeferredBlock<TrapDoorBlock> DARK_STEEL_TRAPDOOR = BLOCKS
+        .register("dark_steel_trapdoor", () -> new TrapDoorBlock(BlockBehaviour.Properties.of().strength(5.0f, 2000.0f).sound(SoundType.METAL).mapColor(MapColor.METAL).noOcclusion(), BlockSetType.IRON))
+        .addBlockTags(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.NEEDS_IRON_TOOL, BlockTags.TRAPDOORS)
+        .setBlockStateProvider((blockStateProvider, trapDoorBlock) -> blockStateProvider.trapdoorBlockWithRenderType(trapDoorBlock, blockStateProvider.mcLoc("block/dark_steel_trapdoor"), true, blockStateProvider.mcLoc("cutout")))
+        .setLootTable(EnderBlockLootProvider::dropSelf)
+        .createBlockItem()
+        .setModelProvider((enderItemModelProvider, item) -> enderItemModelProvider.withExistingParent("dark_steel_trapdoor", enderItemModelProvider.modLoc("block/dark_steel_trapdoor_bottom")))
+        .setTab(EIOCreativeTabs.BLOCKS)
+        .finishBlockItem();
 
-    public static final BlockEntry<IronBarsBlock> END_STEEL_BARS = REGISTRATE
-        .block("end_steel_bars", IronBarsBlock::new)
-        .blockstate(EIOBlockState::paneBlock)
-        .properties(props -> props.strength(5.0f, 1000.0f).requiresCorrectToolForDrops().sound(SoundType.METAL).noOcclusion())
-        .tag(BlockTags.NEEDS_IRON_TOOL)
-        .tag(BlockTags.MINEABLE_WITH_PICKAXE)
-        .item()
-        .tab(EIOCreativeTabs.BLOCKS)
-        .model((ctx, prov) -> prov.generated(ctx, prov.modLoc("block/end_steel_bars")))
-        .build()
-        .register();
+    public static final EnderDeferredBlock<IronBarsBlock> END_STEEL_BARS = BLOCKS
+        .register("end_steel_bars", () -> new IronBarsBlock(BlockBehaviour.Properties.of().strength(5.0f, 1000.0f).requiresCorrectToolForDrops().sound(SoundType.METAL).noOcclusion()))
+        .addBlockTags(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
+        .setLootTable(EnderBlockLootProvider::dropSelf)
+        .setBlockStateProvider(EIOBlockState::paneBlock)
+        .createBlockItem()
+        .setModelProvider(EnderItemModelProvider::basicBlock)
+        .setTab(EIOCreativeTabs.BLOCKS)
+        .finishBlockItem();
 
-    public static final BlockEntry<ReinforcedObsidianBlock> REINFORCED_OBSIDIAN = REGISTRATE
-        .block("reinforced_obsidian_block", ReinforcedObsidianBlock::new)
-        .properties(props -> props
-            .sound(SoundType.STONE)
-            .strength(50, 2000)
-            .requiresCorrectToolForDrops()
-            .mapColor(MapColor.COLOR_BLACK)
-            .instrument(NoteBlockInstrument.BASEDRUM))
-        .tag(BlockTags.WITHER_IMMUNE)
-        .tag(BlockTags.NEEDS_DIAMOND_TOOL)
-        .tag(BlockTags.MINEABLE_WITH_PICKAXE)
-        .item()
-        .tab(EIOCreativeTabs.BLOCKS)
-        .build()
-        .register();
+    public static final EnderDeferredBlock<ReinforcedObsidianBlock> REINFORCED_OBSIDIAN = BLOCKS
+        .register("reinforced_obsidian_block", () -> new ReinforcedObsidianBlock(BlockBehaviour.Properties.of().sound(SoundType.STONE).strength(50, 2000).requiresCorrectToolForDrops().mapColor(MapColor.COLOR_BLACK).instrument(NoteBlockInstrument.BASEDRUM)))
+        .addBlockTags(BlockTags.WITHER_IMMUNE, BlockTags.NEEDS_DIAMOND_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
+        .setLootTable(EnderBlockLootProvider::dropSelf)
+        .setBlockStateProvider(BlockStateProvider::simpleBlock)
+        .createBlockItem()
+        .setTab(EIOCreativeTabs.BLOCKS)
+        .finishBlockItem();
 
     // endregion
 
@@ -280,46 +275,46 @@ public class EIOBlocks {
 
     // region Pressure Plates
 
-    public static final BlockEntry<EIOPressurePlateBlock> DARK_STEEL_PRESSURE_PLATE = pressurePlateBlock("dark_steel_pressure_plate",
+    public static final DeferredBlock<EIOPressurePlateBlock> DARK_STEEL_PRESSURE_PLATE = pressurePlateBlock("dark_steel_pressure_plate",
         EnderIO.loc("block/dark_steel_pressure_plate"), EIOPressurePlateBlock.PLAYER, false);
 
-    public static final BlockEntry<EIOPressurePlateBlock> SILENT_DARK_STEEL_PRESSURE_PLATE = pressurePlateBlock("silent_dark_steel_pressure_plate",
+    public static final DeferredBlock<EIOPressurePlateBlock> SILENT_DARK_STEEL_PRESSURE_PLATE = pressurePlateBlock("silent_dark_steel_pressure_plate",
         EnderIO.loc("block/dark_steel_pressure_plate"), EIOPressurePlateBlock.PLAYER, true);
 
-    public static final BlockEntry<EIOPressurePlateBlock> SOULARIUM_PRESSURE_PLATE = pressurePlateBlock("soularium_pressure_plate",
+    public static final DeferredBlock<EIOPressurePlateBlock> SOULARIUM_PRESSURE_PLATE = pressurePlateBlock("soularium_pressure_plate",
         EnderIO.loc("block/soularium_pressure_plate"), EIOPressurePlateBlock.HOSTILE_MOB, false);
 
-    public static final BlockEntry<EIOPressurePlateBlock> SILENT_SOULARIUM_PRESSURE_PLATE = pressurePlateBlock("silent_soularium_pressure_plate",
+    public static final DeferredBlock<EIOPressurePlateBlock> SILENT_SOULARIUM_PRESSURE_PLATE = pressurePlateBlock("silent_soularium_pressure_plate",
         EnderIO.loc("block/soularium_pressure_plate"), EIOPressurePlateBlock.HOSTILE_MOB, true);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_OAK_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_OAK_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.OAK_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_ACACIA_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_ACACIA_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.ACACIA_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_DARK_OAK_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_DARK_OAK_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.DARK_OAK_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_SPRUCE_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_SPRUCE_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.SPRUCE_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_BIRCH_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_BIRCH_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.BIRCH_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_JUNGLE_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_JUNGLE_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.JUNGLE_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_CRIMSON_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_CRIMSON_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.CRIMSON_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_WARPED_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_WARPED_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.WARPED_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_STONE_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_STONE_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.STONE_PRESSURE_PLATE);
 
-    public static final BlockEntry<SilentPressurePlateBlock> SILENT_POLISHED_BLACKSTONE_PRESSURE_PLATE = silentPressurePlateBlock(
+    public static final DeferredBlock<SilentPressurePlateBlock> SILENT_POLISHED_BLACKSTONE_PRESSURE_PLATE = silentPressurePlateBlock(
         (PressurePlateBlock) Blocks.POLISHED_BLACKSTONE_PRESSURE_PLATE);
 
     public static final BlockEntry<SilentWeightedPressurePlateBlock> SILENT_HEAVY_WEIGHTED_PRESSURE_PLATE = silentWeightedPressurePlateBlock(
@@ -426,72 +421,61 @@ public class EIOBlocks {
         return REGISTRATE.block(name, p -> block).item().tab(EIOCreativeTabs.BLOCKS).build();
     }
 
-    private static BlockBuilder<Block, Registrate> metalBlock(String name, TagKey<Block> blockTag, TagKey<Item> itemTag) {
-        return REGISTRATE
-            .block(name, Block::new)
-            .properties(props -> props.sound(SoundType.METAL).mapColor(MapColor.METAL).strength(5, 6).requiresCorrectToolForDrops())
-            .tag(BlockTags.NEEDS_STONE_TOOL)
-            .tag(BlockTags.MINEABLE_WITH_PICKAXE)
-            .tag(blockTag)
-            .item()
-            .tab(EIOCreativeTabs.BLOCKS)
-            .tag(itemTag)
-            .build();
+    private static EnderDeferredBlock<? extends Block> metalBlock(String name, TagKey<Block> blockTag, TagKey<Item> itemTag) {
+        return BLOCKS.registerBlock(name, BlockBehaviour.Properties.of().sound(SoundType.METAL).mapColor(MapColor.METAL).strength(5, 6).requiresCorrectToolForDrops())
+            .addBlockTags(BlockTags.NEEDS_STONE_TOOL, BlockTags.MINEABLE_WITH_PICKAXE, blockTag)
+            .setLootTable(EnderBlockLootProvider::dropSelf)
+            .createBlockItem()
+            .setTab(EIOCreativeTabs.BLOCKS)
+            .addBlockItemTags(itemTag)
+            .finishBlockItem();
     }
 
-    private static BlockBuilder<Block, Registrate> chassisBlock(String name) {
-        return REGISTRATE
-            .block(name, Block::new)
-            .blockstate((ctx, prov) -> prov.simpleBlock(ctx.get(),
-                prov.models().cubeAll(ctx.getName(), prov.blockTexture(ctx.get())).renderType(prov.mcLoc("translucent"))))
-            .properties(props -> props.noOcclusion().sound(SoundType.METAL).mapColor(MapColor.METAL).strength(5, 6))
-            .tag(BlockTags.NEEDS_STONE_TOOL)
-            .tag(BlockTags.MINEABLE_WITH_PICKAXE)
-            .item()
-            .tab(EIOCreativeTabs.BLOCKS)
-            .build();
+    private static EnderDeferredBlock<? extends Block> chassisBlock(String name) {
+        return BLOCKS.registerBlock(name, BlockBehaviour.Properties.of().noOcclusion().sound(SoundType.METAL).mapColor(MapColor.METAL).strength(5, 6))
+            .setBlockStateProvider((blockStateProvider, block) ->
+                blockStateProvider.simpleBlock(block, blockStateProvider.models().cubeAll(name, blockStateProvider.blockTexture(block)).renderType("translucent")))
+            .addBlockTags(BlockTags.NEEDS_STONE_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
+            .setLootTable(EnderBlockLootProvider::dropSelf)
+            .createBlockItem()
+            .setTab(EIOCreativeTabs.BLOCKS)
+            .finishBlockItem();
     }
 
-    private static BlockEntry<EIOPressurePlateBlock> pressurePlateBlock(String name, ResourceLocation texture, EIOPressurePlateBlock.Detector type,
+    private static DeferredBlock<EIOPressurePlateBlock> pressurePlateBlock(String name, ResourceLocation texture, EIOPressurePlateBlock.Detector type,
         boolean silent) {
+        return BLOCKS.register(name, () -> new EIOPressurePlateBlock(BlockBehaviour.Properties.of().strength(5, 6).mapColor(MapColor.METAL), type, silent))
+            .setBlockStateProvider((blockStateProvider, block) -> {
+                BlockModelProvider modProv = blockStateProvider.models();
+                ModelFile dm = modProv.withExistingParent(name + "_down", blockStateProvider.mcLoc("block/pressure_plate_down")).texture("texture", texture);
+                ModelFile um = modProv.withExistingParent(name, blockStateProvider.mcLoc("block/pressure_plate_up")).texture("texture", texture);
 
-        BlockBuilder<EIOPressurePlateBlock, Registrate> bb = REGISTRATE.block(name,
-            props -> new EIOPressurePlateBlock(props.strength(5, 6).mapColor(MapColor.METAL), type, silent));
-
-        bb.blockstate((ctx, prov) -> {
-
-            BlockModelProvider modProv = prov.models();
-            ModelFile dm = modProv.withExistingParent(ctx.getName() + "_down", prov.mcLoc("block/pressure_plate_down")).texture("texture", texture);
-            ModelFile um = modProv.withExistingParent(ctx.getName(), prov.mcLoc("block/pressure_plate_up")).texture("texture", texture);
-
-            VariantBlockStateBuilder vb = prov.getVariantBuilder(ctx.get());
-            vb.partialState().with(PressurePlateBlock.POWERED, true).addModels(new ConfiguredModel(dm));
-            vb.partialState().with(PressurePlateBlock.POWERED, false).addModels(new ConfiguredModel(um));
-        });
-        bb.tag(BlockTags.NEEDS_STONE_TOOL, BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.PRESSURE_PLATES).item().tab(EIOCreativeTabs.BLOCKS).build();
-        return bb.register();
+                VariantBlockStateBuilder vb = blockStateProvider.getVariantBuilder(block);
+                vb.partialState().with(PressurePlateBlock.POWERED, true).addModels(new ConfiguredModel(dm));
+                vb.partialState().with(PressurePlateBlock.POWERED, false).addModels(new ConfiguredModel(um));
+            })
+            .addBlockTags(BlockTags.NEEDS_STONE_TOOL, BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.PRESSURE_PLATES)
+            .setLootTable(EnderBlockLootProvider::dropSelf)
+            .createBlockItem()
+            .setTab(EIOCreativeTabs.BLOCKS)
+            .finishBlockItem();
     }
 
-    private static BlockEntry<SilentPressurePlateBlock> silentPressurePlateBlock(final PressurePlateBlock block) {
-        ResourceLocation upModelLoc = Objects.requireNonNull(ForgeRegistries.BLOCKS.getKey(block));
+    private static EnderDeferredBlock<SilentPressurePlateBlock> silentPressurePlateBlock(final PressurePlateBlock block) {
+        ResourceLocation upModelLoc = Objects.requireNonNull(BuiltInRegistries.BLOCK.getKey(block));
         ResourceLocation downModelLoc = new ResourceLocation(upModelLoc.getNamespace(), upModelLoc.getPath() + "_down");
-
-        BlockBuilder<SilentPressurePlateBlock, Registrate> bb = REGISTRATE.block("silent_" + upModelLoc.getPath(),
-            props -> new SilentPressurePlateBlock(block));
-        bb.tag(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.PRESSURE_PLATES);
-
-        bb.blockstate((ctx, prov) -> {
-            VariantBlockStateBuilder vb = prov.getVariantBuilder(ctx.get());
-            vb.partialState().with(PressurePlateBlock.POWERED, true).addModels(new ConfiguredModel(prov.models().getExistingFile(downModelLoc)));
-            vb.partialState().with(PressurePlateBlock.POWERED, false).addModels(new ConfiguredModel(prov.models().getExistingFile(upModelLoc)));
-        });
-
-        var itemBuilder = bb.item();
-        itemBuilder.model((ctx, prov) -> prov.withExistingParent(ctx.getName(), upModelLoc));
-        itemBuilder.tab(EIOCreativeTabs.BLOCKS);
-        bb = itemBuilder.build();
-
-        return bb.register();
+        return BLOCKS.register("silent_" + upModelLoc.getPath(), () -> new SilentPressurePlateBlock(block))
+            .addBlockTags(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.PRESSURE_PLATES)
+            .setBlockStateProvider((blockStateProvider, block1) -> {
+                VariantBlockStateBuilder vb = blockStateProvider.getVariantBuilder(block1);
+                vb.partialState().with(PressurePlateBlock.POWERED, true).addModels(new ConfiguredModel(blockStateProvider.models().getExistingFile(downModelLoc)));
+                vb.partialState().with(PressurePlateBlock.POWERED, false).addModels(new ConfiguredModel(blockStateProvider.models().getExistingFile(upModelLoc)));
+            })
+            .setLootTable(EnderBlockLootProvider::dropSelf)
+            .createBlockItem()
+            .setModelProvider((modelProvider, item) -> modelProvider.withExistingParent("silent_" + upModelLoc.getPath(), upModelLoc))
+            .setTab(EIOCreativeTabs.BLOCKS)
+            .finishBlockItem();
     }
 
     private static BlockEntry<SilentWeightedPressurePlateBlock> silentWeightedPressurePlateBlock(WeightedPressurePlateBlock block) {

--- a/src/main/java/com/enderio/base/common/init/EIOEnchantments.java
+++ b/src/main/java/com/enderio/base/common/init/EIOEnchantments.java
@@ -9,13 +9,14 @@ import com.enderio.base.common.enchantment.SoulBoundEnchantment;
 import com.enderio.base.common.enchantment.WitherEnchantment;
 import com.enderio.base.common.enchantment.XPBoostEnchantment;
 import com.enderio.base.common.lang.EIOLang;
-import com.tterrag.registrate.Registrate;
-import com.tterrag.registrate.builders.EnchantmentBuilder;
-import com.tterrag.registrate.util.entry.RegistryEntry;
+import com.enderio.core.common.registry.EnderDeferredObject;
+import com.enderio.core.common.registry.EnderRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.neoforged.neoforge.event.entity.player.ItemTooltipEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod.EventBusSubscriber;
@@ -27,38 +28,34 @@ import java.util.Map;
 @SuppressWarnings("unused")
 @EventBusSubscriber
 public class EIOEnchantments {
-    private static final Registrate REGISTRATE = EnderIO.registrate();
+    private static final EnderRegistry<Enchantment> ENCHANTMENTS = EnderRegistry.createRegistry(BuiltInRegistries.ENCHANTMENT, EnderIO.MODID);
 
     // region enchantments
 
-    public static final RegistryEntry<AutoSmeltEnchantment> AUTO_SMELT = enchantmentBuilder("auto_smelt", new AutoSmeltEnchantment())
-        .lang("Auto Smelt")
-        .register();
+    public static final EnderDeferredObject<Enchantment, AutoSmeltEnchantment> AUTO_SMELT = enchantmentBuilder("auto_smelt", new AutoSmeltEnchantment())
+        .setTranslation("Auto Smelt");
 
-    public static final RegistryEntry<RepellentEnchantment> REPELLENT = enchantmentBuilder("repellent", new RepellentEnchantment())
-        .lang("Repellent")
-        .register();
+    public static final EnderDeferredObject<Enchantment, RepellentEnchantment> REPELLENT = enchantmentBuilder("repellent", new RepellentEnchantment())
+        .setTranslation("Repellent"); //TODO not needed now I think?
 
-    public static final RegistryEntry<ShimmerEnchantment> SHIMMER = enchantmentBuilder("shimmer", new ShimmerEnchantment())
-        .lang("Shimmer")
-        .register();
+    public static final EnderDeferredObject<Enchantment, ShimmerEnchantment> SHIMMER = enchantmentBuilder("shimmer", new ShimmerEnchantment())
+        .setTranslation("Shimmer");
 
-    public static final RegistryEntry<SoulBoundEnchantment> SOULBOUND = enchantmentBuilder("soulbound", new SoulBoundEnchantment())
-        .lang("Soulbound")
-        .register();
+    public static final EnderDeferredObject<Enchantment, SoulBoundEnchantment> SOULBOUND = enchantmentBuilder("soulbound", new SoulBoundEnchantment())
+        .setTranslation("Soulbound");
 
-    public static final RegistryEntry<WitherEnchantment> WITHERING = enchantmentBuilder("withering", new WitherEnchantment())
-        .lang("Withering")
-        .register();
+    public static final EnderDeferredObject<Enchantment, WitherEnchantment> WITHERING = enchantmentBuilder("withering", new WitherEnchantment())
+        .setTranslation("Withering");
 
-    public static final RegistryEntry<XPBoostEnchantment> XP_BOOST = enchantmentBuilder("xp_boost", new XPBoostEnchantment()).lang("XP Boost").register();
+    public static final EnderDeferredObject<Enchantment, XPBoostEnchantment> XP_BOOST = enchantmentBuilder("xp_boost", new XPBoostEnchantment())
+        .setTranslation("XP Boost");
 
     // endregion
 
     // region builders
 
-    private static <T extends EIOBaseEnchantment> EnchantmentBuilder<T, Registrate> enchantmentBuilder(String name, T enchantment) {
-        return REGISTRATE.enchantment(name, enchantment.getCategory(), (r, c, s) -> enchantment);
+    private static <T extends EIOBaseEnchantment> EnderDeferredObject<Enchantment, T> enchantmentBuilder(String name, T enchantment) {
+        return ENCHANTMENTS.register(name, () -> enchantment);
     }
     
     private static void addTooltip(ItemTooltipEvent event, Map<Enchantment, Integer> enchantments, List<Component> toolTip, Enchantment enchantment, Component... components) {
@@ -87,6 +84,8 @@ public class EIOEnchantments {
         }
     }
 
-    public static void register() {}
+    public static void register() {
+        ENCHANTMENTS.register(FMLJavaModLoadingContext.get().getModEventBus());
+    }
 
 }

--- a/src/main/java/com/enderio/base/common/init/EIOItems.java
+++ b/src/main/java/com/enderio/base/common/init/EIOItems.java
@@ -20,143 +20,135 @@ import com.enderio.base.common.item.tool.TravelStaffItem;
 import com.enderio.base.common.item.tool.YetaWrenchItem;
 import com.enderio.base.common.tag.EIOTags;
 import com.enderio.base.data.model.item.GliderItemModel;
+import com.enderio.core.common.registry.EnderDeferredItem;
+import com.enderio.core.common.registry.EnderItemRegistry;
 import com.enderio.core.data.model.EIOModel;
-import com.tterrag.registrate.Registrate;
-import com.tterrag.registrate.builders.ItemBuilder;
-import com.tterrag.registrate.util.entry.ItemEntry;
-import com.tterrag.registrate.util.nullness.NonNullFunction;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
+import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.neoforged.neoforge.common.Tags;
+
+import java.util.function.Function;
 
 @SuppressWarnings("unused")
 public class EIOItems {
-    private static final Registrate REGISTRATE = EnderIO.registrate();
+    private static final EnderItemRegistry ITEMS = EnderItemRegistry.createRegistry(EnderIO.MODID);
 
     // region Alloys
 
-    public static final ItemEntry<MaterialItem> COPPER_ALLOY_INGOT = materialItem("copper_alloy_ingot").tag(EIOTags.Items.INGOTS_COPPER_ALLOY).register();
-    public static final ItemEntry<MaterialItem> ENERGETIC_ALLOY_INGOT = materialItem("energetic_alloy_ingot").tag(EIOTags.Items.INGOTS_ENERGETIC_ALLOY).register();
-    public static final ItemEntry<MaterialItem> VIBRANT_ALLOY_INGOT = materialItem("vibrant_alloy_ingot").tag(EIOTags.Items.INGOTS_VIBRANT_ALLOY).register();
-    public static final ItemEntry<MaterialItem> REDSTONE_ALLOY_INGOT = materialItem("redstone_alloy_ingot").tag(EIOTags.Items.INGOTS_REDSTONE_ALLOY).register();
-    public static final ItemEntry<MaterialItem> CONDUCTIVE_ALLOY_INGOT = materialItem("conductive_alloy_ingot").tag(EIOTags.Items.INGOTS_CONDUCTIVE_ALLOY).register();
-    public static final ItemEntry<MaterialItem> PULSATING_ALLOY_INGOT = materialItem("pulsating_alloy_ingot").tag(EIOTags.Items.INGOTS_PULSATING_ALLOY).register();
-    public static final ItemEntry<MaterialItem> DARK_STEEL_INGOT = materialItem("dark_steel_ingot").tag(EIOTags.Items.INGOTS_DARK_STEEL).register();
-    public static final ItemEntry<MaterialItem> SOULARIUM_INGOT = materialItem("soularium_ingot").tag(EIOTags.Items.INGOTS_SOULARIUM).register();
-    public static final ItemEntry<MaterialItem> END_STEEL_INGOT = materialItem("end_steel_ingot").tag(EIOTags.Items.INGOTS_END_STEEL).register();
+    public static final EnderDeferredItem<MaterialItem> COPPER_ALLOY_INGOT = materialItem("copper_alloy_ingot").addItemTags(EIOTags.Items.INGOTS_COPPER_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> ENERGETIC_ALLOY_INGOT = materialItem("energetic_alloy_ingot").addItemTags(EIOTags.Items.INGOTS_ENERGETIC_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> VIBRANT_ALLOY_INGOT = materialItem("vibrant_alloy_ingot").addItemTags(EIOTags.Items.INGOTS_VIBRANT_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> REDSTONE_ALLOY_INGOT = materialItem("redstone_alloy_ingot").addItemTags(EIOTags.Items.INGOTS_REDSTONE_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> CONDUCTIVE_ALLOY_INGOT = materialItem("conductive_alloy_ingot").addItemTags(EIOTags.Items.INGOTS_CONDUCTIVE_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> PULSATING_ALLOY_INGOT = materialItem("pulsating_alloy_ingot").addItemTags(EIOTags.Items.INGOTS_PULSATING_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> DARK_STEEL_INGOT = materialItem("dark_steel_ingot").addItemTags(EIOTags.Items.INGOTS_DARK_STEEL);
+    public static final EnderDeferredItem<MaterialItem> SOULARIUM_INGOT = materialItem("soularium_ingot").addItemTags(EIOTags.Items.INGOTS_SOULARIUM);
+    public static final EnderDeferredItem<MaterialItem> END_STEEL_INGOT = materialItem("end_steel_ingot").addItemTags(EIOTags.Items.INGOTS_END_STEEL);
 
-    public static final ItemEntry<MaterialItem> COPPER_ALLOY_NUGGET = materialItem("copper_alloy_nugget").tag(EIOTags.Items.NUGGETS_COPPER_ALLOY).register();
-    public static final ItemEntry<MaterialItem> ENERGETIC_ALLOY_NUGGET = materialItem("energetic_alloy_nugget").tag(EIOTags.Items.NUGGETS_ENERGETIC_ALLOY).register();
-    public static final ItemEntry<MaterialItem> VIBRANT_ALLOY_NUGGET = materialItem("vibrant_alloy_nugget").tag(EIOTags.Items.NUGGETS_VIBRANT_ALLOY).register();
-    public static final ItemEntry<MaterialItem> REDSTONE_ALLOY_NUGGET = materialItem("redstone_alloy_nugget").tag(EIOTags.Items.NUGGETS_REDSTONE_ALLOY).register();
-    public static final ItemEntry<MaterialItem> CONDUCTIVE_ALLOY_NUGGET = materialItem("conductive_alloy_nugget").tag(EIOTags.Items.NUGGETS_CONDUCTIVE_ALLOY).register();
-    public static final ItemEntry<MaterialItem> PULSATING_ALLOY_NUGGET = materialItem("pulsating_alloy_nugget").tag(EIOTags.Items.NUGGETS_PULSATING_ALLOY).register();
-    public static final ItemEntry<MaterialItem> DARK_STEEL_NUGGET = materialItem("dark_steel_nugget").tag(EIOTags.Items.NUGGETS_DARK_STEEL).register();
-    public static final ItemEntry<MaterialItem> SOULARIUM_NUGGET = materialItem("soularium_nugget").tag(EIOTags.Items.NUGGETS_SOULARIUM).register();
-    public static final ItemEntry<MaterialItem> END_STEEL_NUGGET = materialItem("end_steel_nugget").tag(EIOTags.Items.NUGGETS_END_STEEL).register();
+    public static final EnderDeferredItem<MaterialItem> COPPER_ALLOY_NUGGET = materialItem("copper_alloy_nugget").addItemTags(EIOTags.Items.NUGGETS_COPPER_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> ENERGETIC_ALLOY_NUGGET = materialItem("energetic_alloy_nugget").addItemTags(EIOTags.Items.NUGGETS_ENERGETIC_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> VIBRANT_ALLOY_NUGGET = materialItem("vibrant_alloy_nugget").addItemTags(EIOTags.Items.NUGGETS_VIBRANT_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> REDSTONE_ALLOY_NUGGET = materialItem("redstone_alloy_nugget").addItemTags(EIOTags.Items.NUGGETS_REDSTONE_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> CONDUCTIVE_ALLOY_NUGGET = materialItem("conductive_alloy_nugget").addItemTags(EIOTags.Items.NUGGETS_CONDUCTIVE_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> PULSATING_ALLOY_NUGGET = materialItem("pulsating_alloy_nugget").addItemTags(EIOTags.Items.NUGGETS_PULSATING_ALLOY);
+    public static final EnderDeferredItem<MaterialItem> DARK_STEEL_NUGGET = materialItem("dark_steel_nugget").addItemTags(EIOTags.Items.NUGGETS_DARK_STEEL);
+    public static final EnderDeferredItem<MaterialItem> SOULARIUM_NUGGET = materialItem("soularium_nugget").addItemTags(EIOTags.Items.NUGGETS_SOULARIUM);
+    public static final EnderDeferredItem<MaterialItem> END_STEEL_NUGGET = materialItem("end_steel_nugget").addItemTags(EIOTags.Items.NUGGETS_END_STEEL);
 
     // endregion
 
     // region Crafting Components
 
-    public static final ItemEntry<MaterialItem> SILICON = materialItem("silicon").tag(EIOTags.Items.SILICON).register();
+    public static final EnderDeferredItem<MaterialItem> SILICON = materialItem("silicon").addItemTags(EIOTags.Items.SILICON);
 
-    public static final ItemEntry<MaterialItem> GRAINS_OF_INFINITY = materialItem("grains_of_infinity").tag(EIOTags.Items.DUSTS_GRAINS_OF_INFINITY).lang("Grains of Infinity").register();
+    public static final EnderDeferredItem<MaterialItem> GRAINS_OF_INFINITY = materialItem("grains_of_infinity").addItemTags(EIOTags.Items.DUSTS_GRAINS_OF_INFINITY).setTranslation("Grains of Infinity");
 
-    public static final ItemEntry<MaterialItem> INFINITY_ROD = materialItem("infinity_rod").register();
+    public static final EnderDeferredItem<MaterialItem> INFINITY_ROD = materialItem("infinity_rod");
 
-    public static final ItemEntry<MaterialItem> CONDUIT_BINDER_COMPOSITE = materialItem("conduit_binder_composite").register();
+    public static final EnderDeferredItem<MaterialItem> CONDUIT_BINDER_COMPOSITE = materialItem("conduit_binder_composite");
 
-    public static final ItemEntry<MaterialItem> CONDUIT_BINDER = materialItem("conduit_binder").register();
+    public static final EnderDeferredItem<MaterialItem> CONDUIT_BINDER = materialItem("conduit_binder");
 
-    public static final ItemEntry<MaterialItem> ZOMBIE_ELECTRODE = materialItem("zombie_electrode").register();
+    public static final EnderDeferredItem<MaterialItem> ZOMBIE_ELECTRODE = materialItem("zombie_electrode");
 
-    public static final ItemEntry<MaterialItem> Z_LOGIC_CONTROLLER = materialItem("z_logic_controller").lang("Z-Logic Controller").register();
+    public static final EnderDeferredItem<MaterialItem> Z_LOGIC_CONTROLLER = materialItem("z_logic_controller").setTranslation("Z-Logic Controller");
 
-    public static final ItemEntry<MaterialItem> FRANK_N_ZOMBIE = materialItemGlinted("frank_n_zombie")
-        .lang("Frank'N'Zombie")
-        .model((ctx, prov) -> EIOModel.mimicItem(ctx, EIOItems.Z_LOGIC_CONTROLLER, prov))
-        .register();
+    public static final EnderDeferredItem<MaterialItem> FRANK_N_ZOMBIE = materialItemGlinted("frank_n_zombie")
+        .setTranslation("Frank'N'Zombie")
+        .setModelProvider((prov, item) -> EIOModel.mimicItem(item, EIOItems.Z_LOGIC_CONTROLLER, prov));
 
-    public static final ItemEntry<MaterialItem> ENDER_RESONATOR = materialItem("ender_resonator").register();
+    public static final EnderDeferredItem<MaterialItem> ENDER_RESONATOR = materialItem("ender_resonator");
 
-    public static final ItemEntry<MaterialItem> SENTIENT_ENDER = materialItemGlinted("sentient_ender")
-        .model((ctx, prov) -> EIOModel.mimicItem(ctx, EIOItems.ENDER_RESONATOR, prov))
-        .register();
+    public static final EnderDeferredItem<MaterialItem> SENTIENT_ENDER = materialItemGlinted("sentient_ender")
+        .setModelProvider((prov, item) -> EIOModel.mimicItem(item, EIOItems.ENDER_RESONATOR, prov));
 
-    public static final ItemEntry<MaterialItem> SKELETAL_CONTRACTOR = materialItem("skeletal_contractor").register();
-    public static final ItemEntry<MaterialItem> GUARDIAN_DIODE = materialItem("guardian_diode").register();
+    public static final EnderDeferredItem<MaterialItem> SKELETAL_CONTRACTOR = materialItem("skeletal_contractor");
+    public static final EnderDeferredItem<MaterialItem> GUARDIAN_DIODE = materialItem("guardian_diode");
 
     // endregion
 
     // region Capacitors
 
-    public static final ItemEntry<FixedCapacitorItem> BASIC_CAPACITOR = REGISTRATE
-        .item("basic_capacitor", props -> new FixedCapacitorItem(DefaultCapacitorData.BASIC, props))
-        .tab(EIOCreativeTabs.MAIN)
-        .register();
+    public static final EnderDeferredItem<FixedCapacitorItem> BASIC_CAPACITOR = ITEMS
+        .registerItem("basic_capacitor", props -> new FixedCapacitorItem(DefaultCapacitorData.BASIC, props))
+        .setTab(EIOCreativeTabs.MAIN);
 
-    public static final ItemEntry<FixedCapacitorItem> DOUBLE_LAYER_CAPACITOR = REGISTRATE
-        .item("double_layer_capacitor", props -> new FixedCapacitorItem(DefaultCapacitorData.DOUBLE_LAYER, props))
-        .tab(EIOCreativeTabs.MAIN)
-        .register();
+    public static final EnderDeferredItem<FixedCapacitorItem> DOUBLE_LAYER_CAPACITOR = ITEMS
+        .registerItem("double_layer_capacitor", props -> new FixedCapacitorItem(DefaultCapacitorData.DOUBLE_LAYER, props))
+        .setTab(EIOCreativeTabs.MAIN);
 
-    public static final ItemEntry<FixedCapacitorItem> OCTADIC_CAPACITOR = REGISTRATE
-        .item("octadic_capacitor", props -> new FixedCapacitorItem(DefaultCapacitorData.OCTADIC, props))
-        .tab(EIOCreativeTabs.MAIN)
-        .register();
+    public static final EnderDeferredItem<FixedCapacitorItem> OCTADIC_CAPACITOR = ITEMS
+        .registerItem("octadic_capacitor", props -> new FixedCapacitorItem(DefaultCapacitorData.OCTADIC, props))
+        .setTab(EIOCreativeTabs.MAIN);
 
-    public static final ItemEntry<LootCapacitorItem> LOOT_CAPACITOR = REGISTRATE
-        .item("loot_capacitor", LootCapacitorItem::new)
-        .properties(p -> p.stacksTo(1))
-        .register();
+    public static final EnderDeferredItem<LootCapacitorItem> LOOT_CAPACITOR = ITEMS
+        .registerItem("loot_capacitor", properties -> new LootCapacitorItem(new Item.Properties().stacksTo(1)));
 
     // endregion
 
     // region Crystals
 
-    public static final ItemEntry<MaterialItem> PULSATING_CRYSTAL = materialItemGlinted("pulsating_crystal").tag(EIOTags.Items.GEMS_PULSATING_CRYSTAL).register();
-    public static final ItemEntry<MaterialItem> VIBRANT_CRYSTAL = materialItemGlinted("vibrant_crystal").tag(EIOTags.Items.GEMS_VIBRANT_CRYSTAL).register();
-    public static final ItemEntry<MaterialItem> ENDER_CRYSTAL = materialItemGlinted("ender_crystal").tag(EIOTags.Items.GEMS_ENDER_CRYSTAL).register();
-    public static final ItemEntry<MaterialItem> ENTICING_CRYSTAL = materialItemGlinted("enticing_crystal").tag(EIOTags.Items.GEMS_ENTICING_CRYSTAL).register();
-    public static final ItemEntry<MaterialItem> WEATHER_CRYSTAL = materialItemGlinted("weather_crystal").tag(EIOTags.Items.GEMS_WEATHER_CRYSTAL).register();
-    public static final ItemEntry<MaterialItem> PRESCIENT_CRYSTAL = materialItemGlinted("prescient_crystal").tag(EIOTags.Items.GEMS_PRESCIENT_CRYSTAL).register();
+    public static final EnderDeferredItem<MaterialItem> PULSATING_CRYSTAL = materialItemGlinted("pulsating_crystal").addItemTags(EIOTags.Items.GEMS_PULSATING_CRYSTAL);
+    public static final EnderDeferredItem<MaterialItem> VIBRANT_CRYSTAL = materialItemGlinted("vibrant_crystal").addItemTags(EIOTags.Items.GEMS_VIBRANT_CRYSTAL);
+    public static final EnderDeferredItem<MaterialItem> ENDER_CRYSTAL = materialItemGlinted("ender_crystal").addItemTags(EIOTags.Items.GEMS_ENDER_CRYSTAL);
+    public static final EnderDeferredItem<MaterialItem> ENTICING_CRYSTAL = materialItemGlinted("enticing_crystal").addItemTags(EIOTags.Items.GEMS_ENTICING_CRYSTAL);
+    public static final EnderDeferredItem<MaterialItem> WEATHER_CRYSTAL = materialItemGlinted("weather_crystal").addItemTags(EIOTags.Items.GEMS_WEATHER_CRYSTAL);
+    public static final EnderDeferredItem<MaterialItem> PRESCIENT_CRYSTAL = materialItemGlinted("prescient_crystal").addItemTags(EIOTags.Items.GEMS_PRESCIENT_CRYSTAL);
 
     // endregion
 
     // region Powders and Fragments
 
-    public static final ItemEntry<MaterialItem> FLOUR = materialItem("flour").register();
-    public static final ItemEntry<MaterialItem> POWDERED_COAL = materialItem("powdered_coal").tag(EIOTags.Items.DUSTS_COAL).register();
-    public static final ItemEntry<MaterialItem> POWDERED_IRON = materialItem("powdered_iron").tag(EIOTags.Items.DUSTS_IRON).register();
-    public static final ItemEntry<MaterialItem> POWDERED_GOLD = materialItem("powdered_gold").tag(EIOTags.Items.DUSTS_GOLD).register();
-    public static final ItemEntry<MaterialItem> POWDERED_COPPER = materialItem("powdered_copper").tag(EIOTags.Items.DUSTS_COPPER).register();
-    public static final ItemEntry<MaterialItem> POWDERED_TIN = materialItem("powdered_tin")
-        .tag(EIOTags.Items.DUSTS_TIN)
-        .register(); // TODO: hide if tin isn't present
-    public static final ItemEntry<MaterialItem> POWDERED_ENDER_PEARL = materialItem("powdered_ender_pearl").tag(EIOTags.Items.DUSTS_ENDER).register();
-    public static final ItemEntry<MaterialItem> POWDERED_OBSIDIAN = materialItem("powdered_obsidian").tag(EIOTags.Items.DUSTS_OBSIDIAN).register();
-    public static final ItemEntry<MaterialItem> POWDERED_COBALT = materialItem("powdered_cobalt")
-        .tag(EIOTags.Items.DUSTS_COBALT)
-        .register(); // TODO: hide if cobalt isnt present
-    public static final ItemEntry<MaterialItem> POWDERED_LAPIS_LAZULI = materialItem("powdered_lapis_lazuli").tag(EIOTags.Items.DUSTS_LAPIS).register();
-    public static final ItemEntry<MaterialItem> POWDERED_QUARTZ = materialItem("powdered_quartz").tag(EIOTags.Items.DUSTS_QUARTZ).register();
+    public static final EnderDeferredItem<MaterialItem> FLOUR = materialItem("flour");
+    public static final EnderDeferredItem<MaterialItem> POWDERED_COAL = materialItem("powdered_coal").addItemTags(EIOTags.Items.DUSTS_COAL);
+    public static final EnderDeferredItem<MaterialItem> POWDERED_IRON = materialItem("powdered_iron").addItemTags(EIOTags.Items.DUSTS_IRON);
+    public static final EnderDeferredItem<MaterialItem> POWDERED_GOLD = materialItem("powdered_gold").addItemTags(EIOTags.Items.DUSTS_GOLD);
+    public static final EnderDeferredItem<MaterialItem> POWDERED_COPPER = materialItem("powdered_copper").addItemTags(EIOTags.Items.DUSTS_COPPER);
+    public static final EnderDeferredItem<MaterialItem> POWDERED_TIN = materialItem("powdered_tin")
+        .addItemTags(EIOTags.Items.DUSTS_TIN); // TODO: hide if tin isn't present
+    public static final EnderDeferredItem<MaterialItem> POWDERED_ENDER_PEARL = materialItem("powdered_ender_pearl").addItemTags(EIOTags.Items.DUSTS_ENDER);
+    public static final EnderDeferredItem<MaterialItem> POWDERED_OBSIDIAN = materialItem("powdered_obsidian").addItemTags(EIOTags.Items.DUSTS_OBSIDIAN);
+    public static final EnderDeferredItem<MaterialItem> POWDERED_COBALT = materialItem("powdered_cobalt")
+        .addItemTags(EIOTags.Items.DUSTS_COBALT); // TODO: hide if cobalt isnt present
+    public static final EnderDeferredItem<MaterialItem> POWDERED_LAPIS_LAZULI = materialItem("powdered_lapis_lazuli").addItemTags(EIOTags.Items.DUSTS_LAPIS);
+    public static final EnderDeferredItem<MaterialItem> POWDERED_QUARTZ = materialItem("powdered_quartz").addItemTags(EIOTags.Items.DUSTS_QUARTZ);
 
-    public static final ItemEntry<MaterialItem> PRESCIENT_POWDER = materialItemGlinted("prescient_powder").tag(EIOTags.Items.DUSTS_GRAINS_OF_PRESCIENCE).lang("Grains of Prescience").register();
+    public static final EnderDeferredItem<MaterialItem> PRESCIENT_POWDER = materialItemGlinted("prescient_powder").addItemTags(EIOTags.Items.DUSTS_GRAINS_OF_PRESCIENCE).setTranslation("Grains of Prescience");
 
-    public static final ItemEntry<MaterialItem> VIBRANT_POWDER = materialItemGlinted("vibrant_powder").tag(EIOTags.Items.DUSTS_GRAINS_OF_VIBRANCY).lang("Grains of Vibrancy").register();
+    public static final EnderDeferredItem<MaterialItem> VIBRANT_POWDER = materialItemGlinted("vibrant_powder").addItemTags(EIOTags.Items.DUSTS_GRAINS_OF_VIBRANCY).setTranslation("Grains of Vibrancy");
 
-    public static final ItemEntry<MaterialItem> PULSATING_POWDER = materialItemGlinted("pulsating_powder").tag(EIOTags.Items.DUSTS_GRAINS_OF_PIZEALLITY).lang("Grains of Piezallity").register();
+    public static final EnderDeferredItem<MaterialItem> PULSATING_POWDER = materialItemGlinted("pulsating_powder").addItemTags(EIOTags.Items.DUSTS_GRAINS_OF_PIZEALLITY).setTranslation("Grains of Piezallity");
 
-    public static final ItemEntry<MaterialItem> ENDER_CRYSTAL_POWDER = materialItemGlinted("ender_crystal_powder").tag(EIOTags.Items.DUSTS_GRAINS_OF_THE_END).lang("Grains of the End").register();
+    public static final EnderDeferredItem<MaterialItem> ENDER_CRYSTAL_POWDER = materialItemGlinted("ender_crystal_powder").addItemTags(EIOTags.Items.DUSTS_GRAINS_OF_THE_END).setTranslation("Grains of the End");
 
-    public static final ItemEntry<MaterialItem> PHOTOVOLTAIC_COMPOSITE = materialItem("photovoltaic_composite").register();
-    public static final ItemEntry<MaterialItem> SOUL_POWDER = materialItem("soul_powder").register();
-    public static final ItemEntry<MaterialItem> CONFUSION_POWDER = materialItem("confusing_powder").register();
-    public static final ItemEntry<MaterialItem> WITHERING_POWDER = materialItem("withering_powder").register();
+    public static final EnderDeferredItem<MaterialItem> PHOTOVOLTAIC_COMPOSITE = materialItem("photovoltaic_composite");
+    public static final EnderDeferredItem<MaterialItem> SOUL_POWDER = materialItem("soul_powder");
+    public static final EnderDeferredItem<MaterialItem> CONFUSION_POWDER = materialItem("confusing_powder");
+    public static final EnderDeferredItem<MaterialItem> WITHERING_POWDER = materialItem("withering_powder");
 
     // endregion
 
@@ -164,73 +156,71 @@ public class EIOItems {
 
     // region Gears
 
-    public static final ItemEntry<MaterialItem> GEAR_WOOD = materialItem("wood_gear").lang("Wooden Gear").tag(EIOTags.Items.GEARS_WOOD).register();
+    public static final EnderDeferredItem<MaterialItem> GEAR_WOOD = materialItem("wood_gear").setTranslation("Wooden Gear").addItemTags(EIOTags.Items.GEARS_WOOD);
 
-    public static final ItemEntry<MaterialItem> GEAR_STONE = materialItem("stone_gear").lang("Stone Compound Gear").tag(EIOTags.Items.GEARS_STONE).register();
+    public static final EnderDeferredItem<MaterialItem> GEAR_STONE = materialItem("stone_gear").setTranslation("Stone Compound Gear").addItemTags(EIOTags.Items.GEARS_STONE);
 
-    public static final ItemEntry<MaterialItem> GEAR_IRON = materialItem("iron_gear").lang("Infinity Bimetal Gear").tag(EIOTags.Items.GEARS_IRON).register();
+    public static final EnderDeferredItem<MaterialItem> GEAR_IRON = materialItem("iron_gear").setTranslation("Infinity Bimetal Gear").addItemTags(EIOTags.Items.GEARS_IRON);
 
-    public static final ItemEntry<MaterialItem> GEAR_ENERGIZED = materialItem("energized_gear").lang("Energized Bimetal Gear").tag(EIOTags.Items.GEARS_ENERGIZED).register();
+    public static final EnderDeferredItem<MaterialItem> GEAR_ENERGIZED = materialItem("energized_gear").setTranslation("Energized Bimetal Gear").addItemTags(EIOTags.Items.GEARS_ENERGIZED);
 
-    public static final ItemEntry<MaterialItem> GEAR_VIBRANT = materialItem("vibrant_gear").lang("Vibrant Bimetal Gear").tag(EIOTags.Items.GEARS_VIBRANT).register();
+    public static final EnderDeferredItem<MaterialItem> GEAR_VIBRANT = materialItem("vibrant_gear").setTranslation("Vibrant Bimetal Gear").addItemTags(EIOTags.Items.GEARS_VIBRANT);
 
-    public static final ItemEntry<MaterialItem> GEAR_DARK_STEEL = materialItem("dark_bimetal_gear").lang("Dark Bimetal Gear").tag(EIOTags.Items.GEARS_DARK_STEEL).register();
+    public static final EnderDeferredItem<MaterialItem> GEAR_DARK_STEEL = materialItem("dark_bimetal_gear").setTranslation("Dark Bimetal Gear").addItemTags(EIOTags.Items.GEARS_DARK_STEEL);
 
     // endregion
 
     // region Dyes
 
-    public static final ItemEntry<MaterialItem> DYE_GREEN = materialItem("organic_green_dye").tag(Tags.Items.DYES_GREEN, Tags.Items.DYES).register();
+    public static final EnderDeferredItem<MaterialItem> DYE_GREEN = materialItem("organic_green_dye").addItemTags(Tags.Items.DYES_GREEN, Tags.Items.DYES);
 
-    public static final ItemEntry<MaterialItem> DYE_BROWN = materialItem("organic_brown_dye").tag(Tags.Items.DYES_BROWN, Tags.Items.DYES).register();
+    public static final EnderDeferredItem<MaterialItem> DYE_BROWN = materialItem("organic_brown_dye").addItemTags(Tags.Items.DYES_BROWN, Tags.Items.DYES);
 
-    public static final ItemEntry<MaterialItem> DYE_BLACK = materialItem("organic_black_dye").tag(Tags.Items.DYES_BLACK, Tags.Items.DYES).register();
+    public static final EnderDeferredItem<MaterialItem> DYE_BLACK = materialItem("organic_black_dye").addItemTags(Tags.Items.DYES_BLACK, Tags.Items.DYES);
 
     // endregion
 
     // region Misc Materials
 
-    public static final ItemEntry<MaterialItem> PHOTOVOLTAIC_PLATE = materialItem("photovoltaic_plate")
-        .model((ctx, prov) -> prov.withExistingParent(prov.name(ctx), prov.mcLoc("block/pressure_plate_up")).texture("texture", prov.itemTexture(ctx)))
-        .register();
+    public static final EnderDeferredItem<MaterialItem> PHOTOVOLTAIC_PLATE = materialItem("photovoltaic_plate")
+        .setModelProvider((prov, item) -> prov.withExistingParent("photovoltaic_plate", prov.mcLoc("block/pressure_plate_up")).texture("texture", prov.itemTexture(item)));
 
-    public static final ItemEntry<MaterialItem> NUTRITIOUS_STICK = materialItem("nutritious_stick").register();
+    public static final EnderDeferredItem<MaterialItem> NUTRITIOUS_STICK = materialItem("nutritious_stick");
 
-    public static final ItemEntry<MaterialItem> PLANT_MATTER_GREEN = materialItem("plant_matter_green").lang("Clippings and Trimmings").register();
+    public static final EnderDeferredItem<MaterialItem> PLANT_MATTER_GREEN = materialItem("plant_matter_green").setTranslation("Clippings and Trimmings");
 
-    public static final ItemEntry<MaterialItem> PLANT_MATTER_BROWN = materialItem("plant_matter_brown").lang("Twigs and Prunings").register();
+    public static final EnderDeferredItem<MaterialItem> PLANT_MATTER_BROWN = materialItem("plant_matter_brown").setTranslation("Twigs and Prunings");
 
-    public static final ItemEntry<MaterialItem> GLIDER_WING = materialItem("glider_wing").register();
+    public static final EnderDeferredItem<MaterialItem> GLIDER_WING = materialItem("glider_wing");
 
-    public static final ItemEntry<MaterialItem> ANIMAL_TOKEN = materialItemGlinted("animal_token").register();
-    public static final ItemEntry<MaterialItem> MONSTER_TOKEN = materialItemGlinted("monster_token").register();
-    public static final ItemEntry<MaterialItem> PLAYER_TOKEN = materialItemGlinted("player_token").register();
-    public static final ItemEntry<MaterialItem> CAKE_BASE = materialItem("cake_base").register();
-    public static final ItemEntry<MaterialItem> BLACK_PAPER = materialItem("black_paper").register();
-    public static final ItemEntry<MaterialItem> CLAYED_GLOWSTONE = materialItem("clayed_glowstone").register();
-    public static final ItemEntry<MaterialItem> NETHERCOTTA = materialItem("nethercotta").register();
-    public static final ItemEntry<MaterialItem> REDSTONE_FILTER_BASE = materialItem("redstone_filter_base").register();
+    public static final EnderDeferredItem<MaterialItem> ANIMAL_TOKEN = materialItemGlinted("animal_token");
+    public static final EnderDeferredItem<MaterialItem> MONSTER_TOKEN = materialItemGlinted("monster_token");
+    public static final EnderDeferredItem<MaterialItem> PLAYER_TOKEN = materialItemGlinted("player_token");
+    public static final EnderDeferredItem<MaterialItem> CAKE_BASE = materialItem("cake_base");
+    public static final EnderDeferredItem<MaterialItem> BLACK_PAPER = materialItem("black_paper");
+    public static final EnderDeferredItem<MaterialItem> CLAYED_GLOWSTONE = materialItem("clayed_glowstone");
+    public static final EnderDeferredItem<MaterialItem> NETHERCOTTA = materialItem("nethercotta");
+    public static final EnderDeferredItem<MaterialItem> REDSTONE_FILTER_BASE = materialItem("redstone_filter_base");
 
-    public static final ItemEntry<BrokenSpawnerItem> BROKEN_SPAWNER = REGISTRATE
-        .item("broken_spawner", BrokenSpawnerItem::new)
-        .model(EIOModel::fakeBlockModel)
-        .tab(EIOCreativeTabs.MAIN)
-        .tab(EIOCreativeTabs.SOULS, modifier -> modifier.acceptAll(BrokenSpawnerItem.gePossibleStacks()))
-        .register();
+    public static final EnderDeferredItem<BrokenSpawnerItem> BROKEN_SPAWNER = ITEMS
+        .registerItem("broken_spawner", BrokenSpawnerItem::new)
+        .setModelProvider(EIOModel::fakeBlockModel)
+        .setTab(EIOCreativeTabs.MAIN);
+        //.setTab(EIOCreativeTabs.SOULS, modifier -> modifier.acceptAll(BrokenSpawnerItem.gePossibleStacks())); TODO, Multiple tabs + filter
 
     // endregion
 
     // region GrindingBalls
 
-    public static final ItemEntry<MaterialItem> SOULARIUM_BALL = materialItem("soularium_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> CONDUCTIVE_ALLOY_BALL = materialItem("conductive_alloy_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> PULSATING_ALLOY_BALL = materialItem("pulsating_alloy_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> REDSTONE_ALLOY_BALL = materialItem("redstone_alloy_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> ENERGETIC_ALLOY_BALL = materialItem("energetic_alloy_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> VIBRANT_ALLOY_BALL = materialItem("vibrant_alloy_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> COPPER_ALLOY_BALL = materialItem("copper_alloy_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> DARK_STEEL_BALL = materialItem("dark_steel_grinding_ball").register();
-    public static final ItemEntry<MaterialItem> END_STEEL_BALL = materialItem("end_steel_grinding_ball").register();
+    public static final EnderDeferredItem<MaterialItem> SOULARIUM_BALL = materialItem("soularium_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> CONDUCTIVE_ALLOY_BALL = materialItem("conductive_alloy_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> PULSATING_ALLOY_BALL = materialItem("pulsating_alloy_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> REDSTONE_ALLOY_BALL = materialItem("redstone_alloy_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> ENERGETIC_ALLOY_BALL = materialItem("energetic_alloy_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> VIBRANT_ALLOY_BALL = materialItem("vibrant_alloy_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> COPPER_ALLOY_BALL = materialItem("copper_alloy_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> DARK_STEEL_BALL = materialItem("dark_steel_grinding_ball");
+    public static final EnderDeferredItem<MaterialItem> END_STEEL_BALL = materialItem("end_steel_grinding_ball");
     //    public static final Map<DyeColor, ItemEntry<HangGliderItem>> COLORED_HANG_GLIDERS = Util.make(() -> {
     //       Map<DyeColor, ItemEntry<HangGliderItem>> tempMap = new EnumMap<>(DyeColor.class);
     //       for (DyeColor color: DyeColor.values()) {
@@ -246,15 +236,15 @@ public class EIOItems {
 
     // region Builders
 
-    private static ItemBuilder<HangGliderItem, Registrate> gliderItem(String name) {
+    private static EnderDeferredItem<HangGliderItem> gliderItem(String name) {
         return dumbItem(name, HangGliderItem::new)
-            .tag(EIOTags.Items.GLIDER)
-            .tab(EIOCreativeTabs.MAIN)
-            .model((ctx, prov) -> GliderItemModel.create(ctx.get(), prov));
+            .addItemTags(EIOTags.Items.GLIDER)
+            .setTab(EIOCreativeTabs.MAIN)
+            .setModelProvider(GliderItemModel::create);
     }
 
-    private static ItemBuilder<MaterialItem, Registrate> materialItem(String name) {
-        return REGISTRATE.item(name, props -> new MaterialItem(props, false)).tab(EIOCreativeTabs.MAIN);
+    private static EnderDeferredItem<MaterialItem> materialItem(String name) {
+        return ITEMS.registerItem(name, props -> new MaterialItem(props, false)).setTab(EIOCreativeTabs.MAIN);
     }
 
     //  private static ItemBuilder<MaterialItem, Registrate> dependMaterialItem(String name, Tag<Item> dependency) {
@@ -262,8 +252,8 @@ public class EIOItems {
     //        .group(() -> EnderIO.TAB_MAIN));
     //  }
 
-    private static ItemBuilder<MaterialItem, Registrate> materialItemGlinted(String name) {
-        return REGISTRATE.item(name, props -> new MaterialItem(props, true)).tab(EIOCreativeTabs.MAIN);
+    private static EnderDeferredItem<MaterialItem> materialItemGlinted(String name) {
+        return ITEMS.registerItem(name, props -> new MaterialItem(props, true)).setTab(EIOCreativeTabs.MAIN);
     }
 
     // endregion
@@ -272,109 +262,87 @@ public class EIOItems {
 
     // TODO: Will need sorted once we have added more.
 
-    public static final ItemEntry<SoulVialItem> EMPTY_SOUL_VIAL = groupedItem("empty_soul_vial", SoulVialItem::new, EIOCreativeTabs.SOULS);
+    public static final EnderDeferredItem<SoulVialItem> EMPTY_SOUL_VIAL = groupedItem("empty_soul_vial", SoulVialItem::new, EIOCreativeTabs.SOULS);
 
-    public static final ItemEntry<SoulVialItem> FILLED_SOUL_VIAL = REGISTRATE
-        .item("filled_soul_vial", SoulVialItem::new)
-        .properties(props -> props.stacksTo(1))
-        .tab(EIOCreativeTabs.SOULS, modifier -> modifier.acceptAll(SoulVialItem.getAllFilled()))
-        .removeTab(CreativeModeTabs.SEARCH)
-        .register();
+    public static final EnderDeferredItem<SoulVialItem> FILLED_SOUL_VIAL = ITEMS
+        .registerItem("filled_soul_vial", properties -> new SoulVialItem(new Item.Properties().stacksTo(1)))
+        //.tab(EIOCreativeTabs.SOULS, modifier -> modifier.acceptAll(SoulVialItem.getAllFilled())) TODO
+        .setTab(EIOCreativeTabs.SOULS);
+        //.removeTab(CreativeModeTabs.SEARCH)
 
-    public static final ItemEntry<EnderiosItem> ENDERIOS = REGISTRATE
-        .item("enderios", EnderiosItem::new)
-        .tab(EIOCreativeTabs.MAIN)
-        .lang("\"Enderios\"")
-        .properties(props -> props.stacksTo(1))
-        .register();
+    public static final EnderDeferredItem<EnderiosItem> ENDERIOS = ITEMS
+        .registerItem("enderios", properties -> new EnderiosItem(new Item.Properties().stacksTo(1)))
+        .setTab(EIOCreativeTabs.MAIN)
+        .setTranslation("\"Enderios\"");
 
     // endregion
 
     // region Tools
-    public static final ItemEntry<YetaWrenchItem> YETA_WRENCH = REGISTRATE
-        .item("yeta_wrench", YetaWrenchItem::new)
-        .tab(EIOCreativeTabs.GEAR)
-        .properties(props -> props.stacksTo(1))
-        .tag(EIOTags.Items.WRENCH)
-        .register();
+    public static final EnderDeferredItem<YetaWrenchItem> YETA_WRENCH = ITEMS
+        .registerItem("yeta_wrench", properties -> new YetaWrenchItem(new Item.Properties().stacksTo(1)))
+        .setTab(EIOCreativeTabs.GEAR)
+        .addItemTags(EIOTags.Items.WRENCH);
+    public static final EnderDeferredItem<LocationPrintoutItem> LOCATION_PRINTOUT = ITEMS
+        .registerItem("location_printout", properties -> new LocationPrintoutItem(new Item.Properties().stacksTo(1)))
+        .setTab(EIOCreativeTabs.GEAR);
 
-    public static final ItemEntry<LocationPrintoutItem> LOCATION_PRINTOUT = REGISTRATE
-        .item("location_printout", LocationPrintoutItem::new)
-        .tab(EIOCreativeTabs.GEAR)
-        .properties(props -> props.stacksTo(1))
-        .register();
+    public static final EnderDeferredItem<CoordinateSelectorItem> COORDINATE_SELECTOR = ITEMS
+        .registerItem("coordinate_selector", properties -> new CoordinateSelectorItem(new Item.Properties().stacksTo(1)))
+        .setTab(EIOCreativeTabs.GEAR);
 
-    public static final ItemEntry<CoordinateSelectorItem> COORDINATE_SELECTOR = REGISTRATE
-        .item("coordinate_selector", CoordinateSelectorItem::new)
-        .tab(EIOCreativeTabs.GEAR)
-        .properties(props -> props.stacksTo(1))
-        .register();
+    public static final EnderDeferredItem<ExperienceRodItem> EXPERIENCE_ROD = ITEMS
+        .registerItem("experience_rod", ExperienceRodItem::new)
+        .setTab(EIOCreativeTabs.GEAR);
 
-    public static final ItemEntry<ExperienceRodItem> EXPERIENCE_ROD = REGISTRATE
-        .item("experience_rod", ExperienceRodItem::new)
-        .tab(EIOCreativeTabs.GEAR)
-        .register();
+    public static final EnderDeferredItem<LevitationStaffItem> LEVITATION_STAFF = ITEMS
+        .registerItem("staff_of_levity", properties -> new LevitationStaffItem(new Item.Properties().stacksTo(1)))
+        //.tab(EIOCreativeTabs.GEAR, modifier -> EIOItems.LEVITATION_STAFF.get().addAllVariants(modifier))
+        .setTab(EIOCreativeTabs.GEAR);
 
-    public static final ItemEntry<LevitationStaffItem> LEVITATION_STAFF = REGISTRATE
-        .item("staff_of_levity", LevitationStaffItem::new)
-        .tab(EIOCreativeTabs.GEAR, modifier -> EIOItems.LEVITATION_STAFF.get().addAllVariants(modifier))
-        .register();
+    public static final EnderDeferredItem<TravelStaffItem> TRAVEL_STAFF = ITEMS
+        .registerItem("staff_of_travelling", properties -> new TravelStaffItem(new Item.Properties().stacksTo(1)))
+        //.tab(EIOCreativeTabs.GEAR, modifier -> EIOItems.TRAVEL_STAFF.get().addAllVariants(modifier))
+        .setTab(EIOCreativeTabs.GEAR);
 
-    public static final ItemEntry<TravelStaffItem> TRAVEL_STAFF = REGISTRATE
-        .item("staff_of_travelling", TravelStaffItem::new)
-        .properties(props -> props.stacksTo(1))
-        .tab(EIOCreativeTabs.GEAR, modifier -> EIOItems.TRAVEL_STAFF.get().addAllVariants(modifier))
-        .register();
+    public static final EnderDeferredItem<ElectromagnetItem> ELECTROMAGNET = ITEMS
+        .registerItem("electromagnet", properties -> new ElectromagnetItem(new Item.Properties().stacksTo(1)))
+        //.tab(EIOCreativeTabs.GEAR, modifier -> EIOItems.ELECTROMAGNET.get().addAllVariants(modifier))
+        .setTab(EIOCreativeTabs.GEAR);
 
-    public static final ItemEntry<ElectromagnetItem> ELECTROMAGNET = REGISTRATE
-        .item("electromagnet", ElectromagnetItem::new)
-        .tab(EIOCreativeTabs.GEAR, modifier -> EIOItems.ELECTROMAGNET.get().addAllVariants(modifier))
-        .register();
+    public static final EnderDeferredItem<ColdFireIgniter> COLD_FIRE_IGNITER = ITEMS
+        .registerItem("cold_fire_igniter", ColdFireIgniter::new)
+        //.tab(EIOCreativeTabs.GEAR,
+        //    modifier -> EIOItems.COLD_FIRE_IGNITER.get().addAllVariants(modifier)) // TODO: Might PR this to Registrate so its nicer, but I like the footprint.
+        .setTab(EIOCreativeTabs.GEAR);
 
-    public static final ItemEntry<ColdFireIgniter> COLD_FIRE_IGNITER = REGISTRATE
-        .item("cold_fire_igniter", ColdFireIgniter::new)
-        .defaultModel()
-        .tab(EIOCreativeTabs.GEAR,
-            modifier -> EIOItems.COLD_FIRE_IGNITER.get().addAllVariants(modifier)) // TODO: Might PR this to Registrate so its nicer, but I like the footprint.
-        .register();
-
-    // endregion
-
-    // region description
-
-    public static MutableComponent capacitorDescriptionBuilder(String type, String value, String description) {
-        return REGISTRATE.addLang("description", EnderIO.loc("capacitor." + type + "." + value), description);
-    }
 
     // endregion
 
     // region Creative Tab Icons
 
-    public static final ItemEntry<CreativeTabIconItem> CREATIVE_ICON_NONE = dumbItem("enderface_none", CreativeTabIconItem::new).register();
-    public static final ItemEntry<CreativeTabIconItem> CREATIVE_ICON_ITEMS = dumbItem("enderface_items", CreativeTabIconItem::new).register();
-    public static final ItemEntry<CreativeTabIconItem> CREATIVE_ICON_MATERIALS = dumbItem("enderface_materials", CreativeTabIconItem::new).register();
-    public static final ItemEntry<CreativeTabIconItem> CREATIVE_ICON_MACHINES = dumbItem("enderface_machines", CreativeTabIconItem::new).register();
-    public static final ItemEntry<CreativeTabIconItem> CREATIVE_ICON_CONDUITS = dumbItem("enderface_conduits", CreativeTabIconItem::new).register();
-    public static final ItemEntry<CreativeTabIconItem> CREATIVE_ICON_MOBS = dumbItem("enderface_mobs", CreativeTabIconItem::new).register();
-    public static final ItemEntry<CreativeTabIconItem> CREATIVE_ICON_INVPANEL = dumbItem("enderface_invpanel", CreativeTabIconItem::new).register();
+    public static final EnderDeferredItem<CreativeTabIconItem> CREATIVE_ICON_NONE = dumbItem("enderface_none", CreativeTabIconItem::new);
+    public static final EnderDeferredItem<CreativeTabIconItem> CREATIVE_ICON_ITEMS = dumbItem("enderface_items", CreativeTabIconItem::new);
+    public static final EnderDeferredItem<CreativeTabIconItem> CREATIVE_ICON_MATERIALS = dumbItem("enderface_materials", CreativeTabIconItem::new);
+    public static final EnderDeferredItem<CreativeTabIconItem> CREATIVE_ICON_MACHINES = dumbItem("enderface_machines", CreativeTabIconItem::new);
+    public static final EnderDeferredItem<CreativeTabIconItem> CREATIVE_ICON_CONDUITS = dumbItem("enderface_conduits", CreativeTabIconItem::new);
+    public static final EnderDeferredItem<CreativeTabIconItem> CREATIVE_ICON_MOBS = dumbItem("enderface_mobs", CreativeTabIconItem::new);
+    public static final EnderDeferredItem<CreativeTabIconItem> CREATIVE_ICON_INVPANEL = dumbItem("enderface_invpanel", CreativeTabIconItem::new);
 
     // endregion
 
     // region Helpers
 
-    public static <T extends Item> ItemBuilder<T, Registrate> dumbItem(String name, NonNullFunction<Item.Properties, T> factory) {
-        return REGISTRATE.item(name, factory).removeTab(CreativeModeTabs.SEARCH);
+    public static <T extends Item> EnderDeferredItem<T> dumbItem(String name, Function<Item.Properties, T> factory) {
+        return ITEMS.registerItem(name, factory); //.removeTab(CreativeModeTabs.SEARCH); TODO remove tab
     }
 
-    public static ItemBuilder<Item, Registrate> dumbItem(String name) {
-        return REGISTRATE.item(name, Item::new);
-    }
-
-    public static <T extends Item> ItemEntry<T> groupedItem(String name, NonNullFunction<Item.Properties, T> factory, ResourceKey<CreativeModeTab> tab) {
-        return REGISTRATE.item(name, factory).tab(tab).register();
+    public static <T extends Item> EnderDeferredItem<T> groupedItem(String name, Function<Item.Properties, T> factory, ResourceKey<CreativeModeTab> tab) {
+        return ITEMS.registerItem(name, factory).setTab(tab);
     }
 
     // endregion
 
-    public static void register() {}
+    public static void register() {
+        ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+    }
 }

--- a/src/main/java/com/enderio/base/common/init/EIOMenus.java
+++ b/src/main/java/com/enderio/base/common/init/EIOMenus.java
@@ -3,14 +3,17 @@ package com.enderio.base.common.init;
 import com.enderio.EnderIO;
 import com.enderio.base.client.gui.screen.CoordinateMenuScreen;
 import com.enderio.base.common.menu.CoordinateMenu;
-import com.tterrag.registrate.Registrate;
-import com.tterrag.registrate.util.entry.MenuEntry;
+import com.enderio.core.common.registry.EnderDeferredMenu;
+import com.enderio.core.common.registry.EnderMenuRegistry;
+import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
 
 public class EIOMenus {
-    private static final Registrate REGISTRATE = EnderIO.registrate();
+    private static final EnderMenuRegistry MENUS = EnderMenuRegistry.create(EnderIO.MODID);
 
-    public static final MenuEntry<CoordinateMenu> COORDINATE = REGISTRATE.menu("coordinate",
-        CoordinateMenu::factory, () -> CoordinateMenuScreen::new).register();
+    public static final EnderDeferredMenu<CoordinateMenu> COORDINATE = MENUS.registerMenu("coordinate",
+        CoordinateMenu::factory, () -> CoordinateMenuScreen::new);
 
-    public static void register() {}
+    public static void register() {
+        MENUS.register(FMLJavaModLoadingContext.get().getModEventBus());
+    }
 }

--- a/src/main/java/com/enderio/base/common/menu/CoordinateMenu.java
+++ b/src/main/java/com/enderio/base/common/menu/CoordinateMenu.java
@@ -45,8 +45,8 @@ public class CoordinateMenu extends AbstractContainerMenu {
         this.name = name != null ? name : "";
     }
 
-    public static CoordinateMenu factory(@Nullable MenuType<CoordinateMenu> pMenuType, int pContainerId, Inventory inventory, FriendlyByteBuf buf) {
-        return new CoordinateMenu(pMenuType, pContainerId, buf);
+    public static CoordinateMenu factory(int pContainerId, Inventory inventory, FriendlyByteBuf buf) {
+        return new CoordinateMenu(EIOMenus.COORDINATE.get(), pContainerId, buf);
     }
 
     /**

--- a/src/main/java/com/enderio/base/data/loot/DecorLootTable.java
+++ b/src/main/java/com/enderio/base/data/loot/DecorLootTable.java
@@ -1,7 +1,7 @@
 package com.enderio.base.data.loot;
 
 import com.enderio.base.EIONBTKeys;
-import com.tterrag.registrate.providers.loot.RegistrateBlockLootTables;
+import com.enderio.core.data.loot.EnderBlockLootProvider;
 import net.minecraft.advancements.critereon.StatePropertiesPredicate;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SlabBlock;
@@ -16,15 +16,15 @@ import net.minecraft.world.level.storage.loot.providers.nbt.ContextNbtProvider;
 
 public class DecorLootTable {
 
-    public static <T extends Block> void withPaint(RegistrateBlockLootTables loot, T block) {
-        loot.add(block, LootTable
+    public static void withPaint(EnderBlockLootProvider provider, Block block) {
+        provider.add(block, LootTable
             .lootTable()
             .withPool(new LootPool.Builder().add(
                 LootItem.lootTableItem(block).apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy(EIONBTKeys.PAINT, EIONBTKeys.BLOCK_ENTITY_TAG + "." + EIONBTKeys.PAINT)))));
     }
 
-    public static <T extends Block> void paintedSlab(RegistrateBlockLootTables loot, T block) {
-        loot.add(block, LootTable
+    public static <T extends Block> void paintedSlab(EnderBlockLootProvider provider, T block) {
+        provider.add(block, LootTable
             .lootTable()
             .withPool(new LootPool.Builder().add(LootItem
                 .lootTableItem(block)

--- a/src/main/java/com/enderio/base/data/model/block/EIOBlockState.java
+++ b/src/main/java/com/enderio/base/data/model/block/EIOBlockState.java
@@ -5,10 +5,13 @@ import com.enderio.base.common.block.light.PoweredLight;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.RegistrateBlockstateProvider;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.IronBarsBlock;
 import net.minecraft.world.level.block.state.properties.AttachFace;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
 import net.neoforged.neoforge.client.model.generators.ConfiguredModel;
 import net.neoforged.neoforge.client.model.generators.ModelFile;
 import net.neoforged.neoforge.registries.ForgeRegistries;
@@ -32,6 +35,26 @@ public class EIOBlockState {
                 .renderType(prov.mcLoc("cutout_mipped")),
             prov.models()
                 .paneNoSideAlt(ctx.getName().concat("_no_side_alt"), prov.blockTexture(ctx.get()))
+                .renderType(prov.mcLoc("cutout_mipped")));
+    }
+
+    public static <T extends IronBarsBlock> void paneBlock(BlockStateProvider prov, T block) {
+        String name = BuiltInRegistries.BLOCK.getKey(block).getPath();
+        prov.paneBlock(block,
+            prov.models()
+                .panePost(name.concat("_post"), prov.blockTexture(block), prov.blockTexture(block))
+                .renderType(prov.mcLoc("cutout_mipped")),
+            prov.models()
+                .paneSide(name.concat("_side"), prov.blockTexture(block), prov.blockTexture(block))
+                .renderType(prov.mcLoc("cutout_mipped")),
+            prov.models()
+                .paneSideAlt(name.concat("_side_alt"), prov.blockTexture(block), prov.blockTexture(block))
+                .renderType(prov.mcLoc("cutout_mipped")),
+            prov.models()
+                .paneNoSide(name.concat("_no_side"), prov.blockTexture(block))
+                .renderType(prov.mcLoc("cutout_mipped")),
+            prov.models()
+                .paneNoSideAlt(name.concat("_no_side_alt"), prov.blockTexture(block))
                 .renderType(prov.mcLoc("cutout_mipped")));
     }
 

--- a/src/main/java/com/enderio/base/data/model/block/EIOBlockState.java
+++ b/src/main/java/com/enderio/base/data/model/block/EIOBlockState.java
@@ -2,11 +2,8 @@ package com.enderio.base.data.model.block;
 
 import com.enderio.EnderIO;
 import com.enderio.base.common.block.light.PoweredLight;
-import com.tterrag.registrate.providers.DataGenContext;
-import com.tterrag.registrate.providers.RegistrateBlockstateProvider;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.IronBarsBlock;
@@ -14,29 +11,9 @@ import net.minecraft.world.level.block.state.properties.AttachFace;
 import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
 import net.neoforged.neoforge.client.model.generators.ConfiguredModel;
 import net.neoforged.neoforge.client.model.generators.ModelFile;
-import net.neoforged.neoforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
 public class EIOBlockState {
-
-    public static void paneBlock(DataGenContext<Block, ? extends IronBarsBlock> ctx, RegistrateBlockstateProvider prov) {
-        prov.paneBlock(ctx.get(),
-            prov.models()
-                .panePost(ctx.getName().concat("_post"), prov.blockTexture(ctx.get()), prov.blockTexture(ctx.get()))
-                .renderType(prov.mcLoc("cutout_mipped")),
-            prov.models()
-                .paneSide(ctx.getName().concat("_side"), prov.blockTexture(ctx.get()), prov.blockTexture(ctx.get()))
-                .renderType(prov.mcLoc("cutout_mipped")),
-            prov.models()
-                .paneSideAlt(ctx.getName().concat("_side_alt"), prov.blockTexture(ctx.get()), prov.blockTexture(ctx.get()))
-                .renderType(prov.mcLoc("cutout_mipped")),
-            prov.models()
-                .paneNoSide(ctx.getName().concat("_no_side"), prov.blockTexture(ctx.get()))
-                .renderType(prov.mcLoc("cutout_mipped")),
-            prov.models()
-                .paneNoSideAlt(ctx.getName().concat("_no_side_alt"), prov.blockTexture(ctx.get()))
-                .renderType(prov.mcLoc("cutout_mipped")));
-    }
 
     public static <T extends IronBarsBlock> void paneBlock(BlockStateProvider prov, T block) {
         String name = BuiltInRegistries.BLOCK.getKey(block).getPath();
@@ -58,8 +35,8 @@ public class EIOBlockState {
                 .renderType(prov.mcLoc("cutout_mipped")));
     }
 
-    public static void paintedBlock(DataGenContext<Block, ? extends Block> ctx, RegistrateBlockstateProvider prov, Block toCopy, @Nullable Direction itemTextureRotation) {
-        prov.simpleBlock(ctx.get(), prov.models().getBuilder(ctx.getName())
+    public static void paintedBlock(Block block, BlockStateProvider prov, Block toCopy, @Nullable Direction itemTextureRotation) {
+        prov.simpleBlock(block, prov.models().getBuilder(BuiltInRegistries.BLOCK.getKey(block).getPath())
             .customLoader(PaintedBlockModelBuilder::begin)
             .reference(toCopy)
             .itemTextureRotation(itemTextureRotation)
@@ -67,13 +44,13 @@ public class EIOBlockState {
         );
     }
 
-    public static void lightBlock(DataGenContext<Block, ? extends Block> ctx, RegistrateBlockstateProvider prov) {
-        prov.getVariantBuilder(ctx.get()).forAllStates(state -> {
+    public static void lightBlock(BlockStateProvider prov, Block block) {
+        prov.getVariantBuilder(block).forAllStates(state -> {
             Direction facing = state.getValue(PoweredLight.FACING);
             AttachFace face = state.getValue(PoweredLight.FACE);
             boolean powered = state.getValue(PoweredLight.ENABLED);
 
-            ResourceLocation id = ForgeRegistries.BLOCKS.getKey(ctx.get());
+            ResourceLocation id = BuiltInRegistries.BLOCK.getKey(block);
             ModelFile light = prov.models().withExistingParent(id.getPath(), EnderIO.loc("block/lightblock"));
             ModelFile light_powered = prov.models().withExistingParent(id.getPath() + "_powered", EnderIO.loc("block/lightblock"));
             return ConfiguredModel.builder()

--- a/src/main/java/com/enderio/base/data/model/item/GliderItemModel.java
+++ b/src/main/java/com/enderio/base/data/model/item/GliderItemModel.java
@@ -1,19 +1,19 @@
 package com.enderio.base.data.model.item;
 
 import com.enderio.EnderIO;
-import com.tterrag.registrate.providers.RegistrateItemModelProvider;
+import com.enderio.core.data.model.EnderItemModelProvider;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
-import net.neoforged.neoforge.registries.ForgeRegistries;
 
 public class GliderItemModel {
 
-    public static void create(Item item, RegistrateItemModelProvider prov) {
+    public static void create(EnderItemModelProvider prov, Item item) {
 
-        ResourceLocation registryName = ForgeRegistries.ITEMS.getKey(item);
+        ResourceLocation registryName = BuiltInRegistries.ITEM.getKey(item);
         prov.getBuilder(registryName.getNamespace() + ":enderio_glider/" + registryName.getPath())
             .parent(prov.getExistingFile(EnderIO.loc("glider/glider3d")))
             .texture("0", registryName.getNamespace() + ":models/glider/" + registryName.getPath());
-        prov.generated(() -> item);
+        prov.basicItem(item);
     }
 }


### PR DESCRIPTION
# Description

For 1.20.2 we decided to go without Registrate. Instead we wanted a system a bit more simple and closer to neoforge. But the ease of use of having datagen done automatically so you don't forget it is really useful. With the changes made to registries in 1.20.2, it becomes possible to make an extension to the neoforge system to still allow for this automatic datagen.

How it works:
- Extension to the holders to store translations, loot tables, models... builders
- Wrapper around the registries to return a custom holder and register datagen automatically
- During datagen, we iterate over all our items and get the builders needed

Closes #(issue) <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Simplify and automate.
- [ ] Verify it all works
- [ ] Make sure this is what we want.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
