### PR TITLE
Make tasks use codec (partially)

### DIFF
--- a/src/core/java/com/enderio/core/common/recipes/OutputStack.java
+++ b/src/core/java/com/enderio/core/common/recipes/OutputStack.java
@@ -1,9 +1,8 @@
 package com.enderio.core.common.recipes;
 
-import com.enderio.core.CoreNBTKeys;
 import com.mojang.datafixers.util.Either;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.CompoundTag;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.fluids.FluidStack;
 
@@ -11,7 +10,11 @@ import net.neoforged.neoforge.fluids.FluidStack;
  * An output stack for a recipe.
  * This can be either an item or fluid stack.
  */
-public record OutputStack(Either<ItemStack, FluidStack> stack) {
+public record OutputStack(Either<FluidStack, ItemStack> stack) {
+
+    public static Codec<OutputStack> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+       Codec.either(FluidStack.CODEC, ItemStack.OPTIONAL_CODEC).fieldOf("stack").forGetter(OutputStack::stack)
+    ).apply(instance, OutputStack::new));
 
     /**
      * An empty item stack. Neither an item nor a fluid.
@@ -22,28 +25,28 @@ public record OutputStack(Either<ItemStack, FluidStack> stack) {
      * Create an item output stack.
      */
     public static OutputStack of(ItemStack itemStack) {
-        return new OutputStack(Either.left(itemStack));
+        return new OutputStack(Either.right(itemStack));
     }
 
     /**
      * Create a fluid output stack.
      */
     public static OutputStack of(FluidStack fluidStack) {
-        return new OutputStack(Either.right(fluidStack));
+        return new OutputStack(Either.left(fluidStack));
     }
 
     /**
      * @return The item output or {@link ItemStack#EMPTY} if this isn't an item.
      */
     public ItemStack getItem() {
-        return stack.left().orElse(ItemStack.EMPTY);
+        return stack.right().orElse(ItemStack.EMPTY);
     }
 
     /**
      * @return The fluid output or {@link FluidStack#EMPTY} if this isn't a fluid.
      */
     public FluidStack getFluid() {
-        return stack.right().orElse(FluidStack.EMPTY);
+        return stack.left().orElse(FluidStack.EMPTY);
     }
 
     /**
@@ -77,30 +80,30 @@ public record OutputStack(Either<ItemStack, FluidStack> stack) {
 
     // region Serialization
 
-    /**
-     * Write to NBT.
-     */
-    public CompoundTag serializeNBT(HolderLookup.Provider lookupProvider) {
-        CompoundTag tag = new CompoundTag();
-        if (isItem()) {
-            tag.put(CoreNBTKeys.ITEM, stack.left().get().saveOptional(lookupProvider));
-        } else if (isFluid()) {
-            tag.put(CoreNBTKeys.FLUID, stack.right().get().saveOptional(lookupProvider));
-        }
-        return tag;
-    }
-
-    /**
-     * Read from NBT.
-     */
-    public static OutputStack fromNBT(HolderLookup.Provider lookupProvider, CompoundTag tag) {
-        if (tag.contains(CoreNBTKeys.ITEM)) {
-            return OutputStack.of(ItemStack.parseOptional(lookupProvider, tag.getCompound(CoreNBTKeys.ITEM)));
-        } else if (tag.contains(CoreNBTKeys.FLUID)) {
-            return OutputStack.of(FluidStack.parseOptional(lookupProvider, tag.getCompound(CoreNBTKeys.FLUID)));
-        }
-        return OutputStack.EMPTY;
-    }
+//    /**
+//     * Write to NBT.
+//     */
+//    public CompoundTag serializeNBT(HolderLookup.Provider lookupProvider) {
+//        CompoundTag tag = new CompoundTag();
+//        if (isItem()) {
+//            tag.put(CoreNBTKeys.ITEM, stack.left().get().saveOptional(lookupProvider));
+//        } else if (isFluid()) {
+//            tag.put(CoreNBTKeys.FLUID, stack.right().get().saveOptional(lookupProvider));
+//        }
+//        return tag;
+//    }
+//
+//    /**
+//     * Read from NBT.
+//     */
+//    public static OutputStack fromNBT(HolderLookup.Provider lookupProvider, CompoundTag tag) {
+//        if (tag.contains(CoreNBTKeys.ITEM)) {
+//            return OutputStack.of(ItemStack.parseOptional(lookupProvider, tag.getCompound(CoreNBTKeys.ITEM)));
+//        } else if (tag.contains(CoreNBTKeys.FLUID)) {
+//            return OutputStack.of(FluidStack.parseOptional(lookupProvider, tag.getCompound(CoreNBTKeys.FLUID)));
+//        }
+//        return OutputStack.EMPTY;
+//    }
 
     // endregion
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/AlloySmelterBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/AlloySmelterBlockEntity.java
@@ -9,7 +9,6 @@ import com.enderio.core.common.blockentity.EnderBlockEntity;
 import com.enderio.core.common.network.NetworkDataSlot;
 import com.enderio.machines.common.MachineNBTKeys;
 import com.enderio.machines.common.blockentity.base.PoweredMachineBlockEntity;
-import com.enderio.machines.common.blockentity.task.CraftingMachineTask;
 import com.enderio.machines.common.blockentity.task.PoweredCraftingMachineTask;
 import com.enderio.machines.common.blockentity.task.host.CraftingMachineTaskHost;
 import com.enderio.machines.common.config.MachinesConfig;
@@ -30,7 +29,6 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -318,14 +316,14 @@ public class AlloySmelterBlockEntity extends PoweredMachineBlockEntity {
         }
 
         @Override
-        public void deserializeNBT(HolderLookup.Provider lookupProvider, CompoundTag nbt) {
-            super.deserializeNBT(lookupProvider, nbt);
+        public void load(CompoundTag nbt) {
+            super.load(nbt);
             inputsConsumed = nbt.getInt(MachineNBTKeys.PROCESSED_INPUTS);
         }
 
         @Override
-        public CompoundTag serializeNBT(HolderLookup.Provider lookupProvider) {
-            var tag = super.serializeNBT(lookupProvider);
+        public CompoundTag save() {
+            var tag = super.save();
             tag.putInt(MachineNBTKeys.PROCESSED_INPUTS, inputsConsumed);
             return tag;
         }

--- a/src/machines/java/com/enderio/machines/common/blockentity/PoweredSpawnerBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/PoweredSpawnerBlockEntity.java
@@ -68,7 +68,7 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity impleme
             @Override
             protected @Nullable MachineTask loadTask(HolderLookup.Provider lookupProvider, CompoundTag nbt) {
                 SpawnerMachineTask task = createTask();
-                task.deserializeNBT(lookupProvider, nbt);
+                task.load(nbt);
                 return task;
             }
         };

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/MachineTask.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/MachineTask.java
@@ -1,12 +1,16 @@
 package com.enderio.machines.common.blockentity.task;
 
 import net.minecraft.nbt.CompoundTag;
-import net.neoforged.neoforge.common.util.INBTSerializable;
+import net.minecraft.nbt.Tag;
 
-public interface MachineTask extends INBTSerializable<CompoundTag> {
+public interface MachineTask {
     void tick();
 
     float getProgress();
 
     boolean isCompleted();
+
+    Tag save();
+
+    void load(CompoundTag tag);
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/SpawnerMachineTask.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/SpawnerMachineTask.java
@@ -10,7 +10,6 @@ import com.mojang.serialization.DataResult;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
@@ -34,7 +33,6 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.EventHooks;
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
 import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
-import net.neoforged.neoforge.event.entity.living.MobSpawnEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -247,14 +245,14 @@ public class SpawnerMachineTask implements PoweredMachineTask {
     private static final String KEY_ENERGY_CONSUMED = "EnergyConsumed";
 
     @Override
-    public CompoundTag serializeNBT(HolderLookup.Provider lookupProvider) {
+    public CompoundTag save() {
         CompoundTag nbt = new CompoundTag();
         nbt.putInt(KEY_ENERGY_CONSUMED, energyConsumed);
         return nbt;
     }
 
     @Override
-    public void deserializeNBT(HolderLookup.Provider lookupProvider, CompoundTag nbt) {
+    public void load(CompoundTag nbt) {
         energyConsumed = nbt.getInt(KEY_ENERGY_CONSUMED);
     }
 

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/host/CraftingMachineTaskHost.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/host/CraftingMachineTaskHost.java
@@ -59,7 +59,7 @@ public class CraftingMachineTaskHost<R extends MachineRecipe<T>, T extends Recip
         }
 
         CraftingMachineTask<R, T> task = taskFactory.createTask(getLevel(), recipeInputSupplier.get(), null);
-        task.deserializeNBT(lookupProvider, nbt);
+        task.load(nbt);
         return task;
     }
 

--- a/src/machines/java/com/enderio/machines/common/blockentity/task/host/MachineTaskHost.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/task/host/MachineTaskHost.java
@@ -145,7 +145,7 @@ public abstract class MachineTaskHost {
 
     public void save(HolderLookup.Provider lookupProvider, CompoundTag tag) {
         if (hasTask()) {
-            tag.put(KEY_TASK, getCurrentTask().serializeNBT(lookupProvider));
+            tag.put(KEY_TASK, getCurrentTask().save());
         }
     }
 


### PR DESCRIPTION
# Description

Changes codec serialization to make use of a codec. However, since these are currently still BE, they will be turned into NBT either way. As such I'm unsure if we really need it.

I have not given the alloy smelter a codec, as I think this one field can stay nbt for now. If at one point Mojang goes full codec, we will fix it.

closes: #690


<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
