### PR TITLE
adding the ensure compiler plugin

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -30,4 +30,9 @@
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
     </module>
+    <module name="Checker">
+        <module name="BeforeExecutionExclusionFileFilter">
+            <property name="fileNamePattern" value="module\-info\.java$"/>
+        </module>
+    </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -30,9 +30,7 @@
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
     </module>
-    <module name="Checker">
-        <module name="BeforeExecutionExclusionFileFilter">
-            <property name="fileNamePattern" value="module\-info\.java$"/>
-        </module>
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
 </module>

--- a/src/api/java/com/enderio/api/UseOnly.java
+++ b/src/api/java/com/enderio/api/UseOnly.java
@@ -1,14 +1,13 @@
 package com.enderio.api;
 
 import net.neoforged.fml.LogicalSide;
-import net.neoforged.fml.util.thread.EffectiveSide;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 /**
  * Marks a method or field to only be used on a side without using the {@link net.neoforged.api.distmarker.OnlyIn} Annotation
- * Todo: Maybe do some bytecode magic to add a check before each invocation of this method to {@link EffectiveSide#get()} and log a warning and print a stacktrace
+ * This is only a documentation thing, to add a runtime check you can use {@link me.liliandev.ensure.ensures.EnsureSide}
  */
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
 public @interface UseOnly {

--- a/src/api/java/com/enderio/api/conduit/ExtendedConduitData.java
+++ b/src/api/java/com/enderio/api/conduit/ExtendedConduitData.java
@@ -1,6 +1,7 @@
 package com.enderio.api.conduit;
 
 import com.enderio.api.UseOnly;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -76,7 +77,7 @@ public interface ExtendedConduitData<T extends ExtendedConduitData<T>> extends I
         return new CompoundTag();
     }
 
-    @UseOnly(LogicalSide.CLIENT)
+    @EnsureSide(EnsureSide.Side.CLIENT)
     default T deepCopy() {
         return cast();
     }

--- a/src/api/java/com/enderio/api/conduit/TieredConduit.java
+++ b/src/api/java/com/enderio/api/conduit/TieredConduit.java
@@ -2,6 +2,7 @@ package com.enderio.api.conduit;
 
 import com.enderio.api.UseOnly;
 import com.enderio.api.misc.Vector2i;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.LogicalSide;
 
@@ -67,6 +68,7 @@ public abstract class TieredConduit<T extends ExtendedConduitData<T>> implements
     }
 
     @Override
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public ClientConduitData<T> getClientData() {
         return clientConduitData;
     }

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
@@ -17,6 +17,7 @@ import com.enderio.core.common.blockentity.EnderBlockEntity;
 import dev.gigaherz.graph3.Graph;
 import dev.gigaherz.graph3.GraphObject;
 import dev.gigaherz.graph3.Mergeable;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -63,7 +64,8 @@ public class ConduitBlockEntity extends EnderBlockEntity {
     private final ConduitShape shape = new ConduitShape();
 
     private final ConduitBundle bundle;
-    @UseOnly(LogicalSide.CLIENT) private ConduitBundle clientBundle;
+    @UseOnly(LogicalSide.CLIENT)
+    private ConduitBundle clientBundle;
 
     private UpdateState checkConnection = UpdateState.NONE;
 
@@ -91,7 +93,8 @@ public class ConduitBlockEntity extends EnderBlockEntity {
     /**
      * Handle a connection state update from the client.
      */
-    @UseOnly(LogicalSide.SERVER)
+
+    @EnsureSide(EnsureSide.Side.SERVER)
     public void handleConnectionStateUpdate(Direction direction, ConduitType<?> conduitType, DynamicConnectionState connectionState) {
         var connection = bundle.getConnection(direction);
 
@@ -106,7 +109,8 @@ public class ConduitBlockEntity extends EnderBlockEntity {
         updateConnectionToData(conduitType);
     }
 
-    @UseOnly(LogicalSide.SERVER)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public void handleExtendedDataUpdate(ConduitType<?> conduitType, CompoundTag compoundTag) {
         getBundle().getNodeFor(conduitType).getExtendedConduitData().deserializeNBT(level.registryAccess(), compoundTag);
     }

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
@@ -94,7 +94,6 @@ public class ConduitBlockEntity extends EnderBlockEntity {
     /**
      * Handle a connection state update from the client.
      */
-
     @EnsureSide(EnsureSide.Side.SERVER)
     public void handleConnectionStateUpdate(Direction direction, ConduitType<?> conduitType, DynamicConnectionState connectionState) {
         var connection = bundle.getConnection(direction);

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBlockEntity.java
@@ -17,6 +17,7 @@ import com.enderio.core.common.blockentity.EnderBlockEntity;
 import dev.gigaherz.graph3.Graph;
 import dev.gigaherz.graph3.GraphObject;
 import dev.gigaherz.graph3.Mergeable;
+import me.liliandev.ensure.ensures.EnsureNotNull;
 import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -110,7 +111,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
     }
 
 
-    @EnsureSide(EnsureSide.Side.CLIENT)
+    @EnsureSide(EnsureSide.Side.SERVER)
     public void handleExtendedDataUpdate(ConduitType<?> conduitType, CompoundTag compoundTag) {
         getBundle().getNodeFor(conduitType).getExtendedConduitData().deserializeNBT(level.registryAccess(), compoundTag);
     }

--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBundle.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitBundle.java
@@ -6,6 +6,7 @@ import com.enderio.api.conduit.NodeIdentifier;
 import com.enderio.api.registry.EnderIORegistries;
 import com.enderio.conduits.client.ConduitClientSetup;
 import com.enderio.conduits.common.blockentity.connection.DynamicConnectionState;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -405,7 +406,8 @@ public final class ConduitBundle implements INBTSerializable<CompoundTag> {
         dataVersion++;
     }
 
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public ConduitBundle deepCopy() {
         var bundle = new ConduitBundle(() -> {}, pos);
         bundle.types.addAll(types);

--- a/src/conduits/java/com/enderio/conduits/common/types/SimpleConduitType.java
+++ b/src/conduits/java/com/enderio/conduits/common/types/SimpleConduitType.java
@@ -1,16 +1,15 @@
 package com.enderio.conduits.common.types;
 
-import com.enderio.api.UseOnly;
 import com.enderio.api.conduit.ClientConduitData;
 import com.enderio.api.conduit.ConduitMenuData;
 import com.enderio.api.conduit.ConduitType;
 import com.enderio.api.conduit.ExtendedConduitData;
 import com.enderio.api.conduit.ticker.ConduitTicker;
 import com.enderio.api.misc.Vector2i;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
-import net.neoforged.fml.LogicalSide;
 
 import java.util.function.Supplier;
 
@@ -54,7 +53,7 @@ public class SimpleConduitType<T extends ExtendedConduitData<T>> implements Cond
     }
 
     @Override
-    @UseOnly(LogicalSide.CLIENT)
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public ClientConduitData<T> getClientData() {
         return clientConduitData;
     }

--- a/src/conduits/java/com/enderio/conduits/common/types/redstone/RedstoneExtendedData.java
+++ b/src/conduits/java/com/enderio/conduits/common/types/redstone/RedstoneExtendedData.java
@@ -2,6 +2,7 @@ package com.enderio.conduits.common.types.redstone;
 
 import com.enderio.api.conduit.ExtendedConduitData;
 import com.enderio.api.misc.ColorControl;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
@@ -82,6 +83,8 @@ public class RedstoneExtendedData implements ExtendedConduitData<RedstoneExtende
         activeColors.add(color);
     }
 
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public RedstoneExtendedData deepCopy() {
         RedstoneExtendedData redstoneExtendedData = new RedstoneExtendedData();
         redstoneExtendedData.isActive = isActive;

--- a/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -162,7 +162,6 @@ public class EnderBlockEntity extends BlockEntity {
     /**
      * Fire this when you change the value of a {@link NetworkDataSlot} on the client side.
      */
-
     @EnsureSide(EnsureSide.Side.CLIENT)
     public <T> void clientUpdateSlot(@Nullable NetworkDataSlot<T> slot, T value) {
         if (slot == null) {
@@ -181,7 +180,6 @@ public class EnderBlockEntity extends BlockEntity {
     /**
      * Sync the BlockEntity to all tracking players. Don't call this if you don't know what you do
      */
-
     @EnsureSide(EnsureSide.Side.SERVER)
     public void sync() {
         var syncData = createBufferSlotUpdate();
@@ -190,7 +188,6 @@ public class EnderBlockEntity extends BlockEntity {
                 new ServerboundCDataSlotUpdate(getBlockPos(), syncData));
         }
     }
-
 
     @EnsureSide(EnsureSide.Side.CLIENT)
     public void clientHandleBufferSync(RegistryFriendlyByteBuf buf) {
@@ -203,7 +200,6 @@ public class EnderBlockEntity extends BlockEntity {
             task.run();
         }
     }
-
 
     @EnsureSide(EnsureSide.Side.SERVER)
     public void serverHandleBufferChange(RegistryFriendlyByteBuf buf) {

--- a/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -1,10 +1,10 @@
 package com.enderio.core.common.blockentity;
 
-import com.enderio.api.UseOnly;
 import com.enderio.core.common.network.ClientboundDataSlotChange;
 import com.enderio.core.common.network.NetworkDataSlot;
 import com.enderio.core.common.network.ServerboundCDataSlotUpdate;
 import io.netty.buffer.Unpooled;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -20,7 +20,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.network.PacketDistributor;
@@ -163,7 +162,8 @@ public class EnderBlockEntity extends BlockEntity {
     /**
      * Fire this when you change the value of a {@link NetworkDataSlot} on the client side.
      */
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public <T> void clientUpdateSlot(@Nullable NetworkDataSlot<T> slot, T value) {
         if (slot == null) {
             return;
@@ -181,7 +181,8 @@ public class EnderBlockEntity extends BlockEntity {
     /**
      * Sync the BlockEntity to all tracking players. Don't call this if you don't know what you do
      */
-    @UseOnly(LogicalSide.SERVER)
+
+    @EnsureSide(EnsureSide.Side.SERVER)
     public void sync() {
         var syncData = createBufferSlotUpdate();
         if (syncData != null && level instanceof ServerLevel serverLevel) {
@@ -190,7 +191,8 @@ public class EnderBlockEntity extends BlockEntity {
         }
     }
 
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public void clientHandleBufferSync(RegistryFriendlyByteBuf buf) {
         for (int amount = buf.readInt(); amount > 0; amount--) {
             int index = buf.readInt();
@@ -202,7 +204,8 @@ public class EnderBlockEntity extends BlockEntity {
         }
     }
 
-    @UseOnly(LogicalSide.SERVER)
+
+    @EnsureSide(EnsureSide.Side.SERVER)
     public void serverHandleBufferChange(RegistryFriendlyByteBuf buf) {
         int index;
         try {

--- a/src/ensure_plugin/LICENSE.txt
+++ b/src/ensure_plugin/LICENSE.txt
@@ -1,0 +1,2 @@
+The Ensure Compiler Plugin has no license yet and therefore ARR.
+Adding a more open license is on my to do list and will probably be done at some point, if you need this before, ask me.

--- a/src/ensure_plugin/java/me/liliandev/ensure/EnsurePlugin.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/EnsurePlugin.java
@@ -1,0 +1,57 @@
+package me.liliandev.ensure;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.Plugin;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.api.BasicJavacTask;
+import me.liliandev.ensure.setup.EnsureSetup;
+import me.liliandev.ensure.transformerutils.TransformerUtil;
+
+public class EnsurePlugin implements Plugin {
+
+    @Override
+    public String getName() {
+        return "ContextEnsure";
+    }
+
+    @Override
+    public void init(JavacTask task, String... args) {
+        try {
+            EnsureSetup.setup();
+        } catch (Exception e) {
+            throw new IllegalStateException("Setup and opening of required packages failed", e);
+        }
+        TransformerUtil.setContext(((BasicJavacTask) task).getContext());
+        task.addTaskListener(new TaskListener() {
+            @Override
+            public void finished(TaskEvent e) {
+                if (e.getKind() == TaskEvent.Kind.ENTER) {
+                    afterASTBuild(e);
+                }
+            }
+        });
+    }
+
+    private void afterASTBuild(TaskEvent e) {
+        e.getCompilationUnit().accept(new TreeScanner<Void, Void>() {
+
+            private String className = "";
+            @Override
+            public Void visitClass(ClassTree node, Void aVoid) {
+                className = node.getSimpleName().toString();
+                return super.visitClass(node, aVoid);
+            }
+
+            @Override
+            public Void visitMethod(MethodTree methodTree, Void aVoid) {
+                TransformerUtil.handle(methodTree, className);
+                methodTree.getParameters()/*.reversed()*/.forEach(parameter -> TransformerUtil.handle(parameter, methodTree, className));
+                return super.visitMethod(methodTree, aVoid);
+            }
+        }, null);
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/EnsurePlugin.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/EnsurePlugin.java
@@ -49,7 +49,7 @@ public class EnsurePlugin implements Plugin {
             @Override
             public Void visitMethod(MethodTree methodTree, Void aVoid) {
                 TransformerManager.handle(methodTree, className);
-                methodTree.getParameters()/*.reversed()*/.forEach(parameter -> TransformerManager.handle(parameter, methodTree, className));
+                methodTree.getParameters().forEach(parameter -> TransformerManager.handle(parameter, methodTree, className));
                 return super.visitMethod(methodTree, aVoid);
             }
         }, null);

--- a/src/ensure_plugin/java/me/liliandev/ensure/EnsurePlugin.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/EnsurePlugin.java
@@ -36,10 +36,10 @@ public class EnsurePlugin implements Plugin {
         });
     }
 
+    public static String className = "";
     private void afterASTBuild(TaskEvent e) {
         e.getCompilationUnit().accept(new TreeScanner<Void, Void>() {
 
-            private String className = "";
             @Override
             public Void visitClass(ClassTree node, Void aVoid) {
                 className = node.getSimpleName().toString();
@@ -48,8 +48,8 @@ public class EnsurePlugin implements Plugin {
 
             @Override
             public Void visitMethod(MethodTree methodTree, Void aVoid) {
-                TransformerUtil.handle(methodTree, className);
-                methodTree.getParameters()/*.reversed()*/.forEach(parameter -> TransformerUtil.handle(parameter, methodTree, className));
+                TransformerManager.handle(methodTree, className);
+                methodTree.getParameters()/*.reversed()*/.forEach(parameter -> TransformerManager.handle(parameter, methodTree, className));
                 return super.visitMethod(methodTree, aVoid);
             }
         }, null);

--- a/src/ensure_plugin/java/me/liliandev/ensure/TransformerManager.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/TransformerManager.java
@@ -1,0 +1,71 @@
+package me.liliandev.ensure;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.tree.JCTree;
+import me.liliandev.ensure.transformerutils.Handler;
+import me.liliandev.ensure.transformerutils.Transformer;
+import me.liliandev.ensure.transformerutils.TransformerUtil;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+public class TransformerManager {
+    private static final Map<String, Transformer> TRANSFORMERS = findTransformers();
+
+    public static void handle(VariableTree argument, MethodTree tree, String className) {
+        argument.getModifiers().getAnnotations()
+            .stream()
+            .map(TransformerManager::matchTransformer)
+            .filter(tuple -> tuple.b() != null)
+            .forEachOrdered(tuple -> tuple.b().transform(argument, tree, tuple.a(), className));
+    }
+
+    public static void handle(MethodTree tree, String className) {
+        tree.getModifiers().getAnnotations()
+            .stream()
+            .map(TransformerManager::matchTransformer)
+            .filter(tuple -> tuple.b() != null)
+            .forEachOrdered(tuple -> tuple.b().transform(null, tree, tuple.a(), className));
+    }
+
+    private static String getName(AnnotationTree annotation) {
+        if (annotation.getAnnotationType() instanceof JCTree.JCIdent ident) {
+            if (ident.sym == null) {
+                //some java.lang annotations don't get a symbol as they are in java.lang
+                return null;
+            }
+            return ident.sym.flatName().toString();
+        }
+        return null;
+    }
+
+    private static Tuple<AnnotationTree, Transformer> matchTransformer(AnnotationTree annotation) {
+        return new Tuple<>(annotation, TRANSFORMERS.get(getName(annotation)));
+    }
+
+    private static Map<String, Transformer> findTransformers() {
+        return ServiceLoader.load(Transformer.class, TransformerUtil.class.getClassLoader())
+            .stream()
+            .map(transformer -> findMarker(transformer.type()).map(annotation -> new Tuple<>(annotation, transformer.get())))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toMap(tuple -> tuple.a.getName(), tuple -> tuple.b));
+    }
+
+    private static  Optional<Class<? extends Annotation>> findMarker(Class<? extends Transformer> clazz) {
+        Handler annotation = clazz.getAnnotation(Handler.class);
+        if (annotation == null) {
+            return Optional.empty();
+        }
+        return Optional.of(annotation.annotation());
+    }
+
+    private record Tuple<A, B>(A a, B b) {
+
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureInRange.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureInRange.java
@@ -1,0 +1,21 @@
+package me.liliandev.ensure.ensures;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.PARAMETER})
+/**
+ * Adds a range check to primitive Numbers
+ * min  is inclusive
+ * max is exclusive
+ */
+public @interface EnsureInRange {
+
+    long min();
+    long max();
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureInRangeTransformer.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureInRangeTransformer.java
@@ -20,9 +20,10 @@ public class EnsureInRangeTransformer implements Transformer {
 
     @Override
     public void transform(VariableTree variableTree, MethodTree methodTree, AnnotationTree ensuresAnnotation, String className) {
-        if (!TransformerUtil.isPrimitive(variableTree))
-            throw new AnnotationFormatError("Ranges can only be added to primitives @" + className + "." + methodTree.getName() + " argument: " + variableTree.getName());
-
+        if (TransformerUtil.isObject(variableTree)) {
+            throw new AnnotationFormatError(
+                "Ranges can only be added to primitives @" + className + "." + methodTree.getName() + " argument: " + variableTree.getName());
+        }
         JCTree.JCExpression min = getAnnotationArgument(ensuresAnnotation.getArguments().get(0));
         JCTree.JCExpression max = getAnnotationArgument(ensuresAnnotation.getArguments().get(1));
         TransformerUtil.addCheck(methodTree, variableTree, createIfCondition(variableTree, min, max), createErrorMessage(variableTree, min, max));

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureInRangeTransformer.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureInRangeTransformer.java
@@ -1,0 +1,51 @@
+package me.liliandev.ensure.ensures;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
+import me.liliandev.ensure.transformerutils.Handler;
+import me.liliandev.ensure.transformerutils.Transformer;
+import me.liliandev.ensure.transformerutils.TransformerUtil;
+
+import java.lang.annotation.AnnotationFormatError;
+
+@Handler(annotation = EnsureInRange.class)
+public class EnsureInRangeTransformer implements Transformer {
+
+    @Override
+    public void transform(VariableTree variableTree, MethodTree methodTree, AnnotationTree ensuresAnnotation, String className) {
+        if (!TransformerUtil.isPrimitive(variableTree))
+            throw new AnnotationFormatError("Ranges can only be added to primitives @" + className + "." + methodTree.getName() + " argument: " + variableTree.getName());
+
+        JCTree.JCExpression min = getAnnotationArgument(ensuresAnnotation.getArguments().get(0));
+        JCTree.JCExpression max = getAnnotationArgument(ensuresAnnotation.getArguments().get(1));
+        TransformerUtil.addCheck(methodTree, variableTree, createIfCondition(variableTree, min, max), createErrorMessage(variableTree, min, max));
+    }
+
+    private static JCTree.JCExpression getAnnotationArgument(ExpressionTree assignment) {
+        return ((JCTree.JCAssign) assignment).getExpression();
+    }
+
+    private static JCTree.JCBinary createIfCondition(VariableTree argument, JCTree.JCExpression min, JCTree.JCExpression max) {
+        Context context = TransformerUtil.getContext();
+        TreeMaker factory = TreeMaker.instance(context);
+        Names symbolsTable = Names.instance(context);
+        Name argumentId = symbolsTable.fromString(argument.getName().toString());
+        JCTree.JCBinary minCheck = factory.Binary(JCTree.Tag.LT, factory.Ident(argumentId), min);
+        JCTree.JCBinary maxCheck = factory.Binary(JCTree.Tag.GE, factory.Ident(argumentId), max);
+        return factory.Binary(JCTree.Tag.OR, minCheck, maxCheck);
+    }
+
+    private static String createErrorMessage(VariableTree parameter, JCTree.JCExpression min, JCTree.JCExpression max) {
+        String parameterName = parameter.getName().toString();
+        return String.format(
+                "Argument '%s' of type %s should be in range [%s, %s) but was: ",
+                parameterName, parameter.getType(), min.toString(), max.toString());
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureNotNull.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureNotNull.java
@@ -1,0 +1,16 @@
+package me.liliandev.ensure.ensures;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.PARAMETER})
+/**
+ * Adds a null check to non primitive parameters
+ */
+public @interface EnsureNotNull {
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureNotNullTransformer.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureNotNullTransformer.java
@@ -20,9 +20,10 @@ public class EnsureNotNullTransformer implements Transformer {
 
     @Override
     public void transform(VariableTree variableTree, MethodTree methodTree, AnnotationTree ensuresAnnotation, String className) {
-        if (TransformerUtil.isPrimitive(variableTree))
-            throw new AnnotationFormatError("Not null can only be added to non primitives @" + className + "." + methodTree.getName() + " argument: " + variableTree.getName());
-
+        if (TransformerUtil.isPrimitive(variableTree)) {
+            throw new AnnotationFormatError(
+                "Not null can only be added to non primitives @" + className + "." + methodTree.getName() + " argument: " + variableTree.getName());
+        }
         TransformerUtil.addCheck(methodTree, variableTree, createIfCondition(variableTree), createErrorMessage(variableTree));
     }
 

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureNotNullTransformer.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureNotNullTransformer.java
@@ -1,0 +1,45 @@
+package me.liliandev.ensure.ensures;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.TypeTag;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
+import me.liliandev.ensure.transformerutils.Handler;
+import me.liliandev.ensure.transformerutils.Transformer;
+import me.liliandev.ensure.transformerutils.TransformerUtil;
+
+import java.lang.annotation.AnnotationFormatError;
+
+@Handler(annotation = EnsureNotNull.class)
+public class EnsureNotNullTransformer implements Transformer {
+
+    @Override
+    public void transform(VariableTree variableTree, MethodTree methodTree, AnnotationTree ensuresAnnotation, String className) {
+        if (TransformerUtil.isPrimitive(variableTree))
+            throw new AnnotationFormatError("Not null can only be added to non primitives @" + className + "." + methodTree.getName() + " argument: " + variableTree.getName());
+
+        TransformerUtil.addCheck(methodTree, variableTree, createIfCondition(variableTree), createErrorMessage(variableTree));
+    }
+
+    private static JCTree.JCBinary createIfCondition(VariableTree parameter) {
+        Context context = TransformerUtil.getContext();
+        TreeMaker factory = TreeMaker.instance(context);
+        Names symbolsTable = Names.instance(context);
+        Name parameterId = symbolsTable.fromString(parameter.getName().toString());
+        return factory.Binary(JCTree.Tag.EQ,
+                factory.Ident(parameterId),
+                factory.Literal(TypeTag.BOT, null));
+    }
+
+    private static String createErrorMessage(VariableTree parameter) {
+        String parameterName = parameter.getName().toString();
+        return String.format(
+                "Argument '%s' of type %s is marked by @EnsureNotNull but was: ",
+                parameterName, parameter.getType());
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureSide.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureSide.java
@@ -1,0 +1,37 @@
+package me.liliandev.ensure.ensures;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD})
+/**
+ * Adds a range check to primitive Numbers
+ * min  is inclusive
+ * max is exclusive
+ */
+public @interface EnsureSide {
+
+    Side value();
+
+    enum Side {
+        CLIENT,
+        SERVER;
+
+        public boolean isClient() {
+            return this == CLIENT;
+        }
+
+        public boolean isServer() {
+            return this == SERVER;
+        }
+
+        public Side getOpposite() {
+            return this.isClient() ? SERVER : CLIENT;
+        }
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureSideTransformer.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureSideTransformer.java
@@ -19,7 +19,7 @@ public class EnsureSideTransformer implements Transformer {
 
     @Override
     public void transform(VariableTree unusedMethod, MethodTree methodTree, AnnotationTree ensuresAnnotation, String className) {
-        EnsureSide.Side side = getAnnotationArgument(ensuresAnnotation.getArguments().get(0));
+        EnsureSide.Side side = getAnnotationArgument(ensuresAnnotation.getArguments().getFirst());
         TransformerUtil.addCheck(methodTree, unusedMethod, createIfCondition(side), createErrorMessage(side));
     }
 

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureSideTransformer.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/EnsureSideTransformer.java
@@ -1,0 +1,60 @@
+package me.liliandev.ensure.ensures;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Names;
+import me.liliandev.ensure.transformerutils.Handler;
+import me.liliandev.ensure.transformerutils.Transformer;
+import me.liliandev.ensure.transformerutils.TransformerUtil;
+
+@Handler(annotation = EnsureSide.class)
+public class EnsureSideTransformer implements Transformer {
+
+    @Override
+    public void transform(VariableTree unusedMethod, MethodTree methodTree, AnnotationTree ensuresAnnotation, String className) {
+        EnsureSide.Side side = getAnnotationArgument(ensuresAnnotation.getArguments().get(0));
+        TransformerUtil.addCheck(methodTree, unusedMethod, createIfCondition(side), createErrorMessage(side));
+    }
+
+    private static EnsureSide.Side getAnnotationArgument(ExpressionTree assignment) {
+        return ((MemberSelectTree) ((JCTree.JCAssign)assignment).getExpression()).getIdentifier().contentEquals("CLIENT") ? EnsureSide.Side.CLIENT : EnsureSide.Side.SERVER;
+    }
+
+    private static JCTree.JCExpression createIfCondition(EnsureSide.Side side) {
+        Context context = TransformerUtil.getContext();
+        TreeMaker factory = TreeMaker.instance(context);
+        Names symbolsTable = Names.instance(context);
+        JCTree.JCMethodInvocation getSide = factory.Apply(
+                List.nil(),
+                qualifiedName(factory, symbolsTable, "net", "neoforged", "fml", "util", "thread", "EffectiveSide", "get"),
+                List.nil()
+        );
+        JCTree.JCFieldAccess target = factory.Select(qualifiedName(factory, symbolsTable, "net", "neoforged", "fml", "LogicalSide"), symbolsTable.fromString(side.getOpposite()
+                .name()));
+
+        return factory.Binary(JCTree.Tag.EQ,
+                getSide,
+                target);
+    }
+
+    private static JCTree.JCExpression qualifiedName(TreeMaker factory, Names symbolsTable, String... name) {
+        JCTree.JCExpression prior = factory.Ident(symbolsTable.fromString(name[0]));
+        for(int i = 1; i < name.length; i++) {
+            prior = factory.Select(prior, symbolsTable.fromString(name[i]));
+        }
+        return prior;
+    }
+
+    private static String createErrorMessage(EnsureSide.Side side) {
+        return String.format(
+                "Method should be called on %s but was called on %s",
+                side.toString(), side.getOpposite().toString());
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/ensures/package-info.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/ensures/package-info.java
@@ -1,0 +1,1 @@
+package me.liliandev.ensure.ensures;

--- a/src/ensure_plugin/java/me/liliandev/ensure/package-info.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/package-info.java
@@ -1,0 +1,1 @@
+package me.liliandev.ensure;

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/EnsureSetup.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/EnsureSetup.java
@@ -1,0 +1,54 @@
+package me.liliandev.ensure.setup;
+
+import me.liliandev.ensure.EnsurePlugin;
+import me.liliandev.ensure.setup.jdkdummy.Parent;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+//Stolen from lombok tysm
+public class EnsureSetup {
+
+    private static final String[] expectedPackages = new String[] {
+            "com.sun.tools.javac.api",
+            "com.sun.tools.javac.util",
+            "com.sun.tools.javac.tree",
+            "com.sun.tools.javac.code",
+            "com.sun.tools.javac.processing"
+    };
+
+    public static void setup() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Module module = EnsurePlugin.class.getModule();
+        Module compilerModule = ModuleLayer.boot().findModule("jdk.compiler").orElseThrow(IllegalStateException::new);
+
+        Method m = Module.class.getDeclaredMethod("implAddOpens", String.class, Module.class);
+        Unsafe unsafe = getUnsafe();
+        long firstFieldOffset = getFirstFieldOffset(unsafe);
+        unsafe.putBooleanVolatile(m, firstFieldOffset, true);
+        for (String pckage : expectedPackages) {
+            m.invoke(compilerModule, pckage, module);
+        }
+    }
+
+
+    private static long getFirstFieldOffset(Unsafe unsafe) {
+        try {
+            return unsafe.objectFieldOffset(Parent.class.getDeclaredField("first"));
+        } catch (NoSuchFieldException | SecurityException e) {
+            // can't happen.
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Unsafe getUnsafe() {
+        try {
+            Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+            theUnsafe.setAccessible(true);
+            return (Unsafe) theUnsafe.get(null);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/EnsureSetup.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/EnsureSetup.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Method;
 //Stolen from lombok tysm
 public class EnsureSetup {
 
-    private static final String[] expectedPackages = new String[] {
+    private static final String[] EXPECTED_PACKAGES = new String[] {
             "com.sun.tools.javac.api",
             "com.sun.tools.javac.util",
             "com.sun.tools.javac.tree",
@@ -27,7 +27,7 @@ public class EnsureSetup {
         Unsafe unsafe = getUnsafe();
         long firstFieldOffset = getFirstFieldOffset(unsafe);
         unsafe.putBooleanVolatile(m, firstFieldOffset, true);
-        for (String pckage : expectedPackages) {
+        for (String pckage : EXPECTED_PACKAGES) {
             m.invoke(compilerModule, pckage, module);
         }
     }

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/Child.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/Child.java
@@ -1,0 +1,9 @@
+package me.liliandev.ensure.setup.jdkdummy;
+
+@SuppressWarnings("all")
+public class Child extends Parent {
+    private transient volatile boolean foo;
+    private transient volatile Object[] bar;
+    private transient volatile Object baz;
+
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/GrandChild.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/GrandChild.java
@@ -1,0 +1,20 @@
+package me.liliandev.ensure.setup.jdkdummy;
+
+
+@SuppressWarnings("all")
+public final class GrandChild extends Child {
+    private Class<?> a;
+    private int b;
+    private String c;
+    private Class<?> d;
+    private Class<?>[] e;
+    private Class<?>[] f;
+    private int g;
+    private transient String h;
+    private transient Object i;
+    private byte[] j;
+    private byte[] k;
+    private byte[] l;
+    private volatile Object m;
+    private Object n;
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/Parent.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/Parent.java
@@ -1,0 +1,12 @@
+package me.liliandev.ensure.setup.jdkdummy;
+
+import java.io.OutputStream;
+
+@SuppressWarnings("all")
+public class Parent {
+    boolean first;
+    static final Object staticObj = OutputStream.class;
+    volatile Object second;
+    private static volatile boolean staticSecond;
+    private static volatile boolean staticThird;
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/Parent.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/Parent.java
@@ -5,7 +5,7 @@ import java.io.OutputStream;
 @SuppressWarnings("all")
 public class Parent {
     boolean first;
-    static final Object staticObj = OutputStream.class;
+    static final Object STATIC_OBJ = OutputStream.class;
     volatile Object second;
     private static volatile boolean staticSecond;
     private static volatile boolean staticThird;

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/package-info.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/jdkdummy/package-info.java
@@ -1,0 +1,3 @@
+package me.liliandev.ensure.setup.jdkdummy;
+
+//Code partially copied from projectlombok licensed under MIT (2024)

--- a/src/ensure_plugin/java/me/liliandev/ensure/setup/package-info.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/setup/package-info.java
@@ -1,0 +1,3 @@
+package me.liliandev.ensure.setup;
+
+//Code partially copied from projectlombok licensed under MIT (2024)

--- a/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/Handler.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/Handler.java
@@ -1,0 +1,13 @@
+package me.liliandev.ensure.transformerutils;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Handler {
+    Class<? extends Annotation> annotation();
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/Transformer.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/Transformer.java
@@ -1,0 +1,10 @@
+package me.liliandev.ensure.transformerutils;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+
+public interface Transformer {
+
+    void transform(VariableTree variableTree, MethodTree methodTree, AnnotationTree ensuresAnnotation, String className);
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
@@ -9,7 +9,6 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
-import me.liliandev.ensure.EnsurePlugin;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -17,7 +16,6 @@ import java.util.stream.Stream;
 
 public class TransformerUtil {
     private static final Set<String> PRIMITIVES = Stream.of(byte.class, short.class, char.class, int.class, long.class, float.class, double.class).map(Class::getName).collect(Collectors.toUnmodifiableSet());
-
 
     private static Context context = null;
 
@@ -50,12 +48,10 @@ public class TransformerUtil {
         boolean shouldDelayCheck1Statement = false;
         if (!body.stats.isEmpty()) {
             JCTree.JCStatement firstStatement = body.stats.getFirst();
-            if (EnsurePlugin.className.contains("ConduitBlockEntity")) {
-                if (firstStatement instanceof JCTree.JCExpressionStatement potentialConstructor) {
-                    if (potentialConstructor.getExpression() instanceof JCTree.JCMethodInvocation methodInvocation) {
-                        if (methodInvocation.meth instanceof JCTree.JCIdent methodIdentifier && methodIdentifier.name.contentEquals("super")) {
-                            shouldDelayCheck1Statement = true;
-                        }
+            if (firstStatement instanceof JCTree.JCExpressionStatement potentialConstructor) {
+                if (potentialConstructor.getExpression() instanceof JCTree.JCMethodInvocation methodInvocation) {
+                    if (methodInvocation.meth instanceof JCTree.JCIdent methodIdentifier && methodIdentifier.name.contentEquals("super")) {
+                        shouldDelayCheck1Statement = true;
                     }
                 }
             }
@@ -109,13 +105,8 @@ public class TransformerUtil {
                 ));
     }
 
-
-
-
-
     public static Name getParameterId(Names symbolsTable, VariableTree parameter) {
         String parameterName = parameter.getName().toString();
         return symbolsTable.fromString(parameterName);
     }
-
 }

--- a/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
@@ -12,7 +12,6 @@ import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
 
 import java.lang.annotation.Annotation;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -23,7 +22,7 @@ import java.util.stream.Stream;
 public class TransformerUtil {
     private static final Set<String> PRIMITIVES = Stream.of(byte.class, short.class, char.class, int.class, long.class, float.class, double.class).map(Class::getName).collect(Collectors.toUnmodifiableSet());
 
-    private static final Map<String, Transformer> transformers = findTransformers();
+    private static final Map<String, Transformer> TRANSFORMERS = findTransformers();
 
     private static Context context = null;
 
@@ -127,7 +126,7 @@ public class TransformerUtil {
     }
 
     private static Tuple<AnnotationTree, Transformer> matchTransformer(AnnotationTree annotation) {
-        return new Tuple<>(annotation, transformers.get(getName(annotation)));
+        return new Tuple<>(annotation, TRANSFORMERS.get(getName(annotation)));
     }
 
 
@@ -142,8 +141,9 @@ public class TransformerUtil {
 
     private static  Optional<Class<? extends Annotation>> findMarker(Class<? extends Transformer> clazz) {
         Handler annotation = clazz.getAnnotation(Handler.class);
-        if (annotation == null)
+        if (annotation == null) {
             return Optional.empty();
+        }
         return Optional.of(annotation.annotation());
     }
 

--- a/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
@@ -1,0 +1,153 @@
+package me.liliandev.ensure.transformerutils;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.TypeTag;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TransformerUtil {
+    private static final Set<String> PRIMITIVES = Stream.of(byte.class, short.class, char.class, int.class, long.class, float.class, double.class).map(Class::getName).collect(Collectors.toUnmodifiableSet());
+
+    private static final Map<String, Transformer> transformers = findTransformers();
+
+    private static Context context = null;
+
+    public static Context getContext() {
+        return context;
+    }
+
+    public static void setContext(Context context) {
+        TransformerUtil.context = context;
+    }
+
+    public static boolean isPrimitive(VariableTree parameter) {
+        return PRIMITIVES.contains(parameter.getType().toString());
+    }
+
+    public static boolean isObject(VariableTree parameter) {
+        return !isPrimitive(parameter);
+    }
+
+    /**
+     *
+     * @param method the method to add the check to
+     * @param argument the argument to add the check for
+     * @param condition the condition
+     * @param errorMessage the errorMessage, the value of the thing will be printed after the error
+     */
+    public static void addCheck(MethodTree method, VariableTree argument, JCTree.JCExpression condition, String errorMessage) {
+        JCTree.JCIf check = createCheck(argument, condition, getPos(argument, method), errorMessage);
+        JCTree.JCBlock body = (JCTree.JCBlock) method.getBody();
+        body.stats = body.stats.prepend(check);
+    }
+    private static JCTree.JCIf createCheck(VariableTree argument, JCTree.JCExpression condition, int pos, String errorMessage) {
+        Context context = TransformerUtil.getContext();
+        TreeMaker factory = TreeMaker.instance(context);
+        Names symbolsTable = Names.instance(context);
+        return factory.at(pos)
+                .If(factory.Parens(condition),
+                        buildErrorBlock(factory, symbolsTable, argument, errorMessage),
+                        null);
+    }
+
+    public static int getPos(VariableTree argument, MethodTree method) {
+        return argument == null ? ((JCTree)method).pos : ((JCTree)argument).pos;
+    }
+
+    public static JCTree.JCBlock buildErrorBlock(TreeMaker factory, Names symbolsTable, VariableTree argument, String errorMessage) {
+        List<JCTree.JCExpression> content;
+        JCTree.JCLiteral message = factory.Literal(TypeTag.CLASS, errorMessage);
+        if (argument == null) {
+            content = List.of(message);
+        } else {
+            content = List.of(
+                    factory.Binary(
+                            JCTree.Tag.PLUS,
+                            factory.Literal(TypeTag.CLASS, errorMessage),
+                            factory.Ident(getParameterId(symbolsTable, argument))
+                    ));
+        }
+
+        return factory.Block(0,
+                List.of(factory.Throw(factory.NewClass(null,
+                        List.nil(),
+                        factory.Ident(symbolsTable.fromString(IllegalArgumentException.class.getSimpleName())),
+                        content,
+                        null
+                        ))
+                ));
+    }
+
+
+
+    public static void handle(VariableTree argument, MethodTree tree, String className) {
+        argument.getModifiers().getAnnotations()
+                .stream()
+                .map(TransformerUtil::matchTransformer)
+                .filter(tuple -> tuple.b() != null)
+                .forEachOrdered(tuple -> tuple.b().transform(argument, tree, tuple.a(), className));
+    }
+    public static void handle(MethodTree tree, String className) {
+        tree.getModifiers().getAnnotations()
+                .stream()
+                .map(TransformerUtil::matchTransformer)
+                .filter(tuple -> tuple.b() != null)
+                .forEachOrdered(tuple -> tuple.b().transform(null, tree, tuple.a(), className));
+    }
+    public static String getName(AnnotationTree annotation) {
+
+        if (annotation.getAnnotationType() instanceof JCTree.JCIdent ident) {
+            if (ident.sym == null) {
+                //some java.lang annotations don't get a symbol as they are in java.lang
+                return null;
+            }
+            return ident.sym.flatName().toString();
+        }
+        return null;
+    }
+
+    public static Name getParameterId(Names symbolsTable, VariableTree parameter) {
+        String parameterName = parameter.getName().toString();
+        return symbolsTable.fromString(parameterName);
+    }
+
+    private static Tuple<AnnotationTree, Transformer> matchTransformer(AnnotationTree annotation) {
+        return new Tuple<>(annotation, transformers.get(getName(annotation)));
+    }
+
+
+    public static Map<String, Transformer> findTransformers() {
+        return ServiceLoader.load(Transformer.class, TransformerUtil.class.getClassLoader())
+                .stream()
+                .map(transformer -> findMarker(transformer.type()).map(annotation -> new Tuple<>(annotation, transformer.get())))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(tuple -> tuple.a.getName(), tuple -> tuple.b));
+    }
+
+    private static  Optional<Class<? extends Annotation>> findMarker(Class<? extends Transformer> clazz) {
+        Handler annotation = clazz.getAnnotation(Handler.class);
+        if (annotation == null)
+            return Optional.empty();
+        return Optional.of(annotation.annotation());
+    }
+
+    private record Tuple<A, B>(A a, B b) {
+
+    }
+}

--- a/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/TransformerUtil.java
@@ -1,6 +1,5 @@
 package me.liliandev.ensure.transformerutils;
 
-import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.TypeTag;
@@ -10,11 +9,8 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
+import me.liliandev.ensure.EnsurePlugin;
 
-import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,7 +18,6 @@ import java.util.stream.Stream;
 public class TransformerUtil {
     private static final Set<String> PRIMITIVES = Stream.of(byte.class, short.class, char.class, int.class, long.class, float.class, double.class).map(Class::getName).collect(Collectors.toUnmodifiableSet());
 
-    private static final Map<String, Transformer> TRANSFORMERS = findTransformers();
 
     private static Context context = null;
 
@@ -52,7 +47,29 @@ public class TransformerUtil {
     public static void addCheck(MethodTree method, VariableTree argument, JCTree.JCExpression condition, String errorMessage) {
         JCTree.JCIf check = createCheck(argument, condition, getPos(argument, method), errorMessage);
         JCTree.JCBlock body = (JCTree.JCBlock) method.getBody();
-        body.stats = body.stats.prepend(check);
+        boolean shouldDelayCheck1Statement = false;
+        if (!body.stats.isEmpty()) {
+            JCTree.JCStatement firstStatement = body.stats.getFirst();
+            if (EnsurePlugin.className.contains("ConduitBlockEntity")) {
+                if (firstStatement instanceof JCTree.JCExpressionStatement potentialConstructor) {
+                    if (potentialConstructor.getExpression() instanceof JCTree.JCMethodInvocation methodInvocation) {
+                        if (methodInvocation.meth instanceof JCTree.JCIdent methodIdentifier && methodIdentifier.name.contentEquals("super")) {
+                            shouldDelayCheck1Statement = true;
+                        }
+                    }
+                }
+            }
+        }
+        if (shouldDelayCheck1Statement) {
+            List<JCTree.JCStatement> existingStatements = body.stats;
+            body.stats = List.of(existingStatements.getFirst());
+            body.stats = body.stats.append(check);
+            for (int i = 1; i < existingStatements.size(); i++) {
+                body.stats = body.stats.append(existingStatements.get(i));
+            }
+        } else {
+            body.stats = body.stats.prepend(check);
+        }
     }
     private static JCTree.JCIf createCheck(VariableTree argument, JCTree.JCExpression condition, int pos, String errorMessage) {
         Context context = TransformerUtil.getContext();
@@ -94,60 +111,11 @@ public class TransformerUtil {
 
 
 
-    public static void handle(VariableTree argument, MethodTree tree, String className) {
-        argument.getModifiers().getAnnotations()
-                .stream()
-                .map(TransformerUtil::matchTransformer)
-                .filter(tuple -> tuple.b() != null)
-                .forEachOrdered(tuple -> tuple.b().transform(argument, tree, tuple.a(), className));
-    }
-    public static void handle(MethodTree tree, String className) {
-        tree.getModifiers().getAnnotations()
-                .stream()
-                .map(TransformerUtil::matchTransformer)
-                .filter(tuple -> tuple.b() != null)
-                .forEachOrdered(tuple -> tuple.b().transform(null, tree, tuple.a(), className));
-    }
-    public static String getName(AnnotationTree annotation) {
 
-        if (annotation.getAnnotationType() instanceof JCTree.JCIdent ident) {
-            if (ident.sym == null) {
-                //some java.lang annotations don't get a symbol as they are in java.lang
-                return null;
-            }
-            return ident.sym.flatName().toString();
-        }
-        return null;
-    }
 
     public static Name getParameterId(Names symbolsTable, VariableTree parameter) {
         String parameterName = parameter.getName().toString();
         return symbolsTable.fromString(parameterName);
     }
 
-    private static Tuple<AnnotationTree, Transformer> matchTransformer(AnnotationTree annotation) {
-        return new Tuple<>(annotation, TRANSFORMERS.get(getName(annotation)));
-    }
-
-
-    public static Map<String, Transformer> findTransformers() {
-        return ServiceLoader.load(Transformer.class, TransformerUtil.class.getClassLoader())
-                .stream()
-                .map(transformer -> findMarker(transformer.type()).map(annotation -> new Tuple<>(annotation, transformer.get())))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Collectors.toMap(tuple -> tuple.a.getName(), tuple -> tuple.b));
-    }
-
-    private static  Optional<Class<? extends Annotation>> findMarker(Class<? extends Transformer> clazz) {
-        Handler annotation = clazz.getAnnotation(Handler.class);
-        if (annotation == null) {
-            return Optional.empty();
-        }
-        return Optional.of(annotation.annotation());
-    }
-
-    private record Tuple<A, B>(A a, B b) {
-
-    }
 }

--- a/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/package-info.java
+++ b/src/ensure_plugin/java/me/liliandev/ensure/transformerutils/package-info.java
@@ -1,0 +1,1 @@
+package me.liliandev.ensure.transformerutils;

--- a/src/ensure_plugin/java/module-info.java
+++ b/src/ensure_plugin/java/module-info.java
@@ -1,0 +1,5 @@
+module ensureplugin {
+    uses me.liliandev.ensure.transformerutils.Transformer;
+    requires jdk.compiler;
+    requires jdk.unsupported;
+}

--- a/src/ensure_plugin/resources/META-INF/services/com.sun.source.util.Plugin
+++ b/src/ensure_plugin/resources/META-INF/services/com.sun.source.util.Plugin
@@ -1,0 +1,1 @@
+me.liliandev.ensure.EnsurePlugin

--- a/src/ensure_plugin/resources/META-INF/services/me.liliandev.ensure.transformerutils.Transformer
+++ b/src/ensure_plugin/resources/META-INF/services/me.liliandev.ensure.transformerutils.Transformer
@@ -1,0 +1,3 @@
+me.liliandev.ensure.ensures.EnsureNotNullTransformer
+me.liliandev.ensure.ensures.EnsureInRangeTransformer
+me.liliandev.ensure.ensures.EnsureSideTransformer

--- a/src/machines/java/com/enderio/machines/common/attachment/ActionRange.java
+++ b/src/machines/java/com/enderio/machines/common/attachment/ActionRange.java
@@ -6,6 +6,7 @@ import com.enderio.core.common.network.NetworkDataSlot;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.ByteBuf;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.codec.ByteBufCodecs;
@@ -45,7 +46,8 @@ public record ActionRange(int range, boolean isVisible) {
         return new ActionRange(range - 1, isVisible);
     }
 
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public void addClientParticle(ClientLevel level, BlockPos pos, String color) {
         if (!isVisible) {
             return;

--- a/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
@@ -26,6 +26,7 @@ import com.enderio.machines.common.io.item.SingleSlotAccess;
 import com.enderio.machines.common.menu.SoulBinderMenu;
 import com.enderio.machines.common.recipe.RecipeCaches;
 import com.enderio.machines.common.recipe.SoulBindingRecipe;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -128,7 +129,8 @@ public class SoulBinderBlockEntity extends PoweredMachineBlockEntity implements 
 
     // endregion
 
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public int getClientExp() {
         return clientExp;
     }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -18,6 +18,7 @@ import com.enderio.machines.common.io.SidedIOConfigurable;
 import com.enderio.machines.common.io.TransferUtil;
 import com.enderio.machines.common.io.item.MachineInventory;
 import com.enderio.machines.common.io.item.MachineInventoryLayout;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -498,7 +499,8 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
         return pPlayer.canInteractWithBlock(this.worldPosition, 1.5);
     }
 
-    @UseOnly(LogicalSide.SERVER)
+
+    @EnsureSide(EnsureSide.Side.SERVER)
     @Override
     public ItemInteractionResult onWrenched(@Nullable Player player, @Nullable Direction side) {
         if (player == null || level == null) {

--- a/src/main/java/com/enderio/base/common/blockentity/EnderSkullBlockEntity.java
+++ b/src/main/java/com/enderio/base/common/blockentity/EnderSkullBlockEntity.java
@@ -2,6 +2,7 @@ package com.enderio.base.common.blockentity;
 
 import com.enderio.api.UseOnly;
 import com.enderio.base.common.init.EIOBlockEntities;
+import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -15,17 +16,20 @@ public class EnderSkullBlockEntity extends BlockEntity {
         super(EIOBlockEntities.ENDER_SKULL.get(), pos, blockState);
     }
 
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public float getAnimation(float partialTick) {
         return animationticks;
     }
 
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public void setAnimation(float ticks) {
         animationticks = ticks;
     }
 
-    @UseOnly(LogicalSide.CLIENT)
+
+    @EnsureSide(EnsureSide.Side.CLIENT)
     public static void animation(Level level, BlockPos blockPos, BlockState state, EnderSkullBlockEntity enderSkull) {
         if (enderSkull.animationticks > 0) {
             enderSkull.animationticks--;

--- a/src/main/java/com/enderio/base/common/blockentity/Wrenchable.java
+++ b/src/main/java/com/enderio/base/common/blockentity/Wrenchable.java
@@ -11,6 +11,6 @@ import org.jetbrains.annotations.Nullable;
  * An interface that block entities may implement in order to implement special behaviours(other than to rotate the block) when right-clicked with the Yeta wrench.
  */
 public interface Wrenchable {
-    @UseOnly(LogicalSide.CLIENT)
+    @UseOnly(LogicalSide.SERVER)
     ItemInteractionResult onWrenched(@Nullable Player player, @Nullable Direction side);
 }


### PR DESCRIPTION
# Description

This PR adds the Ensure Compiler Plugin, it allows the usage of Ensure[XYZ] Annotations to add bytecode to check certain things. Currently added are null checks, range checks and Side Checks.

## How to add checks

New checks can be added by creating a new Transformer, adding it to the Service, let it Target a new Ensure Annotation using the Target Annotation and then add the code checks in Transformer#transform.

# TODO

- [ ] Add more EnsureNotNull checks to places where we may obtain a null, but don't use it directly, causing delayed npe which are hard to track down
- [x] Test and potentially fix Ensure Annotations on constructors as the checks are inserted as the first statement which may not work when having to call a super constructor

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.