### PR TITLE
ChunkBoundLookup for Obelisk Managers

### DIFF
--- a/endercore/src/main/java/com/enderio/core/common/util/ChunkBoundLookup.java
+++ b/endercore/src/main/java/com/enderio/core/common/util/ChunkBoundLookup.java
@@ -1,0 +1,56 @@
+package com.enderio.core.common.util;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.ChunkPos;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Implements the concept of a spatial hashmap, bucketed by chunk.
+ */
+public class ChunkBoundLookup<T> {
+    private final Long2ObjectMap<Set<T>> chunkData = new Long2ObjectOpenHashMap<>();
+    private final Reference2ObjectMap<T, Set<ChunkPos>> valueKeys = new Reference2ObjectOpenHashMap<>();
+
+    @Nullable
+    public Set<T> getForChunk(ChunkPos pos) {
+        return chunkData.get(pos.toLong());
+    }
+
+    public void addForChunk(ChunkPos pos, T value) {
+        chunkData.computeIfAbsent(pos.toLong(), k -> new HashSet<>()).add(value);
+        valueKeys.computeIfAbsent(value, k -> new HashSet<>()).add(pos);
+    }
+
+    public void addForRadius(BlockPos pos, int radius, T value) {
+        BlockPos startBlockPos = new BlockPos(pos.getX() - radius, 0, pos.getZ() - radius);
+        BlockPos endBlockPos = new BlockPos(pos.getX() + radius, 0, pos.getZ() + radius);
+
+        ChunkPos startChunkPos = new ChunkPos(startBlockPos);
+        ChunkPos endChunkPos = new ChunkPos(endBlockPos);
+        
+        ChunkPos.rangeClosed(startChunkPos, endChunkPos).forEach(chunkPos -> addForChunk(chunkPos, value));
+    }
+
+    public void remove(T value) {
+        Set<ChunkPos> chunks = valueKeys.get(value);
+        for (ChunkPos chunkPos : chunks) {
+            Set<T> dataAtChunk = chunkData.get(chunkPos.toLong());
+
+            if (dataAtChunk != null) {
+                dataAtChunk.remove(value);
+                if (dataAtChunk.isEmpty()) {
+                    chunkData.remove(chunkPos.toLong());
+                }
+            }
+        }
+
+        valueKeys.remove(value);
+    }
+}

--- a/endercore/src/main/java/com/enderio/core/common/util/ChunkBoundLookup.java
+++ b/endercore/src/main/java/com/enderio/core/common/util/ChunkBoundLookup.java
@@ -1,5 +1,6 @@
 package com.enderio.core.common.util;
 
+import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
@@ -10,6 +11,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Implements the concept of a spatial hashmap, bucketed by chunk.
@@ -23,21 +26,126 @@ public class ChunkBoundLookup<T> {
         return chunkData.get(pos.toLong());
     }
 
-    public void addForChunk(ChunkPos pos, T value) {
+    // region Direct Chunk Manipulation
+
+    /**
+     * Adds a value to a chunk in the lookup.
+     *
+     * @param pos   The chunk to be added to.
+     * @param value The value to add.
+     */
+    public void addToChunk(ChunkPos pos, T value) {
         chunkData.computeIfAbsent(pos.toLong(), k -> new HashSet<>()).add(value);
         valueKeys.computeIfAbsent(value, k -> new HashSet<>()).add(pos);
     }
 
-    public void addForRadius(BlockPos pos, int radius, T value) {
-        BlockPos startBlockPos = new BlockPos(pos.getX() - radius, 0, pos.getZ() - radius);
-        BlockPos endBlockPos = new BlockPos(pos.getX() + radius, 0, pos.getZ() + radius);
+    /**
+     * Remove a value from a chunk in the lookup.
+     *
+     * @param pos   The chunk to be removed from.
+     * @param value The value to remove.
+     */
+    public void removeFromChunk(ChunkPos pos, T value) {
+        if (chunkData.containsKey(pos.toLong())) {
+            chunkData.get(pos.toLong()).remove(value);
+        }
+
+        if (valueKeys.containsKey(value)) {
+            valueKeys.get(value).remove(pos);
+        }
+    }
+
+    // endregion
+
+    // region Chunk and Block Ranges
+
+    /**
+     * Add the given value to the lookup with the given center point and square radius.
+     *
+     * @param centerPos   The center block position of the range.
+     * @param blockRadius The radius (in blocks) of the range.
+     * @param value       The value to add.
+     */
+    public void addForBlockRadius(BlockPos centerPos, int blockRadius, T value) {
+        getBlockRadius(centerPos, blockRadius).forEach(chunkPos -> addToChunk(chunkPos, value));
+    }
+
+    /**
+     * Update the center position and radius of an existing entry efficiently.
+     * Instead of removing from all chunks then adding to all chunks, this only adds and removes the differences.
+     * If the item does not yet exist, behaves the same as addForBlockRadius.
+     *
+     * @param centerPos   The center block position of the range.
+     * @param blockRadius The radius (in blocks) of the range.
+     * @param value       The value to update.
+     */
+    public void updateForBlockRadius(BlockPos centerPos, int blockRadius, T value) {
+        Set<ChunkPos> currentChunks = valueKeys.get(value);
+        if (currentChunks == null) {
+            addForBlockRadius(centerPos, blockRadius, value);
+            return;
+        }
+
+        Set<ChunkPos> newChunks = getBlockRadius(centerPos, blockRadius).collect(Collectors.toSet());
+        bulkUpdate(value, currentChunks, newChunks);
+    }
+
+    /**
+     * Add the given value to the lookup with the given center point and square radius.
+     *
+     * @param centerPos   The center chunk position of the range.
+     * @param chunkRadius The radius (in chunks) of the range.
+     * @param value       The value to add.
+     */
+    public void addForChunkRadius(ChunkPos centerPos, int chunkRadius, T value) {
+        ChunkPos.rangeClosed(centerPos, chunkRadius).forEach(chunkPos -> addToChunk(chunkPos, value));
+    }
+
+    /**
+     * Update the center position and radius of an existing entry efficiently.
+     * Instead of removing from all chunks then adding to all chunks, this only adds and removes the differences.
+     * If the item does not yet exist, behaves the same as addForBlockRadius.
+     *
+     * @param centerPos   The center chunk position of the range.
+     * @param chunkRadius The radius (in chunks) of the range.
+     * @param value       The value to update.
+     */
+    public void updateForChunkRadius(ChunkPos centerPos, int chunkRadius, T value) {
+        Set<ChunkPos> currentChunks = valueKeys.get(value);
+        if (currentChunks == null) {
+            addForChunkRadius(centerPos, chunkRadius, value);
+            return;
+        }
+
+        Set<ChunkPos> newChunks = ChunkPos.rangeClosed(centerPos, chunkRadius).collect(Collectors.toSet());
+        bulkUpdate(value, currentChunks, newChunks);
+    }
+
+    private Stream<ChunkPos> getBlockRadius(BlockPos centerPos, int blockRadius) {
+        BlockPos startBlockPos = new BlockPos(centerPos.getX() - blockRadius, 0, centerPos.getZ() - blockRadius);
+        BlockPos endBlockPos = new BlockPos(centerPos.getX() + blockRadius, 0, centerPos.getZ() + blockRadius);
 
         ChunkPos startChunkPos = new ChunkPos(startBlockPos);
         ChunkPos endChunkPos = new ChunkPos(endBlockPos);
-        
-        ChunkPos.rangeClosed(startChunkPos, endChunkPos).forEach(chunkPos -> addForChunk(chunkPos, value));
+
+        return ChunkPos.rangeClosed(startChunkPos, endChunkPos);
     }
 
+    private void bulkUpdate(T value, Set<ChunkPos> chunksBefore, Set<ChunkPos> chunksAfter) {
+        Sets.SetView<ChunkPos> removedChunks = Sets.difference(chunksBefore, chunksAfter);
+        Sets.SetView<ChunkPos> addedChunks = Sets.difference(chunksAfter, chunksBefore);
+
+        removedChunks.forEach(chunkPos -> removeFromChunk(chunkPos, value));
+        addedChunks.forEach(chunkPos -> addToChunk(chunkPos, value));
+    }
+
+    // endregion
+
+    /**
+     * Remove all instances of this value from the lookup.
+     *
+     * @param value The value to remove.
+     */
     public void remove(T value) {
         Set<ChunkPos> chunks = valueKeys.get(value);
         for (ChunkPos chunkPos : chunks) {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/AversionObeliskBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/AversionObeliskBlockEntity.java
@@ -5,24 +5,22 @@ import com.enderio.base.api.capacitor.QuadraticScalable;
 import com.enderio.base.api.filter.EntityFilter;
 import com.enderio.base.api.io.energy.EnergyIOMode;
 import com.enderio.base.common.init.EIOCapabilities;
+import com.enderio.machines.common.attachment.ActionRange;
 import com.enderio.machines.common.blockentity.base.ObeliskBlockEntity;
 import com.enderio.machines.common.config.MachinesConfig;
 import com.enderio.machines.common.init.MachineBlockEntities;
 import com.enderio.machines.common.io.item.MachineInventoryLayout;
 import com.enderio.machines.common.menu.AversionObeliskMenu;
+import com.enderio.machines.common.obelisk.AversionObeliskManager;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Consumer;
 
 public class AversionObeliskBlockEntity extends ObeliskBlockEntity {
 
@@ -36,13 +34,29 @@ public class AversionObeliskBlockEntity extends ObeliskBlockEntity {
     @Override
     public void setLevel(Level level) {
         super.setLevel(level);
-        NeoForge.EVENT_BUS.addListener(this::spawnEvent);
+
+        if (level instanceof ServerLevel serverLevel) {
+            AversionObeliskManager.getManager(serverLevel).register(this);
+        }
     }
 
     @Override
     public void setRemoved() {
+        if (level instanceof ServerLevel serverLevel) {
+            AversionObeliskManager.getManager(serverLevel).unregister(this);
+        }
+
         super.setRemoved();
-        NeoForge.EVENT_BUS.unregister((Consumer<FinalizeSpawnEvent>)this::spawnEvent);
+    }
+
+    @Override
+    protected void updateLocations() {
+        super.updateLocations();
+
+        // Update range in obelisk manager
+        if (level instanceof ServerLevel serverLevel) {
+            AversionObeliskManager.getManager(serverLevel).update(this);
+        }
     }
 
     @Override
@@ -70,23 +84,27 @@ public class AversionObeliskBlockEntity extends ObeliskBlockEntity {
         return MachinesConfig.CLIENT.BLOCKS.AVERSION_RANGE_COLOR.get();
     }
 
-    @SubscribeEvent
-    public void spawnEvent(FinalizeSpawnEvent event) {
-        if (level == null || level.isClientSide || event.getSpawnType() != MobSpawnType.NATURAL || !event.getLevel().getLevel().dimension().equals(this.level.dimension())) {
-            return;
+    public boolean handleSpawnEvent(FinalizeSpawnEvent event) {
+        if (!isActive()) {
+            return false;
         }
+
         if (FILTER.getItemStack(this).getCapability(EIOCapabilities.Filter.ITEM) instanceof EntityFilter entityFilter) {
             if (!entityFilter.test(event.getEntity())) {
-                return;
+                return false;
             }
         }
+
         if (isActive() && getAABB().contains(event.getX(), event.getY(), event.getZ())) {
             int cost = ENERGY_USAGE.base().get(); //TODO scale on entity and range? The issue is that it needs the energy "now" and can't wait for it like other machines
             int energy = getEnergyStorage().consumeEnergy(cost, true);
             if (energy == cost) {
                 event.setSpawnCancelled(true);
                 getEnergyStorage().consumeEnergy(cost, true);
+                return true;
             }
         }
+
+        return false;
     }
 }

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/RelocatorObeliskBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/RelocatorObeliskBlockEntity.java
@@ -10,21 +10,19 @@ import com.enderio.machines.common.config.MachinesConfig;
 import com.enderio.machines.common.init.MachineBlockEntities;
 import com.enderio.machines.common.io.item.MachineInventoryLayout;
 import com.enderio.machines.common.menu.RelocatorObeliskMenu;
+import com.enderio.machines.common.obelisk.RelocatorObeliskManager;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.EntityTeleportEvent;
 import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Consumer;
 
 public class RelocatorObeliskBlockEntity extends ObeliskBlockEntity {
 
@@ -38,13 +36,29 @@ public class RelocatorObeliskBlockEntity extends ObeliskBlockEntity {
     @Override
     public void setLevel(Level level) {
         super.setLevel(level);
-        NeoForge.EVENT_BUS.addListener(this::spawnEvent);
+
+        if (level instanceof ServerLevel serverLevel) {
+            RelocatorObeliskManager.getManager(serverLevel).register(this);
+        }
     }
 
     @Override
     public void setRemoved() {
+        if (level instanceof ServerLevel serverLevel) {
+            RelocatorObeliskManager.getManager(serverLevel).unregister(this);
+        }
+
         super.setRemoved();
-        NeoForge.EVENT_BUS.unregister((Consumer<FinalizeSpawnEvent>)this::spawnEvent);
+    }
+
+    @Override
+    protected void updateLocations() {
+        super.updateLocations();
+
+        // Update range in obelisk manager
+        if (level instanceof ServerLevel serverLevel) {
+            RelocatorObeliskManager.getManager(serverLevel).update(this);
+        }
     }
 
     @Override
@@ -72,16 +86,13 @@ public class RelocatorObeliskBlockEntity extends ObeliskBlockEntity {
         return MachinesConfig.CLIENT.BLOCKS.RELOCATOR_RANGE_COLOR.get();
     }
 
-    @SubscribeEvent
-    public void spawnEvent(FinalizeSpawnEvent event) {
-        if (level == null || level.isClientSide || event.getSpawnType() != MobSpawnType.NATURAL || !event.getLevel().getLevel().dimension().equals(this.level.dimension())) {
-            return;
-        }
+    public boolean handleSpawnEvent(FinalizeSpawnEvent event) {
         if (FILTER.getItemStack(this).getCapability(EIOCapabilities.Filter.ITEM) instanceof EntityFilter entityFilter) {
             if (!entityFilter.test(event.getEntity())) {
-                return;
+                return false;
             }
         }
+
         if (isActive() && getAABB().contains(event.getX(), event.getY(), event.getZ())) {
             int cost = ENERGY_USAGE.base().get(); //TODO scale on entity and range? The issue is that it needs the energy "now" and can't wait for it like other machines
             int energy = getEnergyStorage().consumeEnergy(cost, true);
@@ -94,8 +105,11 @@ public class RelocatorObeliskBlockEntity extends ObeliskBlockEntity {
                 if (!NeoForge.EVENT_BUS.post(telEvent).isCanceled()) {
                     event.getEntity().teleportTo(x, y, z);
                     getEnergyStorage().consumeEnergy(cost, false);
+                    return true;
                 }
             }
         }
+
+        return false;
     }
 }

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/ObeliskBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/ObeliskBlockEntity.java
@@ -89,7 +89,7 @@ public abstract class ObeliskBlockEntity extends PoweredMachineBlockEntity imple
         updateLocations();
     }
 
-    private void updateLocations() {
+    protected void updateLocations() {
         aabb = new AABB(getBlockPos()).inflate(getRange());
     }
 

--- a/enderio-machines/src/main/java/com/enderio/machines/common/init/MachineAttachments.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/init/MachineAttachments.java
@@ -6,6 +6,8 @@ import com.enderio.machines.common.attachment.ActionRange;
 import com.enderio.machines.common.blockentity.AversionObeliskBlockEntity;
 import com.enderio.machines.common.io.IOConfig;
 import com.enderio.machines.common.obelisk.AversionObeliskManager;
+import com.enderio.machines.common.obelisk.InhibitorObeliskManager;
+import com.enderio.machines.common.obelisk.RelocatorObeliskManager;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -31,6 +33,12 @@ public class MachineAttachments {
 
     public static final Supplier<AttachmentType<AversionObeliskManager>> AVERSION_OBELISK_MANAGER
         = ATTACHMENT_TYPES.register("aversion_obelisk_manager", () -> AttachmentType.builder(AversionObeliskManager::new).build());
+
+    public static final Supplier<AttachmentType<InhibitorObeliskManager>> INHIBITOR_OBELISK_MANAGER
+        = ATTACHMENT_TYPES.register("inhibitor_obelisk_manager", () -> AttachmentType.builder(InhibitorObeliskManager::new).build());
+
+    public static final Supplier<AttachmentType<RelocatorObeliskManager>> RELOCATOR_OBELISK_MANAGER
+        = ATTACHMENT_TYPES.register("relocator_obelisk_manager", () -> AttachmentType.builder(RelocatorObeliskManager::new).build());
 
     public static void register(IEventBus bus) {
         ATTACHMENT_TYPES.register(bus);

--- a/enderio-machines/src/main/java/com/enderio/machines/common/init/MachineAttachments.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/init/MachineAttachments.java
@@ -3,7 +3,9 @@ package com.enderio.machines.common.init;
 import com.enderio.EnderIOBase;
 import com.enderio.base.api.misc.RedstoneControl;
 import com.enderio.machines.common.attachment.ActionRange;
+import com.enderio.machines.common.blockentity.AversionObeliskBlockEntity;
 import com.enderio.machines.common.io.IOConfig;
+import com.enderio.machines.common.obelisk.AversionObeliskManager;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -26,6 +28,9 @@ public class MachineAttachments {
 
     public static final Supplier<AttachmentType<IOConfig>> IO_CONFIG
         = ATTACHMENT_TYPES.register("io_config", () -> AttachmentType.builder(IOConfig::empty).serialize(IOConfig.CODEC).build());
+
+    public static final Supplier<AttachmentType<AversionObeliskManager>> AVERSION_OBELISK_MANAGER
+        = ATTACHMENT_TYPES.register("aversion_obelisk_manager", () -> AttachmentType.builder(AversionObeliskManager::new).build());
 
     public static void register(IEventBus bus) {
         ATTACHMENT_TYPES.register(bus);

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/AversionObeliskManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/AversionObeliskManager.java
@@ -1,0 +1,47 @@
+package com.enderio.machines.common.obelisk;
+
+import com.enderio.machines.EnderIOMachines;
+import com.enderio.machines.common.blockentity.AversionObeliskBlockEntity;
+import com.enderio.machines.common.init.MachineAttachments;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
+
+import java.util.Set;
+
+@EventBusSubscriber(modid = EnderIOMachines.MODULE_MOD_ID, bus = EventBusSubscriber.Bus.GAME)
+public class AversionObeliskManager extends ObeliskAreaManager<AversionObeliskBlockEntity> {
+
+    public static AversionObeliskManager getManager(ServerLevel level) {
+        return level.getData(MachineAttachments.AVERSION_OBELISK_MANAGER);
+    }
+
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public static void onSpawnEvent(FinalizeSpawnEvent event) {
+        if (event.getSpawnType() != MobSpawnType.NATURAL) {
+            return;
+        }
+
+        ServerLevelAccessor levelAccessor = event.getLevel();
+        var pos = new BlockPos((int)event.getX(), (int)event.getY(), (int)event.getZ());
+
+        var obeliskManager = getManager(levelAccessor.getLevel());
+
+        Set<AversionObeliskBlockEntity> obelisks = obeliskManager.getObelisksFor(pos);
+
+        if (obelisks == null || obelisks.isEmpty()) {
+            return;
+        }
+
+        for (AversionObeliskBlockEntity obelisk : obelisks) {
+            if (obelisk.handleSpawnEvent(event)) {
+                break;
+            }
+        }
+    }
+}

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/AversionObeliskManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/AversionObeliskManager.java
@@ -23,14 +23,20 @@ public class AversionObeliskManager extends ObeliskAreaManager<AversionObeliskBl
     @SuppressWarnings("unused")
     @SubscribeEvent
     public static void onSpawnEvent(FinalizeSpawnEvent event) {
+        // Only affects natural spawns
         if (event.getSpawnType() != MobSpawnType.NATURAL) {
             return;
         }
 
+        // If there is no obelisk manager, there is nothing to do.
         ServerLevelAccessor levelAccessor = event.getLevel();
-        var pos = new BlockPos((int)event.getX(), (int)event.getY(), (int)event.getZ());
+        ServerLevel level = levelAccessor.getLevel();
+        if (!level.hasData(MachineAttachments.AVERSION_OBELISK_MANAGER)) {
+            return;
+        }
 
-        var obeliskManager = getManager(levelAccessor.getLevel());
+        var pos = new BlockPos((int)event.getX(), (int)event.getY(), (int)event.getZ());
+        var obeliskManager = getManager(level);
 
         Set<AversionObeliskBlockEntity> obelisks = obeliskManager.getObelisksFor(pos);
         if (obelisks == null || obelisks.isEmpty()) {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/InhibitorObeliskManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/InhibitorObeliskManager.java
@@ -1,0 +1,43 @@
+package com.enderio.machines.common.obelisk;
+
+import com.enderio.machines.EnderIOMachines;
+import com.enderio.machines.common.blockentity.InhibitorObeliskBlockEntity;
+import com.enderio.machines.common.init.MachineAttachments;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.EntityTeleportEvent;
+
+import java.util.Set;
+
+@EventBusSubscriber(modid = EnderIOMachines.MODULE_MOD_ID, bus = EventBusSubscriber.Bus.GAME)
+public class InhibitorObeliskManager extends ObeliskAreaManager<InhibitorObeliskBlockEntity> {
+
+    public static InhibitorObeliskManager getManager(ServerLevel level) {
+        return level.getData(MachineAttachments.INHIBITOR_OBELISK_MANAGER);
+    }
+
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public static void onTeleportEvent(EntityTeleportEvent event) {
+        if (!(event.getEntity().level() instanceof ServerLevel serverLevel)) {
+            return;
+        }
+
+        var pos = new BlockPos((int)event.getTargetX(), (int)event.getTargetY(), (int)event.getTargetZ());
+
+        var obeliskManager = getManager(serverLevel);
+
+        Set<InhibitorObeliskBlockEntity> obelisks = obeliskManager.getObelisksFor(pos);
+        if (obelisks == null || obelisks.isEmpty()) {
+            return;
+        }
+
+        for (InhibitorObeliskBlockEntity obelisk : obelisks) {
+            if (obelisk.handleTeleportEvent(event)) {
+                break;
+            }
+        }
+    }
+}

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/InhibitorObeliskManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/InhibitorObeliskManager.java
@@ -25,6 +25,11 @@ public class InhibitorObeliskManager extends ObeliskAreaManager<InhibitorObelisk
             return;
         }
 
+        // If there is no obelisk manager, there is nothing to do.
+        if (!serverLevel.hasData(MachineAttachments.INHIBITOR_OBELISK_MANAGER)) {
+            return;
+        }
+
         var pos = new BlockPos((int)event.getTargetX(), (int)event.getTargetY(), (int)event.getTargetZ());
 
         var obeliskManager = getManager(serverLevel);

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/ObeliskAreaManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/ObeliskAreaManager.java
@@ -12,7 +12,7 @@ public abstract class ObeliskAreaManager<T extends ObeliskBlockEntity> {
     private final ChunkBoundLookup<T> lookup = new ChunkBoundLookup<>();
 
     public void register(T obelisk) {
-        lookup.addForRadius(obelisk.getBlockPos(), obelisk.getRange(), obelisk);
+        lookup.addForBlockRadius(obelisk.getBlockPos(), obelisk.getRange(), obelisk);
     }
 
     public void unregister(T obelisk) {
@@ -20,9 +20,7 @@ public abstract class ObeliskAreaManager<T extends ObeliskBlockEntity> {
     }
 
     public void update(T obelisk) {
-        // TODO: Do we need to do anything fancier in here? We have enough information to create a "diff" between before and after in the lookup.
-        unregister(obelisk);
-        register(obelisk);
+        lookup.updateForBlockRadius(obelisk.getBlockPos(), obelisk.getRange(), obelisk);
     }
 
     @Nullable

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/ObeliskAreaManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/ObeliskAreaManager.java
@@ -1,0 +1,32 @@
+package com.enderio.machines.common.obelisk;
+
+import com.enderio.core.common.util.ChunkBoundLookup;
+import com.enderio.machines.common.blockentity.base.ObeliskBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.ChunkPos;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+public abstract class ObeliskAreaManager<T extends ObeliskBlockEntity> {
+    private final ChunkBoundLookup<T> lookup = new ChunkBoundLookup<>();
+
+    public void register(T obelisk) {
+        lookup.addForRadius(obelisk.getBlockPos(), obelisk.getRange(), obelisk);
+    }
+
+    public void unregister(T obelisk) {
+        lookup.remove(obelisk);
+    }
+
+    public void update(T obelisk) {
+        // TODO: Do we need to do anything fancier in here? We have enough information to create a "diff" between before and after in the lookup.
+        unregister(obelisk);
+        register(obelisk);
+    }
+
+    @Nullable
+    public Set<T> getObelisksFor(BlockPos pos) {
+        return lookup.getForChunk(new ChunkPos(pos));
+    }
+}

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/RelocatorObeliskManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/RelocatorObeliskManager.java
@@ -1,7 +1,7 @@
 package com.enderio.machines.common.obelisk;
 
 import com.enderio.machines.EnderIOMachines;
-import com.enderio.machines.common.blockentity.AversionObeliskBlockEntity;
+import com.enderio.machines.common.blockentity.RelocatorObeliskBlockEntity;
 import com.enderio.machines.common.init.MachineAttachments;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -14,10 +14,10 @@ import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
 import java.util.Set;
 
 @EventBusSubscriber(modid = EnderIOMachines.MODULE_MOD_ID, bus = EventBusSubscriber.Bus.GAME)
-public class AversionObeliskManager extends ObeliskAreaManager<AversionObeliskBlockEntity> {
+public class RelocatorObeliskManager extends ObeliskAreaManager<RelocatorObeliskBlockEntity> {
 
-    public static AversionObeliskManager getManager(ServerLevel serverLevel) {
-        return serverLevel.getData(MachineAttachments.AVERSION_OBELISK_MANAGER);
+    public static RelocatorObeliskManager getManager(ServerLevel serverLevel) {
+        return serverLevel.getData(MachineAttachments.RELOCATOR_OBELISK_MANAGER);
     }
 
     @SuppressWarnings("unused")
@@ -32,12 +32,12 @@ public class AversionObeliskManager extends ObeliskAreaManager<AversionObeliskBl
 
         var obeliskManager = getManager(levelAccessor.getLevel());
 
-        Set<AversionObeliskBlockEntity> obelisks = obeliskManager.getObelisksFor(pos);
+        Set<RelocatorObeliskBlockEntity> obelisks = obeliskManager.getObelisksFor(pos);
         if (obelisks == null || obelisks.isEmpty()) {
             return;
         }
 
-        for (AversionObeliskBlockEntity obelisk : obelisks) {
+        for (RelocatorObeliskBlockEntity obelisk : obelisks) {
             if (obelisk.handleSpawnEvent(event)) {
                 break;
             }

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/RelocatorObeliskManager.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/RelocatorObeliskManager.java
@@ -23,14 +23,21 @@ public class RelocatorObeliskManager extends ObeliskAreaManager<RelocatorObelisk
     @SuppressWarnings("unused")
     @SubscribeEvent
     public static void onSpawnEvent(FinalizeSpawnEvent event) {
+        // Only affects natural spawns
         if (event.getSpawnType() != MobSpawnType.NATURAL) {
             return;
         }
 
+        // If there is no obelisk manager, there is nothing to do.
         ServerLevelAccessor levelAccessor = event.getLevel();
+        ServerLevel level = levelAccessor.getLevel();
+        if (!level.hasData(MachineAttachments.RELOCATOR_OBELISK_MANAGER)) {
+            return;
+        }
+
         var pos = new BlockPos((int)event.getX(), (int)event.getY(), (int)event.getZ());
 
-        var obeliskManager = getManager(levelAccessor.getLevel());
+        var obeliskManager = getManager(level);
 
         Set<RelocatorObeliskBlockEntity> obelisks = obeliskManager.getObelisksFor(pos);
         if (obelisks == null || obelisks.isEmpty()) {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/package-info.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/obelisk/package-info.java
@@ -1,0 +1,4 @@
+@javax.annotation.ParametersAreNonnullByDefault
+@net.minecraft.MethodsReturnNonnullByDefault
+
+package com.enderio.machines.common.obelisk;


### PR DESCRIPTION
# Description

Implements a fast way to lookup objects based on ChunkPos.

Uses this to implement Obelisk Manager's - these are used to handle event-based obelisks where we can gather a subset of obelisks that are in effect on a certain point in the world, without having to check all obelisks in the world.

I've implemented this as a level attachment, removing the need for explicit dimension checks.

Closes #742 

# Breaking Changes

No public API or gameplay breaking changes.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
