### PR TITLE
Misc travel improvements

### DIFF
--- a/src/api/java/com/enderio/api/travel/TravelRenderer.java
+++ b/src/api/java/com/enderio/api/travel/TravelRenderer.java
@@ -4,5 +4,5 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.LevelRenderer;
 
 public interface TravelRenderer<T extends TravelTarget> {
-    void render(T travelData, LevelRenderer levelRenderer, PoseStack poseStack, double distanceSquared, boolean active);
+    void render(T travelData, LevelRenderer levelRenderer, PoseStack poseStack, double distanceSquared, boolean active, float partialTick);
 }

--- a/src/main/java/com/enderio/base/client/travel/TravelTargetRendering.java
+++ b/src/main/java/com/enderio/base/client/travel/TravelTargetRendering.java
@@ -42,9 +42,10 @@ public class TravelTargetRendering {
         return (TravelRenderer<T>) RENDERERS.get(type);
     }
 
-    private static <T extends TravelTarget> void render(T target, LevelRenderer levelRender, PoseStack poseStack, double distanceSquared, boolean isActive) {
+    private static <T extends TravelTarget> void render(T target, LevelRenderer levelRender, PoseStack poseStack, double distanceSquared, boolean isActive,
+        float partialTick) {
         //noinspection unchecked
-        getRenderer((TravelTargetType<T>)target.type()).render(target, levelRender, poseStack, distanceSquared, isActive);
+        getRenderer((TravelTargetType<T>)target.type()).render(target, levelRender, poseStack, distanceSquared, isActive, partialTick);
     }
 
     @SubscribeEvent
@@ -80,7 +81,11 @@ public class TravelTargetRendering {
 
             boolean active = activeTarget == target;
 
-            render(target, event.getLevelRenderer(), poseStack, distanceSquared, active);
+            // needed for smooth rendering
+            // the boolean value controls whether it's still smooth while the game world is paused (e.g. /tick freeze)
+            float partialTick = event.getPartialTick().getGameTimeDeltaPartialTick(true);
+
+            render(target, event.getLevelRenderer(), poseStack, distanceSquared, active, partialTick);
             poseStack.popPose();
         }
     }

--- a/src/main/java/com/enderio/base/common/handler/TravelHandler.java
+++ b/src/main/java/com/enderio/base/common/handler/TravelHandler.java
@@ -12,6 +12,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
@@ -71,6 +72,12 @@ public class TravelHandler {
                     player.teleportTo(eventPos.get().x(), eventPos.get().y(), eventPos.get().z());
                     serverPlayer.connection.resetPosition();
                     player.fallDistance = 0;
+
+                    if (player.isInWall()) {
+                        // without this line the player takes 1 tick of damage before their pose changes
+                        player.setPose(Pose.SWIMMING);
+                    }
+
                     player.playNotifySound(SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1F, 1F);
                 } else {
                     player.playNotifySound(SoundEvents.DISPENSER_FAIL, SoundSource.PLAYERS, 1F, 1F);


### PR DESCRIPTION
# Description

Suffocation fix:
In survival teleporting into a 1-block-high gap deals 1 damage before putting you in the swimming pose, this PR just preemptively sets the pose if there would be any suffocation damage.

Travel target rendering:
Minor improvements to text/icon clarity, mainly in keeping them aligned directly to the screen, see below.
<details>
<summary>Demonstration videos</summary>

## Before:
https://github.com/Team-EnderIO/EnderIO/assets/5243039/faa0737a-022d-460f-a343-b3ba8eee6280

## After:

https://github.com/Team-EnderIO/EnderIO/assets/5243039/5484e66c-d26d-442e-b609-734c4ec40cc8

</details>


<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
