### PR TITLE
Rewrite ticking logic to be a bit more performant

### DIFF
--- a/src/api/java/com/enderio/api/grindingball/IGrindingBallData.java
+++ b/src/api/java/com/enderio/api/grindingball/IGrindingBallData.java
@@ -41,10 +41,13 @@ public interface IGrindingBallData {
      * Grinding ball identity value. Used when no bonus grinding ball is installed.
      */
     IGrindingBallData IDENTITY = new IGrindingBallData() {
+
+        public static final ResourceLocation ENDERIO = new ResourceLocation("enderio", "grindingball/identity");
+
         @Override
         public ResourceLocation getGrindingBallId() {
             // ID isn't actually mapped anywhere.
-            return new ResourceLocation("enderio", "grindingball/identity");
+            return ENDERIO;
         }
 
         @Override

--- a/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -150,23 +150,24 @@ public class EnderBlockEntity extends BlockEntity {
 
     @Nullable
     private FriendlyByteBuf createBufferSlotUpdate() {
-        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
-        int amount = 0;
+        List<Integer> needsUpdate = new ArrayList<>();
         for (int i = 0; i < dataSlots.size(); i++) {
-            NetworkDataSlot<?> networkDataSlot = dataSlots.get(i);
-            if (networkDataSlot.needsUpdate()) {
-                amount ++;
-                buf.writeInt(i);
-                networkDataSlot.writeBuffer(buf);
+            if (dataSlots.get(i).needsUpdate()) {
+                needsUpdate.add(i);
             }
         }
-        if (amount == 0) {
+
+        if (needsUpdate.isEmpty()) {
             return null;
         }
-        FriendlyByteBuf result = new FriendlyByteBuf(Unpooled.buffer()); //Use 2 buffers to be able to write the amount of data
-        result.writeInt(amount);
-        result.writeBytes(buf.copy());
-        return result;
+
+        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
+        buf.writeInt(needsUpdate.size());
+        needsUpdate.forEach(i -> {
+            buf.writeInt(i);
+            dataSlots.get(i).writeBuffer(buf);
+        });
+        return buf;
     }
 
     public void addDataSlot(NetworkDataSlot<?> slot) {

--- a/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -37,7 +37,7 @@ public class EnderBlockEntity extends BlockEntity {
 
     public static final String DATA = "Data";
     public static final String INDEX = "Index";
-    private boolean changed = true;
+    private boolean isChangedDeferred = true;
     private final List<NetworkDataSlot<?>> dataSlots = new ArrayList<>();
 
     private final List<Runnable> afterDataSync = new ArrayList<>();
@@ -86,15 +86,15 @@ public class EnderBlockEntity extends BlockEntity {
         if (this.level == null) {
             return;
         }
-        if (changed) {
-            changed = false;
+        if (isChangedDeferred) {
+            isChangedDeferred = false;
             setChanged(level, getBlockPos(), getBlockState());
         }
     }
 
     @Override
     public void setChanged() {
-        this.changed = true;
+        this.isChangedDeferred = true;
     }
 
     // endregion

--- a/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -37,6 +37,7 @@ public class EnderBlockEntity extends BlockEntity {
 
     public static final String DATA = "Data";
     public static final String INDEX = "Index";
+    private boolean changed = true;
     private final List<NetworkDataSlot<?>> dataSlots = new ArrayList<>();
 
     private final List<Runnable> afterDataSync = new ArrayList<>();
@@ -56,6 +57,7 @@ public class EnderBlockEntity extends BlockEntity {
         } else {
             blockEntity.serverTick();
         }
+        blockEntity.endTick();
     }
 
     /**
@@ -74,6 +76,24 @@ public class EnderBlockEntity extends BlockEntity {
      */
     public void clientTick() {
 
+    }
+
+    /**
+     * Perform tick on both client and server, on the end.
+     */
+    public void endTick() {
+        if (this.level != null) {
+            return;
+        }
+        if (changed) {
+            changed = false;
+            setChanged(level, getBlockPos(), getBlockState());
+        }
+    }
+
+    @Override
+    public void setChanged() {
+        this.changed = true;
     }
 
     // endregion

--- a/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/src/core/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -63,26 +63,27 @@ public class EnderBlockEntity extends BlockEntity {
     /**
      * Perform server-side ticking
      */
-    public void serverTick() {
+    @UseOnly(LogicalSide.SERVER)
+    protected void serverTick() {
         // Perform syncing.
-        if (level != null && !level.isClientSide) {
+        if (level != null) {
             sync();
-            level.blockEntityChanged(worldPosition);
         }
     }
 
     /**
      * Perform client side ticking.
      */
-    public void clientTick() {
+    @UseOnly(LogicalSide.CLIENT)
+    protected void clientTick() {
 
     }
 
     /**
      * Perform tick on both client and server, on the end.
      */
-    public void endTick() {
-        if (this.level != null) {
+    protected void endTick() {
+        if (this.level == null) {
             return;
         }
         if (changed) {
@@ -201,6 +202,7 @@ public class EnderBlockEntity extends BlockEntity {
     public void sync() {
         var syncData = createBufferSlotUpdate();
         if (syncData != null) {
+            setChanged();
             CoreNetwork.sendToTracking(level.getChunkAt(getBlockPos()), new S2CDataSlotUpdate(getBlockPos(), syncData));
         }
     }

--- a/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
@@ -69,12 +69,18 @@ public class MachineBlock extends BaseEntityBlock {
     public void neighborChanged(BlockState pState, Level pLevel, BlockPos pPos, Block pBlock, BlockPos pFromPos, boolean pIsMoving) {
         super.neighborChanged(pState, pLevel, pPos, pBlock, pFromPos, pIsMoving);
         updateBlockEntityCache(pLevel, pPos);
+        if (pLevel.getBlockEntity(pPos) instanceof MachineBlockEntity machineBlock) {
+            machineBlock.neighborChanged(pState, pLevel, pPos, pFromPos);
+        }
     }
 
     @Override
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         super.onNeighborChange(state, level, pos, neighbor);
         updateBlockEntityCache(level, pos);
+        if (level.getBlockEntity(pos) instanceof MachineBlockEntity machineBlock) {
+            machineBlock.neighborChanged(state, level, pos, neighbor);
+        }
     }
 
     private void updateBlockEntityCache(LevelReader level, BlockPos pos) {

--- a/src/machines/java/com/enderio/machines/common/blockentity/AlloySmelterBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/AlloySmelterBlockEntity.java
@@ -151,7 +151,7 @@ public class AlloySmelterBlockEntity extends PoweredMachineBlockEntity {
     // region Inventory
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .inputSlot(3, this::acceptSlotInput)
             .slotAccess(INPUTS)

--- a/src/machines/java/com/enderio/machines/common/blockentity/CrafterBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/CrafterBlockEntity.java
@@ -85,7 +85,7 @@ public class CrafterBlockEntity extends PoweredMachineBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout
             .builder()
             .capacitor()

--- a/src/machines/java/com/enderio/machines/common/blockentity/DrainBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/DrainBlockEntity.java
@@ -69,7 +69,7 @@ public class DrainBlockEntity extends PoweredMachineBlockEntity {
     }
 
     @Override
-    public @Nullable MachineInventoryLayout getInventoryLayout() {
+    public @Nullable MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .capacitor()
             .build();

--- a/src/machines/java/com/enderio/machines/common/blockentity/EnchanterBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/EnchanterBlockEntity.java
@@ -42,7 +42,7 @@ public class EnchanterBlockEntity extends MachineBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .inputSlot((slot, stack) -> stack.getItem() == Items.WRITABLE_BOOK)
             .slotAccess(BOOK)

--- a/src/machines/java/com/enderio/machines/common/blockentity/FluidTankBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/FluidTankBlockEntity.java
@@ -152,7 +152,7 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout
             .builder()
             .inputSlot((slot, stack) -> acceptItemFill(stack))

--- a/src/machines/java/com/enderio/machines/common/blockentity/ImpulseHopperBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/ImpulseHopperBlockEntity.java
@@ -35,7 +35,7 @@ public class ImpulseHopperBlockEntity extends PoweredMachineBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .inputSlot(6, (integer, itemStack) -> ItemStack.isSameItemSameTags(itemStack, GHOST.get(integer).getItemStack(this)))
             .slotAccess(INPUT)

--- a/src/machines/java/com/enderio/machines/common/blockentity/MachineState.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/MachineState.java
@@ -23,11 +23,12 @@ public record MachineState(MachineStateType type, MutableComponent component) {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
-
+        }
         MachineState that = (MachineState) o;
         return type == that.type && component == that.component; //Use identity
     }

--- a/src/machines/java/com/enderio/machines/common/blockentity/MachineState.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/MachineState.java
@@ -21,27 +21,21 @@ public record MachineState(MachineStateType type, MutableComponent component) {
     public static final MachineState FULL_OUTPUT = new MachineState(MachineStateType.ERROR, MachineLang.TOOLTIP_OUTPUT_FULL);
     public static final MachineState REDSTONE = new MachineState(MachineStateType.DISABLED, MachineLang.TOOLTIP_BLOCKED_RESTONE);
 
-
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
+        if (this == o)
             return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || getClass() != o.getClass())
             return false;
-        }
-        MachineState that = (MachineState) o;
 
-        if (type != that.type) {
-            return false;
-        }
-        return component.equals(that.component);
+        MachineState that = (MachineState) o;
+        return type == that.type && component == that.component; //Use identity
     }
 
     @Override
     public int hashCode() {
-        int result = type.hashCode();
-        result = 31 * result + component.hashCode();
+        int result = type.ordinal();
+        result = 31 * result + System.identityHashCode(component); //Only hash instance
         return result;
     }
 

--- a/src/machines/java/com/enderio/machines/common/blockentity/PaintingMachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/PaintingMachineBlockEntity.java
@@ -85,7 +85,7 @@ public class PaintingMachineBlockEntity extends PoweredMachineBlockEntity {
     // region Inventory
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .capacitor()
             .inputSlot(this::isValidInput)

--- a/src/machines/java/com/enderio/machines/common/blockentity/PoweredSpawnerBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/PoweredSpawnerBlockEntity.java
@@ -95,7 +95,7 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity {
     // region Inventory
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder().capacitor().build();
     }
 

--- a/src/machines/java/com/enderio/machines/common/blockentity/PrimitiveAlloySmelterBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/PrimitiveAlloySmelterBlockEntity.java
@@ -64,7 +64,7 @@ public class PrimitiveAlloySmelterBlockEntity extends AlloySmelterBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .inputSlot((s, i) -> ForgeHooks.getBurnTime(i, RecipeType.SMELTING) > 0)
             .slotAccess(FUEL)

--- a/src/machines/java/com/enderio/machines/common/blockentity/SagMillBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SagMillBlockEntity.java
@@ -103,7 +103,7 @@ public class SagMillBlockEntity extends PoweredMachineBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .inputSlot(this::isValidInput)
             .slotAccess(INPUT)

--- a/src/machines/java/com/enderio/machines/common/blockentity/SlicerBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SlicerBlockEntity.java
@@ -89,7 +89,7 @@ public class SlicerBlockEntity extends PoweredMachineBlockEntity {
     // region Inventory
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .setStackLimit(1) // Force all input slots to have 1 output
             .inputSlot(6, this::isValidInput)

--- a/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SoulBinderBlockEntity.java
@@ -95,7 +95,7 @@ public class SoulBinderBlockEntity extends PoweredMachineBlockEntity {
     // region Inventory
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .setStackLimit(1)
             .inputSlot((slot, stack) -> stack.is(EIOItems.FILLED_SOUL_VIAL.get()))

--- a/src/machines/java/com/enderio/machines/common/blockentity/SoulEngineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/SoulEngineBlockEntity.java
@@ -74,7 +74,7 @@ public class SoulEngineBlockEntity extends PoweredMachineBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .capacitor()
             .build();

--- a/src/machines/java/com/enderio/machines/common/blockentity/StirlingGeneratorBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/StirlingGeneratorBlockEntity.java
@@ -62,7 +62,7 @@ public class StirlingGeneratorBlockEntity extends PoweredMachineBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
             .inputSlot((slot, stack) -> ForgeHooks.getBurnTime(stack, RecipeType.SMELTING) > 0 && stack.getCraftingRemainingItem().isEmpty())
             .slotAccess(FUEL)

--- a/src/machines/java/com/enderio/machines/common/blockentity/TravelAnchorBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/TravelAnchorBlockEntity.java
@@ -53,7 +53,7 @@ public class TravelAnchorBlockEntity extends MachineBlockEntity {
     }
 
     @Override
-    public @Nullable MachineInventoryLayout getInventoryLayout() {
+    public @Nullable MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder().setStackLimit(1).ghostSlot().slotAccess(GHOST).build();
     }
 

--- a/src/machines/java/com/enderio/machines/common/blockentity/VacuumChestBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/VacuumChestBlockEntity.java
@@ -28,7 +28,7 @@ public class VacuumChestBlockEntity extends VacuumMachineBlockEntity<ItemEntity>
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return extractableGUISlot(MachineInventoryLayout.builder(), 27)
             .slot(slot -> slot.guiInsert().guiExtract().filter((i, s) -> false))
             .build(); //TODO add proper filter slot and predicate

--- a/src/machines/java/com/enderio/machines/common/blockentity/WiredChargerBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/WiredChargerBlockEntity.java
@@ -38,7 +38,7 @@ public class WiredChargerBlockEntity extends PoweredMachineBlockEntity {
     }
 
     @Override
-    public MachineInventoryLayout getInventoryLayout() {
+    public MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout
             .builder()
             .capacitor()

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -114,7 +114,7 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
     // endregion
 
     private Set<MachineState> states = new HashSet<>();
-    private boolean redstoneBlocked;
+    private boolean isRedstoneBlocked;
     @Nullable
     private final MachineInventoryLayout inventoryLayout;
 
@@ -332,7 +332,7 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
     }
 
     public boolean isRedstoneBlocked() {
-        return redstoneBlocked;
+        return isRedstoneBlocked;
     }
 
     public RedstoneControl getRedstoneControl() {
@@ -470,7 +470,7 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
             return false;
         }
 
-        return !redstoneBlocked;
+        return !isRedstoneBlocked;
     }
 
     @Override
@@ -783,7 +783,7 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
         if (supportsRedstoneControl()) {
             boolean active = redstoneControl.isActive(this.level.hasNeighborSignal(worldPosition));
             updateMachineState(MachineState.REDSTONE, !active);
-            this.redstoneBlocked = !active;
+            this.isRedstoneBlocked = !active;
         }
     }
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -33,6 +33,7 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -61,8 +62,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.WeakHashMap;
-
-import static net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
 public abstract class MachineBlockEntity extends EnderBlockEntity implements MenuProvider, IWrenchable {
 
@@ -115,6 +114,9 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
     // endregion
 
     private Set<MachineState> states = new HashSet<>();
+    private boolean redstoneBlocked;
+    @Nullable
+    private final MachineInventoryLayout inventoryLayout;
 
     public MachineBlockEntity(BlockEntityType<?> type, BlockPos worldPosition, BlockState blockState) {
         super(type, worldPosition, blockState);
@@ -124,9 +126,9 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
         addCapabilityProvider(ioConfig);
 
         // If the machine declares an inventory layout, use it to create a handler
-        MachineInventoryLayout slotLayout = getInventoryLayout();
-        if (slotLayout != null) {
-            inventory = createMachineInventory(slotLayout);
+        inventoryLayout = createInventoryLayout();
+        if (inventoryLayout != null) {
+            inventory = createMachineInventory(inventoryLayout);
             addCapabilityProvider(inventory);
         } else {
             inventory = null;
@@ -145,7 +147,10 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
 
         if (supportsRedstoneControl()) {
             redstoneControlDataSlot = new EnumNetworkDataSlot<>(RedstoneControl.class,
-                this::getRedstoneControl, e -> redstoneControl = e);
+                this::getRedstoneControl, e -> {
+                redstoneControl = e;
+                updateRedstone();
+            });
             addDataSlot(redstoneControlDataSlot);
         } else {
             redstoneControlDataSlot = null;
@@ -335,6 +340,7 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
             clientUpdateSlot(redstoneControlDataSlot, redstoneControl);
         } else {
             this.redstoneControl = redstoneControl;
+            updateRedstone();
         }
     }
 
@@ -343,11 +349,19 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
     // region Inventory
 
     /**
-     * Get the block entity's inventory slot layout.
+     * Makes the block entity's inventory slot layout.
+     */
+    @Nullable
+    public MachineInventoryLayout createInventoryLayout() {
+        return null;
+    }
+
+    /**
+     * Gets the block entity's inventory slot layout.
      */
     @Nullable
     public MachineInventoryLayout getInventoryLayout() {
-        return null;
+        return inventoryLayout;
     }
 
     @Nullable
@@ -452,13 +466,13 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
             return false;
         }
 
-        if (supportsRedstoneControl()) {
-            boolean active = redstoneControl.isActive(this.level.hasNeighborSignal(worldPosition));
-            updateMachineState(MachineState.REDSTONE, !active);
-            return active;
-        }
+        return !redstoneBlocked;
+    }
 
-        return true;
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        updateRedstone();
     }
 
     public boolean canActSlow() {
@@ -754,6 +768,18 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
             states.add(state);
         } else {
             states.remove(state);
+        }
+    }
+
+    public void neighborChanged(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
+        updateRedstone();
+    }
+
+    private void updateRedstone() {
+        if (supportsRedstoneControl()) {
+            boolean active = redstoneControl.isActive(this.level.hasNeighborSignal(worldPosition));
+            updateMachineState(MachineState.REDSTONE, !active);
+            this.redstoneBlocked = !active;
         }
     }
 }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/MachineBlockEntity.java
@@ -331,6 +331,10 @@ public abstract class MachineBlockEntity extends EnderBlockEntity implements Men
         return true;
     }
 
+    public boolean isRedstoneBlocked() {
+        return redstoneBlocked;
+    }
+
     public RedstoneControl getRedstoneControl() {
         return redstoneControl;
     }

--- a/src/machines/java/com/enderio/machines/common/blockentity/base/VacuumMachineBlockEntity.java
+++ b/src/machines/java/com/enderio/machines/common/blockentity/base/VacuumMachineBlockEntity.java
@@ -40,7 +40,7 @@ public abstract class VacuumMachineBlockEntity<T extends Entity> extends Machine
 
     @Override
     public void serverTick() {
-        if (this.getRedstoneControl().isActive(level.hasNeighborSignal(worldPosition))) {
+        if (!isRedstoneBlocked()) {
             this.attractEntities(this.getLevel(), this.getBlockPos(), this.getRange());
         }
 
@@ -49,7 +49,7 @@ public abstract class VacuumMachineBlockEntity<T extends Entity> extends Machine
 
     @Override
     public void clientTick() {
-        if (this.getRedstoneControl().isActive(level.hasNeighborSignal(worldPosition))) {
+        if (!isRedstoneBlocked()) {
             this.attractEntities(this.getLevel(), this.getBlockPos(), this.getRange());
         }
 

--- a/src/machines/java/com/enderio/machines/common/io/IOConfig.java
+++ b/src/machines/java/com/enderio/machines/common/io/IOConfig.java
@@ -6,7 +6,6 @@ import com.enderio.api.io.IOMode;
 import com.enderio.base.common.init.EIOCapabilities;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
@@ -167,9 +166,18 @@ public class IOConfig implements IIOConfig {
         return config.equals(ioConfig.config);
     }
 
+    /**
+     * Simplified hashcode impl for EnumMap using ordinal instead of hashcode for enums
+     */
     @Override
     public int hashCode() {
-        return config.hashCode();
+        int h = 0;
+
+        for (var entry : config.entrySet()) {
+            h += entry.getKey().ordinal() ^ (31 * entry.getValue().ordinal());
+        }
+
+        return h;
     }
 
     // endregion


### PR DESCRIPTION
# Description

Changes:
- only call `setChanged` once at the end of the tick
- only call redstone changed on neighbor changed (and updates of the state)
- cache model state ACTIVE property
- cache inventory layout
- cache grinding ball RL
- reimpl IOConfig hash
- force MachineState to use the same Components so Identity checks are possible
- rewrite sync collect data logic to only create a buffer if needed

fixes: 
- energy resetting on load due to cap data not present

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] verify no regressions are made

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
