### PR TITLE
Fix FluidFilterMenu.java crash

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/common/menu/FluidFilterMenu.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/menu/FluidFilterMenu.java
@@ -93,7 +93,7 @@ public class FluidFilterMenu extends AbstractContainerMenu {
 
     @Override
     public void clicked(int pSlotId, int pButton, ClickType pClickType, Player pPlayer) {
-        if (pSlotId < capability.getEntries().size()) {
+        if (pSlotId >= 0 && pSlotId < capability.getEntries().size()) {
             if (!capability.getEntries().get(pSlotId).isEmpty()) {
                 capability.setEntry(pSlotId, FluidStack.EMPTY);
             }


### PR DESCRIPTION
# Description

In monifactory, the game will randomly crash when trying to set some fluid filters (in my case using a bucket).

This seems to fix the issue. I believe this fixes #770 as well, but it's possibly a bandaid for the underlying issue thats causing a -999 value to be passed in in the first place.