### PR TITLE
Fix XP Obelisk draining when other xp fluid is in it.

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/XPObeliskBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/XPObeliskBlockEntity.java
@@ -89,7 +89,7 @@ public class XPObeliskBlockEntity extends MachineBlockEntity {
         // Positive -> Give levels to player ; Negative -> Take levels from player
         if (volumeToRemove > 0) {
             int cappedVolume = (int) Math.min(Integer.MAX_VALUE, volumeToRemove);
-            FluidStack drained = getFluidTankNN().drain(new FluidStack(EIOFluids.XP_JUICE.getSource(), cappedVolume), IFluidHandler.FluidAction.EXECUTE);
+            FluidStack drained = getFluidTankNN().drain(cappedVolume, IFluidHandler.FluidAction.EXECUTE);
             player.giveExperiencePoints(drained.getAmount() / ExperienceUtil.EXP_TO_FLUID);
 
         } else {


### PR DESCRIPTION
# Description

Fix XP Obelisk draining when other xp fluid is in it by making the drain not request our fluid.

Closes #580 <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Things that are yet to be completed for this PR to no longer be a draft.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
