### PR TITLE
NBT Stack -> BE conversion

### DIFF
--- a/src/api/java/com/enderio/api/attachment/NBTAttachment.java
+++ b/src/api/java/com/enderio/api/attachment/NBTAttachment.java
@@ -1,0 +1,32 @@
+package com.enderio.api.attachment;
+
+import net.minecraft.nbt.CompoundTag;
+import net.neoforged.neoforge.common.util.INBTSerializable;
+
+public class NBTAttachment implements INBTSerializable<CompoundTag> {
+
+    private CompoundTag tag;
+
+    // TODO: NEO-PORT: Not happy with this class having an "empty" constructor
+    //       Either needs to be removed somehow, or make this safe to have nulls.
+    public NBTAttachment() {
+    }
+
+    public NBTAttachment(CompoundTag tag) {
+        this.tag = tag;
+    }
+
+    public CompoundTag getTag() {
+        return tag;
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag nbt) {
+        this.tag = nbt;
+    }
+}

--- a/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -21,7 +22,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
-import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -277,4 +277,8 @@ public class EnderBlockEntity extends BlockEntity {
     }
 
     // endregion
+
+    public void copyFromStack(ItemStack stack) {
+        
+    }
 }

--- a/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
@@ -1,6 +1,7 @@
 package com.enderio.machines.common.block;
 
 import com.enderio.base.common.tag.EIOTags;
+import com.enderio.core.common.blockentity.EnderBlockEntity;
 import com.enderio.machines.common.blockentity.base.MachineBlockEntity;
 import com.enderio.regilite.holder.RegiliteBlockEntity;
 import com.mojang.serialization.Codec;
@@ -14,7 +15,9 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -145,5 +148,14 @@ public class MachineBlock extends BaseEntityBlock {
             return machineBlock.getLightEmission();
         }
         return super.getLightEmission(state, level, pos);
+    }
+
+    @Override
+    public void setPlacedBy(Level pLevel, BlockPos pPos, BlockState pState, @Nullable LivingEntity pPlacer, ItemStack pStack) {
+        BlockEntity be = pLevel.getBlockEntity(pPos);
+        if (be instanceof EnderBlockEntity enderBlockEntity) {
+            enderBlockEntity.copyFromStack(pStack);
+        }
+        super.setPlacedBy(pLevel, pPos, pState, pPlacer, pStack);
     }
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -710,8 +710,7 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
         super.copyFromStack(stack);
         if (stack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
             CompoundTag tag = stack.getData(EIOAttachments.NBT_ATTACHMENT).getTag();
-            //TODO get inv since it's not an attachment?
-            //TODO get fluid since it's not an attachment?
+            this.load(tag); //Handles data transfer of anything stored in the BE
         }
     }
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -704,4 +704,14 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
             states.remove(state);
         }
     }
+
+    @Override
+    public void copyFromStack(ItemStack stack) {
+        super.copyFromStack(stack);
+        if (stack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
+            CompoundTag tag = stack.getData(EIOAttachments.NBT_ATTACHMENT).getTag();
+            //TODO get inv since it's not an attachment?
+            //TODO get fluid since it's not an attachment?
+        }
+    }
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/PoweredMachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/PoweredMachineBlockEntity.java
@@ -6,6 +6,7 @@ import com.enderio.api.io.energy.EnergyIOMode;
 import com.enderio.base.common.blockentity.IMachineInstall;
 import com.enderio.base.common.capacitor.CapacitorUtil;
 import com.enderio.base.common.capacitor.DefaultCapacitorData;
+import com.enderio.base.common.init.EIOAttachments;
 import com.enderio.base.common.item.capacitors.BaseCapacitorItem;
 import com.enderio.core.common.network.slot.NetworkDataSlot;
 import com.enderio.machines.common.MachineNBTKeys;
@@ -32,7 +33,6 @@ import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -373,5 +373,14 @@ public abstract class PoweredMachineBlockEntity extends MachineBlockEntity imple
         //Ideally I would want to use onLoad, but when placing a block this is called before load is done.
         updateMachineState(MachineState.NO_CAPACITOR, requiresCapacitor() && getCapacitorItem().isEmpty());
         updateMachineState(MachineState.NO_POWER, energyStorage.getEnergyStored() <= 0);
+    }
+
+    @Override
+    public void copyFromStack(ItemStack stack) {
+        super.copyFromStack(stack);
+        if (stack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
+            CompoundTag tag = stack.getData(EIOAttachments.NBT_ATTACHMENT).getTag();
+            //TODO get energy since it's not an attachment?
+        }
     }
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/PoweredMachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/PoweredMachineBlockEntity.java
@@ -6,7 +6,6 @@ import com.enderio.api.io.energy.EnergyIOMode;
 import com.enderio.base.common.blockentity.IMachineInstall;
 import com.enderio.base.common.capacitor.CapacitorUtil;
 import com.enderio.base.common.capacitor.DefaultCapacitorData;
-import com.enderio.base.common.init.EIOAttachments;
 import com.enderio.base.common.item.capacitors.BaseCapacitorItem;
 import com.enderio.core.common.network.slot.NetworkDataSlot;
 import com.enderio.machines.common.MachineNBTKeys;
@@ -373,14 +372,5 @@ public abstract class PoweredMachineBlockEntity extends MachineBlockEntity imple
         //Ideally I would want to use onLoad, but when placing a block this is called before load is done.
         updateMachineState(MachineState.NO_CAPACITOR, requiresCapacitor() && getCapacitorItem().isEmpty());
         updateMachineState(MachineState.NO_POWER, energyStorage.getEnergyStored() <= 0);
-    }
-
-    @Override
-    public void copyFromStack(ItemStack stack) {
-        super.copyFromStack(stack);
-        if (stack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
-            CompoundTag tag = stack.getData(EIOAttachments.NBT_ATTACHMENT).getTag();
-            //TODO get energy since it's not an attachment?
-        }
     }
 }

--- a/src/main/java/com/enderio/EnderIO.java
+++ b/src/main/java/com/enderio/EnderIO.java
@@ -12,6 +12,7 @@ import com.enderio.base.common.init.EIOEnchantments;
 import com.enderio.base.common.init.EIOEntities;
 import com.enderio.base.common.init.EIOFluids;
 import com.enderio.base.common.init.EIOItems;
+import com.enderio.base.common.init.EIOLootFunctions;
 import com.enderio.base.common.init.EIOLootModifiers;
 import com.enderio.base.common.init.EIOMenus;
 import com.enderio.base.common.init.EIOParticles;
@@ -103,6 +104,7 @@ public class EnderIO {
         EIOParticles.register(modEventBus);
         EIOEntities.register(modEventBus);
         EIOAttachments.register(modEventBus);
+        EIOLootFunctions.register(modEventBus);
 
         // Run datagen after registrate is finished.
         modEventBus.addListener(EventPriority.LOWEST, this::onGatherData);

--- a/src/main/java/com/enderio/base/common/init/EIOAttachments.java
+++ b/src/main/java/com/enderio/base/common/init/EIOAttachments.java
@@ -1,8 +1,9 @@
 package com.enderio.base.common.init;
 
 import com.enderio.EnderIO;
-import com.enderio.api.attachment.StoredEntityData;
 import com.enderio.api.attachment.CoordinateSelection;
+import com.enderio.api.attachment.NBTAttachment;
+import com.enderio.api.attachment.StoredEntityData;
 import com.enderio.base.common.capacitor.LootCapacitorData;
 import com.enderio.core.common.attachment.AttachmentUtil;
 import com.enderio.core.common.capability.StrictFluidHandlerItemStack;
@@ -11,7 +12,6 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.energy.EnergyStorage;
 import net.neoforged.neoforge.fluids.capability.templates.FluidHandlerItemStack;
-import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 
@@ -40,6 +40,9 @@ public class EIOAttachments {
 
     public static final Supplier<AttachmentType<EnergyStorage>> ITEM_ENERGY_STORAGE
         = ATTACHMENT_TYPES.register("item_energy_storage", AttachmentUtil.itemEnergyStorageAttachment());
+
+    public static final Supplier<AttachmentType<NBTAttachment>> NBT_ATTACHMENT
+        = ATTACHMENT_TYPES.register("nbt_attachment", () -> AttachmentType.serializable(() -> new NBTAttachment()).build());
 
     public static void register(IEventBus bus) {
         ATTACHMENT_TYPES.register(bus);

--- a/src/main/java/com/enderio/base/common/init/EIOLootFunctions.java
+++ b/src/main/java/com/enderio/base/common/init/EIOLootFunctions.java
@@ -2,6 +2,7 @@ package com.enderio.base.common.init;
 
 import com.enderio.EnderIO;
 import com.enderio.base.common.loot.CopyAttachment;
+import com.enderio.base.common.loot.CopyNBT;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
 import net.neoforged.bus.api.IEventBus;
@@ -12,7 +13,8 @@ import java.util.function.Supplier;
 public class EIOLootFunctions {
     private static final DeferredRegister<LootItemFunctionType> LOOT_FUNCTIONS = DeferredRegister.create(Registries.LOOT_FUNCTION_TYPE, EnderIO.MODID);
 
-    public static final Supplier<LootItemFunctionType> COPY_ATTACHMENT = LOOT_FUNCTIONS.register("nbt", () -> new LootItemFunctionType(CopyAttachment.CODEC));
+    public static final Supplier<LootItemFunctionType> COPY_ATTACHMENT = LOOT_FUNCTIONS.register("copy_attachment", () -> new LootItemFunctionType(CopyAttachment.CODEC));
+    public static final Supplier<LootItemFunctionType> COPY_NBT = LOOT_FUNCTIONS.register("copy_nbt", () -> new LootItemFunctionType(CopyNBT.CODEC));
 
     public static void register(IEventBus bus) {
         LOOT_FUNCTIONS.register(bus);

--- a/src/main/java/com/enderio/base/common/init/EIOLootFunctions.java
+++ b/src/main/java/com/enderio/base/common/init/EIOLootFunctions.java
@@ -1,0 +1,20 @@
+package com.enderio.base.common.init;
+
+import com.enderio.EnderIO;
+import com.enderio.base.common.loot.CopyAttachment;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Supplier;
+
+public class EIOLootFunctions {
+    private static final DeferredRegister<LootItemFunctionType> LOOT_FUNCTIONS = DeferredRegister.create(Registries.LOOT_FUNCTION_TYPE, EnderIO.MODID);
+
+    public static final Supplier<LootItemFunctionType> COPY_ATTACHMENT = LOOT_FUNCTIONS.register("nbt", () -> new LootItemFunctionType(CopyAttachment.CODEC));
+
+    public static void register(IEventBus bus) {
+        LOOT_FUNCTIONS.register(bus);
+    }
+}

--- a/src/main/java/com/enderio/base/common/loot/CopyAttachment.java
+++ b/src/main/java/com/enderio/base/common/loot/CopyAttachment.java
@@ -1,0 +1,84 @@
+package com.enderio.base.common.loot;
+
+import com.enderio.api.attachment.NBTAttachment;
+import com.enderio.base.common.init.EIOAttachments;
+import com.enderio.base.common.init.EIOLootFunctions;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.common.util.INBTSerializable;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+//Based on https://github.com/mekanism/Mekanism/blob/1.20.4/src/main/java/mekanism/common/item/loot/CopyContainersLootFunction.java
+
+public class CopyAttachment extends LootItemConditionalFunction {
+
+    public static final Codec<CopyAttachment> CODEC = RecordCodecBuilder.create(instance -> commonFields(instance)
+        .and(NeoForgeRegistries.ATTACHMENT_TYPES.byNameCodec().listOf().fieldOf("types")
+        .forGetter(function -> function.attachments))
+        .apply(instance, CopyAttachment::new)
+    );
+    private final List<AttachmentType<?>> attachments;
+
+    protected CopyAttachment(List<LootItemCondition> pPredicates, List<AttachmentType<?>> attachments) {
+        super(pPredicates);
+        this.attachments = attachments;
+    }
+
+    @Override
+    public LootItemFunctionType getType() {
+        return EIOLootFunctions.COPY_ATTACHMENT.get();
+    }
+
+    @Override
+    protected ItemStack run(ItemStack pStack, LootContext pContext) {
+        BlockEntity blockEntity = pContext.getParamOrNull(LootContextParams.BLOCK_ENTITY);
+        CompoundTag tag = new CompoundTag();
+        for (AttachmentType<?> type : attachments) {
+            if (blockEntity.hasData(type)) {
+                if (blockEntity.getData(type) instanceof INBTSerializable serializable) {
+                    tag.put(NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type).toString(),serializable.serializeNBT());
+                }
+            }
+            if (pStack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
+                pStack.setData(EIOAttachments.NBT_ATTACHMENT, new NBTAttachment(tag));
+            }
+        }
+        return pStack;
+    }
+
+    public static class Builder extends LootItemConditionalFunction.Builder<CopyAttachment.Builder> {
+
+        private final List<AttachmentType<?>> attachments = new ArrayList<>();
+
+        protected Builder() {
+        }
+
+        public Builder copy(AttachmentType<?> type) {
+            attachments.add(type);
+            return this;
+        }
+
+        @Override
+        protected Builder getThis() {
+            return this;
+        }
+
+        @Override
+        public LootItemFunction build() {
+            return new CopyAttachment(getConditions(), this.attachments);
+        }
+    }
+}

--- a/src/main/java/com/enderio/base/common/loot/CopyAttachment.java
+++ b/src/main/java/com/enderio/base/common/loot/CopyAttachment.java
@@ -30,6 +30,7 @@ public class CopyAttachment extends LootItemConditionalFunction {
         .forGetter(function -> function.attachments))
         .apply(instance, CopyAttachment::new)
     );
+
     private final List<AttachmentType<?>> attachments;
 
     protected CopyAttachment(List<LootItemCondition> pPredicates, List<AttachmentType<?>> attachments) {
@@ -46,16 +47,18 @@ public class CopyAttachment extends LootItemConditionalFunction {
     protected ItemStack run(ItemStack pStack, LootContext pContext) {
         BlockEntity blockEntity = pContext.getParamOrNull(LootContextParams.BLOCK_ENTITY);
         CompoundTag tag = new CompoundTag();
+        if (pStack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
+            tag = pStack.getData(EIOAttachments.NBT_ATTACHMENT).getTag();
+        }
         for (AttachmentType<?> type : attachments) {
             if (blockEntity.hasData(type)) {
                 if (blockEntity.getData(type) instanceof INBTSerializable serializable) {
                     tag.put(NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type).toString(),serializable.serializeNBT());
                 }
             }
-            if (pStack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
-                pStack.setData(EIOAttachments.NBT_ATTACHMENT, new NBTAttachment(tag));
-            }
         }
+        pStack.setData(EIOAttachments.NBT_ATTACHMENT, new NBTAttachment(tag));
+
         return pStack;
     }
 

--- a/src/main/java/com/enderio/base/common/loot/CopyNBT.java
+++ b/src/main/java/com/enderio/base/common/loot/CopyNBT.java
@@ -1,0 +1,81 @@
+package com.enderio.base.common.loot;
+
+import com.enderio.api.attachment.NBTAttachment;
+import com.enderio.base.common.init.EIOAttachments;
+import com.enderio.base.common.init.EIOLootFunctions;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CopyNBT extends LootItemConditionalFunction {
+
+    public static final Codec<CopyNBT> CODEC = RecordCodecBuilder.create(instance -> commonFields(instance)
+        .and(Codec.STRING.listOf().fieldOf("keys")
+            .forGetter(function -> function.keys))
+        .apply(instance, CopyNBT::new)
+    );
+
+    private final List<String> keys;
+
+    protected CopyNBT(List<LootItemCondition> pPredicates, List<String> keys) {
+        super(pPredicates);
+        this.keys = keys;
+    }
+
+    @Override
+    protected ItemStack run(ItemStack pStack, LootContext pContext) {
+        BlockEntity blockEntity = pContext.getParamOrNull(LootContextParams.BLOCK_ENTITY);
+        CompoundTag tag = new CompoundTag();
+        if (pStack.hasData(EIOAttachments.NBT_ATTACHMENT)) {
+            tag = pStack.getData(EIOAttachments.NBT_ATTACHMENT).getTag();
+        }
+        for (String key : keys) {
+            CompoundTag serializeNBT = blockEntity.serializeNBT();
+            if (serializeNBT.contains(key)) {
+                tag.put(key, serializeNBT.get(key));
+            }
+        }
+        pStack.setData(EIOAttachments.NBT_ATTACHMENT, new NBTAttachment(tag));
+
+        return pStack;
+    }
+
+    @Override
+    public LootItemFunctionType getType() {
+        return EIOLootFunctions.COPY_NBT.get();
+    }
+
+    public static class Builder extends LootItemConditionalFunction.Builder<CopyNBT.Builder> {
+
+        private final List<String> keys = new ArrayList<>();
+
+        protected Builder() {
+        }
+
+        public CopyNBT.Builder copy(String key) {
+            keys.add(key);
+            return this;
+        }
+
+        @Override
+        protected CopyNBT.Builder getThis() {
+            return this;
+        }
+
+        @Override
+        public LootItemFunction build() {
+            return new CopyNBT(getConditions(), this.keys);
+        }
+    }
+}


### PR DESCRIPTION
# Description

With the 1.20.4 cap changes, we need to review how we transfer from an itemstack of a block to the block entity. Here is an initial idea I had:

The data from the BE is copied to an attachment that only holds nbt data. 
When placing the itemstack, we call a method in the BE that retrieves the nbt and serializes it into the data.

~~Current issues:~~
~~This idea was based on the assumption all data is in an attachment. However, items/energy/fluids are purely a capability, with no underlying attachment. As such I can't load them.~~

Additional Idea:
Second loot method that serialises raw nbt into the attachment (very similar to us moving data to the blockentitytag)
call "load" on the attachment, which loads any data possible from the attachment (so non-attachment BE stuff like energy/items/fluids).

Closes #(issue) <!-- Follow this exact pattern for every issue you've fixed to help GitHub automatically link your PR to the relevant issues -->

<!-- Remove this section if you're submitting an already-complete PR -->
# Todo

- [ ] Things that are yet to be completed for this PR to no longer be a draft.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all done -->
# Checklist:

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
