### PR TITLE
Fix fluid handler not properly filtering

### DIFF
--- a/src/machines/java/com/enderio/machines/common/io/TransferUtil.java
+++ b/src/machines/java/com/enderio/machines/common/io/TransferUtil.java
@@ -2,6 +2,7 @@ package com.enderio.machines.common.io;
 
 import com.enderio.api.io.IOMode;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidUtil;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.items.IItemHandler;
@@ -61,14 +62,19 @@ public class TransferUtil {
         // TODO: Do we want to imitate old behaviour where if we have no fluid, we pull by default?
 
         if (canPush) {
-            int filled = FluidUtil.tryFluidTransfer(otherItemHandler, selfItemHandler, maxDrain, true).getAmount();
+            int filled = 0;
+            for (int i = 0; i < selfItemHandler.getTanks(); i++) {
+                filled += FluidUtil.tryFluidTransfer(otherItemHandler, selfItemHandler, new FluidStack(selfItemHandler.getFluidInTank(i), maxDrain), true).getAmount();
+            }
             if (filled > 0) {
                 return;
             }
         }
 
         if (canPull) {
-            FluidUtil.tryFluidTransfer(selfItemHandler, otherItemHandler, maxDrain, true);
+            for (int i = 0; i < selfItemHandler.getTanks(); i++) {
+                FluidUtil.tryFluidTransfer(selfItemHandler, otherItemHandler, new FluidStack(selfItemHandler.getFluidInTank(i), maxDrain), true).getAmount();
+            }
         }
     }
 


### PR DESCRIPTION
# Description
Seems that during the port + tank rewrite I made some mistakes with regards to tank filtering. Have a look if this fixes everything I say it does, and if there are no more case I've missed.

Fixes
- Not checking the resource in drain.
- Only checking the filter, not the current fluid for validity.
- Not checking the filter on fill.
- Pushing/pulling fluids without stack sensitive calls.

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
