### PR TITLE
Conduit upgrade void

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
@@ -197,25 +197,25 @@ public class ConduitBlock extends Block implements EntityBlock, SimpleWaterlogge
             conduit.getLevel().setBlockAndUpdate(conduit.getBlockPos(), conduit.getBlockState());
         }
 
-        Optional<ItemInteractionResult> result;
+        ItemInteractionResult result;
 
         if (action instanceof RightClickAction.Upgrade upgradeAction) {
             if (!player.getAbilities().instabuild) {
                 stack.shrink(1);
                 player.getInventory().placeItemBackInInventory(upgradeAction.getNotInConduit().getConduitItem().getDefaultInstance());
             }
-            result = Optional.of(ItemInteractionResult.sidedSuccess(isClientSide));
+            result = ItemInteractionResult.sidedSuccess(isClientSide);
         } else if (action instanceof RightClickAction.Insert) {
             if (!player.getAbilities().instabuild) {
                 stack.shrink(1);
             }
 
-            result = Optional.of(ItemInteractionResult.sidedSuccess(isClientSide));
+            result = ItemInteractionResult.sidedSuccess(isClientSide);
         } else {
-            result = Optional.empty();
+            result = ItemInteractionResult.FAIL;
         }
 
-        if (result.isPresent()) {
+        if (result != ItemInteractionResult.FAIL) {
             Level level = conduit.getLevel();
             BlockPos blockpos = conduit.getBlockPos();
 
@@ -226,7 +226,7 @@ public class ConduitBlock extends Block implements EntityBlock, SimpleWaterlogge
             level.gameEvent(GameEvent.BLOCK_PLACE, blockpos, GameEvent.Context.of(player, blockState));
         }
 
-        return result;
+        return Optional.of(result);
     }
 
     private Optional<ItemInteractionResult> handleYeta(ConduitBlockEntity conduit, Player player, ItemStack stack, BlockHitResult hit, boolean isClientSide) {


### PR DESCRIPTION
# Description

Currently, if adding a conduit fails it still runs the vanilla place code that consumes the stack. This is fixed here by returning "FAIL" when the conduit can not be added. 

This methods use of optional is unclear to me, maybe a simple null is better?

fixes: #669 

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
