### PR TITLE
Check for dimension in FireCraftingHandler fallback method

### DIFF
--- a/src/main/java/com/enderio/base/common/handler/FireCraftingHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/FireCraftingHandler.java
@@ -148,6 +148,10 @@ public class FireCraftingHandler {
             // Search for any fires that are due to spawn drops.
             long gameTime = event.level.getGameTime();
             for (Map.Entry<FireIndex, Long> fire : FIRE_TRACKER.entrySet()) {
+                if (!fire.getKey().dimension().equals(event.level.dimension())) {
+                    continue;
+                }
+
                 BlockPos pos = fire.getKey().pos();
                 if (gameTime > fire.getValue()) {
                     if (event.level.getBlockState(pos).getBlock() instanceof FireBlock) {


### PR DESCRIPTION
# Description

The fallback method for when doFireTick is disabled doesn't check which dimension the tracked fire belongs to, and thus will end up ignoring fires in dimensions other than the overworld, as the blocks obviously won't be found in the wrong dimension and it simply removes the tracker entries. It also breaks with doFireTick *enabled* when Aether is installed, due to Aether using a wrapped gamerules object to return false for doFireTick in its dimension only.

The fix is very simple, just skip over any non-matching dimension entries when iterating. I tested locally with Aether installed and confirmed it works.

This shouldn't be a breaking change.

Closes #603

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
