### PR TITLE
Stop capacitors from clearing stored energy when removed

### DIFF
--- a/src/machines/java/com/enderio/machines/common/blockentity/multienergy/MultiEnergyStorageWrapper.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/multienergy/MultiEnergyStorageWrapper.java
@@ -73,7 +73,7 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
 
     @Override
     public int receiveEnergy(int maxReceive, boolean simulate) {
-        if (!canReceive()) {
+        if (!canReceive() || getMaxEnergyStored() == 0) {
             return 0;
         }
 

--- a/src/machines/java/com/enderio/machines/common/io/energy/MachineEnergyStorage.java
+++ b/src/machines/java/com/enderio/machines/common/io/energy/MachineEnergyStorage.java
@@ -117,7 +117,7 @@ public class MachineEnergyStorage implements IMachineEnergyStorage, INBTSerializ
 
     @Override
     public int receiveEnergy(int maxReceive, boolean simulate) {
-        if (!canReceive()) {
+        if (!canReceive() || getMaxEnergyStored() == 0) {
             return 0;
         }
 


### PR DESCRIPTION
# Description

Currently, if a capacitor is removed and energy is inserted all energy will be cleared (if no energy is inserted it's actually fine). This happens because the set energy logic calls `getEnergyStored`, which becomes 0 when no cap is installed due the the max capacity being 0 (even if energy is present). I have fixed this by making `receiveEnergy` short when the capacity is 0, as it is not possible to insert energy in that case. This fixes the issue, and now energy is stored.

P.S.: in case a lower tier capacitor is inserted, the surplus energy will be voided, which is intended.
P.S.S.: This will need to be backported as well.

Closes: #444
<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
