### PR TITLE
fix: Aversion Obelisk and Entity Filter bugs and crash fixes on 1.21.1

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/common/capability/EntityFilterCapability.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/capability/EntityFilterCapability.java
@@ -59,7 +59,7 @@ public class EntityFilterCapability implements IFilterCapability<StoredEntityDat
 
     @Override
     public int size() {
-        return 0;
+        return getEntries().size();
     }
 
     @Override

--- a/enderio-base/src/main/java/com/enderio/base/common/capability/EntityFilterCapability.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/capability/EntityFilterCapability.java
@@ -125,7 +125,7 @@ public class EntityFilterCapability implements IFilterCapability<StoredEntityDat
     public record Component(List<StoredEntityData> entities, boolean nbt, boolean invert) {
         public static Codec<Component> CODEC = RecordCodecBuilder.create(componentInstance -> componentInstance
             .group(Slot.CODEC.sizeLimitedListOf(256).fieldOf("entities").xmap(Component::fromList, Component::fromEntities).forGetter(Component::entities),
-                Codec.BOOL.fieldOf("nbt").forGetter(Component::nbt), Codec.BOOL.fieldOf("nbt").forGetter(Component::invert))
+                Codec.BOOL.fieldOf("nbt").forGetter(Component::nbt), Codec.BOOL.fieldOf("isInvert").forGetter(Component::invert))
             .apply(componentInstance, Component::new));
 
         public static final StreamCodec<RegistryFriendlyByteBuf, Component> STREAM_CODEC = StreamCodec.composite(

--- a/enderio-base/src/main/java/com/enderio/base/common/capability/EntityFilterCapability.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/capability/EntityFilterCapability.java
@@ -15,7 +15,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.fluids.FluidStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -123,10 +122,19 @@ public class EntityFilterCapability implements IFilterCapability<StoredEntityDat
     }
 
     public record Component(List<StoredEntityData> entities, boolean nbt, boolean invert) {
-        public static Codec<Component> CODEC = RecordCodecBuilder.create(componentInstance -> componentInstance
+        public static Codec<Component> NEW_CODEC = RecordCodecBuilder.create(componentInstance -> componentInstance
             .group(Slot.CODEC.sizeLimitedListOf(256).fieldOf("entities").xmap(Component::fromList, Component::fromEntities).forGetter(Component::entities),
                 Codec.BOOL.fieldOf("nbt").forGetter(Component::nbt), Codec.BOOL.fieldOf("isInvert").forGetter(Component::invert))
             .apply(componentInstance, Component::new));
+
+        // TODO: Remove in Ender IO 8
+        // The Codec used up to and including v7.0.7-alpha
+        public static Codec<Component> LEGACY_CODEC = RecordCodecBuilder.create(componentInstance -> componentInstance
+            .group(Slot.CODEC.sizeLimitedListOf(256).fieldOf("entities").xmap(Component::fromList, Component::fromEntities).forGetter(Component::entities),
+                Codec.BOOL.fieldOf("nbt").forGetter(Component::nbt), Codec.BOOL.fieldOf("nbt").forGetter(Component::invert))
+            .apply(componentInstance, Component::new));
+
+        public static final Codec<Component> CODEC = Codec.withAlternative(NEW_CODEC, LEGACY_CODEC);
 
         public static final StreamCodec<RegistryFriendlyByteBuf, Component> STREAM_CODEC = StreamCodec.composite(
             StoredEntityData.STREAM_CODEC.apply(ByteBufCodecs.list(256)),

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/AversionObeliskBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/AversionObeliskBlockEntity.java
@@ -85,7 +85,7 @@ public class AversionObeliskBlockEntity extends ObeliskBlockEntity {
     }
 
     public boolean handleSpawnEvent(FinalizeSpawnEvent event) {
-        if (!isActive()) {
+        if (!isActive() || getAABB() == null) {
             return false;
         }
 

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/ObeliskBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/ObeliskBlockEntity.java
@@ -19,9 +19,11 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 
+import javax.annotation.Nullable;
+
 public abstract class ObeliskBlockEntity extends PoweredMachineBlockEntity implements RangedActor {
 
-    private AABB aabb;
+    private @Nullable AABB aabb;
     private final NetworkDataSlot<ActionRange> actionRangeDataSlot;
     public static SingleSlotAccess FILTER = new SingleSlotAccess();
 
@@ -79,7 +81,7 @@ public abstract class ObeliskBlockEntity extends PoweredMachineBlockEntity imple
 
     public abstract String getColor();
 
-    public AABB getAABB() {
+    public @Nullable AABB getAABB() {
         return aabb;
     }
 


### PR DESCRIPTION
# Description

This pull request addresses 3 issues.

1. I previously backported Aversion Obelisk and Entity Filter from 1.21.1 to 1.20.1. During the port I have identified a very extreme way to crash the game on my port. However, I came to realize that the problem is also present in 1.21.1. You can see the explanation of the crash here: https://github.com/Team-EnderIO/EnderIO/pull/777#issuecomment-2384035922

2. While fixing this I also came across the fact that 1.21.1 Entity Filters has started to instantly crash the game starting from a week ago. This was due to a change that limited the max size to 0 rather than it's real size.

3. After fixing this I also found out that the NBT matching mode and blacklist/whitelist mode were conflicted in such a way that blacklist can only work with match NBT and whitelist can only work with ignore NBT after a reload of the world.

No other changes were made other than to fix these issues.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] ~I have made corresponding changes to the documentation.~ (No changes needed)
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
