### PR TITLE
Fix conflicting recipe IDs in smelting recipe inheritance

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/mixin/RecipeManagerMixin.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/mixin/RecipeManagerMixin.java
@@ -42,7 +42,7 @@ public class RecipeManagerMixin {
         int energy = MachinesConfig.COMMON.ENERGY.ALLOY_SMELTER_VANILLA_ITEM_ENERGY.get();
         AlloySmeltingRecipe recipe = new AlloySmeltingRecipe(List.of(input), accessor.getResult(), energy, accessor.getExperience(), true);
 
-        String path = "smelting/" + originalId.getPath();
+        String path = "smelting/" + originalId.getNamespace() + "/" + originalId.getPath();
         ResourceLocation id = EnderIOBase.loc(path);
         return new RecipeHolder<>(id, recipe);
     }


### PR DESCRIPTION
# Description

This pull request fixes an issue introduced in #812.

The change introduces the addition of the original namespace to the new recipe ID which should prevent any conflicts.

The conflict reported in #818 originated from a [Farmers Delight recipe](https://github.com/Team-EnderIO/EnderIO/pull/812) that used the exact same path as a vanilla smelting recipe. After converting the namespace to EnderIO, the recipe IDs matched and conflicted.

fixes #818 

# Breaking Changes

- /

# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.
