### PR TITLE
Change Energy conduit limit to be per-node instead of per-tick.

### DIFF
--- a/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/energy/EnergyConduitNetworkContext.java
+++ b/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/energy/EnergyConduitNetworkContext.java
@@ -16,7 +16,6 @@ public class EnergyConduitNetworkContext implements ConduitNetworkContext<Energy
     );
 
     private int energyStored = 0;
-    private int energyInsertedThisTick = 0;
     private int rotatingIndex = 0;
 
     public EnergyConduitNetworkContext() {
@@ -40,14 +39,6 @@ public class EnergyConduitNetworkContext implements ConduitNetworkContext<Energy
 
     public void setEnergyStored(int energyStored) {
         this.energyStored = energyStored;
-    }
-
-    public int energyInsertedThisTick() {
-        return energyInsertedThisTick;
-    }
-
-    public void setEnergyInsertedThisTick(int energyInsertedThisTick) {
-        this.energyInsertedThisTick = energyInsertedThisTick;
     }
 
     public int rotatingIndex() {

--- a/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/energy/EnergyConduitStorage.java
+++ b/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/energy/EnergyConduitStorage.java
@@ -20,12 +20,10 @@ public record EnergyConduitStorage(
         EnergyConduitNetworkContext context = node.getParentGraph().getOrCreateContext(Conduits.ContextSerializers.ENERGY.get());
 
         // Cap to transfer rate.
-        // TODO: Do we cap the transfer rate at all, or should we receive as much as we can and only cap output?
-        toReceive = Math.min(transferRate() - context.energyInsertedThisTick(), toReceive);
+        toReceive = Math.min(transferRate(), toReceive);
 
         int energyReceived = Math.min(getMaxEnergyStored() - getEnergyStored(), toReceive);
         if (!simulate) {
-            context.setEnergyInsertedThisTick(context.energyInsertedThisTick() + energyReceived);
             context.setEnergyStored(getEnergyStored() + energyReceived);
         }
 

--- a/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/energy/EnergyConduitTicker.java
+++ b/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/energy/EnergyConduitTicker.java
@@ -23,20 +23,6 @@ public class EnergyConduitTicker implements IOAwareConduitTicker<EnergyConduit> 
     }
 
     @Override
-    public void tickGraph(ServerLevel level, EnergyConduit conduit,
-                          List<ConduitNode> loadedNodes,
-                          ConduitNetwork graph, ColoredRedstoneProvider coloredRedstoneProvider) {
-
-        // Reset insertion cap
-        EnergyConduitNetworkContext context = graph.getContext(Conduits.ContextSerializers.ENERGY.get());
-        if (context != null) {
-            context.setEnergyInsertedThisTick(0);
-        }
-
-        IOAwareConduitTicker.super.tickGraph(level, conduit, loadedNodes, graph, coloredRedstoneProvider);
-    }
-
-    @Override
     public void tickColoredGraph(ServerLevel level, EnergyConduit conduit, List<Connection> inserts, List<Connection> extracts, DyeColor color,
         ConduitNetwork graph, ColoredRedstoneProvider coloredRedstoneProvider) {
 
@@ -63,8 +49,6 @@ public class EnergyConduitTicker implements IOAwareConduitTicker<EnergyConduit> 
             context.setRotatingIndex(0);
         }
 
-        int totalEnergyInserted = 0;
-
         int startingRotatingIndex = context.rotatingIndex();
         for (int i = startingRotatingIndex; i < startingRotatingIndex + storagesForInsert.size(); i++) {
             int insertIndex = i % storagesForInsert.size();
@@ -75,17 +59,9 @@ public class EnergyConduitTicker implements IOAwareConduitTicker<EnergyConduit> 
                 continue;
             }
 
-            int energyToInsert = Math.min(conduit.transferRate() - totalEnergyInserted, availableEnergy);
-
-            int energyInserted = insertHandler.receiveEnergy(energyToInsert, false);
+            int energyInserted = insertHandler.receiveEnergy(conduit.transferRate(), false);
             context.setEnergyStored(context.energyStored() - energyInserted);
             context.setRotatingIndex(insertIndex + 1);
-
-            totalEnergyInserted += energyInserted;
-
-            if (totalEnergyInserted >= conduit.transferRate()) {
-                break;
-            }
         }
     }
 

--- a/enderio-conduits/src/main/java/com/enderio/conduits/common/init/Conduits.java
+++ b/enderio-conduits/src/main/java/com/enderio/conduits/common/init/Conduits.java
@@ -29,8 +29,6 @@ public class Conduits {
     public static ResourceKey<Conduit<?>> ITEM = ResourceKey.create(EnderIOConduitsRegistries.Keys.CONDUIT, EnderIOBase.loc("item"));
 
     public static void bootstrap(BootstrapContext<Conduit<?>> context) {
-        // TODO: Is there a way to generate conditions for these? i.e. "neoforge:conditions":[{"type":"neoforge:mod_loaded","modid":"ae2"}]
-
         // TODO: These rates are still up for change, but will refine through testing.
         context.register(ENERGY,
             new EnergyConduit(EnderIOBase.loc("block/conduit/energy"), ConduitLang.ENERGY_CONDUIT, 1_000));


### PR DESCRIPTION
# Description

Instead of limiting the conduit to it's rate over the entire tick, instead it is limited to this rate on a per-connection basis. I.e. it can receive <X> FE/t from each connected source and can push <X> FE/t into each connected consumer.

The energy rates could potentially be nerfed now, however I am tempted to leave it to help compatibility with other mods.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
