### PR TITLE
Fix redstone conduits and filters

### DIFF
--- a/src/api/java/com/enderio/api/conduit/ticker/ConduitTicker.java
+++ b/src/api/java/com/enderio/api/conduit/ticker/ConduitTicker.java
@@ -24,6 +24,10 @@ public interface ConduitTicker<T extends ConduitData<T>> {
     // TODO: I'd argue this goes into ConduitType, and then you can use getTicker() if you need additional context from it.
     boolean canConnectTo(Level level, BlockPos conduitPos, Direction direction);
 
+    default boolean canHaveConnection(Level level, BlockPos conduitPos, Direction direction) {
+        return canConnectTo(level, conduitPos, direction);
+    }
+
     /**
      *
      * @return if this is not always able to determine connectivity to its neighbours at time of placement, but the tick later

--- a/src/api/java/com/enderio/api/conduit/ticker/ConduitTicker.java
+++ b/src/api/java/com/enderio/api/conduit/ticker/ConduitTicker.java
@@ -22,9 +22,15 @@ public interface ConduitTicker<T extends ConduitData<T>> {
     }
 
     // TODO: I'd argue this goes into ConduitType, and then you can use getTicker() if you need additional context from it.
+    /**
+     * @return if the conduit can automatically connect to a neighbor block
+     */
     boolean canConnectTo(Level level, BlockPos conduitPos, Direction direction);
 
-    default boolean canHaveConnection(Level level, BlockPos conduitPos, Direction direction) {
+    /**
+     * @return if the conduit is allowed to have a forced connection (with the wrench) but won't necessarily connect when placed
+     */
+    default boolean canForceConnect(Level level, BlockPos conduitPos, Direction direction) {
         return canConnectTo(level, conduitPos, direction);
     }
 

--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
@@ -263,7 +263,7 @@ public class ConduitBlock extends Block implements EntityBlock, SimpleWaterlogge
             } else {
                 ConnectionState connectionState = conduit.getBundle().getConnectionState(hit.getDirection(), type);
                 if (connectionState == StaticConnectionStates.DISABLED) {
-                    conduit.tryConnectTo(hit.getDirection(), type, true, true);
+                    conduit.tryConnectTo(hit.getDirection(), type, true, true, true);
                 }
             }
 

--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
@@ -262,7 +262,7 @@ public class ConduitBlock extends Block implements EntityBlock, SimpleWaterlogge
                 }
             } else {
                 ConnectionState connectionState = conduit.getBundle().getConnectionState(hit.getDirection(), type);
-                if (connectionState == StaticConnectionStates.DISABLED) {
+                if (!connectionState.isConnection()) {
                     conduit.tryConnectTo(hit.getDirection(), type, true, true, true);
                 }
             }

--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlockEntity.java
@@ -192,7 +192,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
 
                     ConnectionState connectionState = bundle.getConnectionState(direction, type);
                     if (connectionState instanceof DynamicConnectionState dyn) {
-                        if (!type.getTicker().canHaveConnection(level, pos, direction)) {
+                        if (!type.getTicker().canForceConnect(level, pos, direction)) {
                             bundle.getNodeFor(type).clearState(direction);
                             dropConnection(dyn);
                             bundle.setConnectionState(direction, type, StaticConnectionStates.DISCONNECTED);
@@ -306,7 +306,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
 
             return Optional.of(conduit.bundle.getNodeFor(type));
         } else if (type.getTicker().canConnectTo(level, getBlockPos(), dir)
-            || (forceConnection && type.getTicker().canHaveConnection(level, getBlockPos(), dir))) {
+            || (forceConnection && type.getTicker().canForceConnect(level, getBlockPos(), dir))) {
             if (bundle.getConnectionState(dir, type) instanceof DynamicConnectionState dyn && dyn.isConnection()) {  // Already connected
                 updateConnectionToData(type);
                 return Optional.empty();

--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlockEntity.java
@@ -135,7 +135,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
             for (var entry: lazyNodes.entrySet()) {
                 ConduitGraphObject<?> node = entry.getValue();
                 for (Direction dir : Direction.values()) {
-                    tryConnectTo(dir, entry.getKey(), false, false).ifPresent(otherNode -> Graph.connect(node, otherNode));
+                    tryConnectTo(dir, entry.getKey(), false, false, false).ifPresent(otherNode -> Graph.connect(node, otherNode));
                 }
 
                 for (GraphObject<Mergeable.Dummy> object : node.getGraph().getObjects()) {
@@ -192,7 +192,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
 
                     ConnectionState connectionState = bundle.getConnectionState(direction, type);
                     if (connectionState instanceof DynamicConnectionState dyn) {
-                        if (!type.getTicker().canConnectTo(level, pos, direction)) {
+                        if (!type.getTicker().canHaveConnection(level, pos, direction)) {
                             bundle.getNodeFor(type).clearState(direction);
                             dropConnection(dyn);
                             bundle.setConnectionState(direction, type, StaticConnectionStates.DISCONNECTED);
@@ -200,7 +200,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
                             updateConnectionToData(type);
                         }
                     } else if (connectionState == StaticConnectionStates.DISCONNECTED) {
-                        tryConnectTo(direction, type, true, true);
+                        tryConnectTo(direction, type, true, true, false);
                     }
                 }
             }
@@ -250,7 +250,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
         if (action.hasChanged()) {
             List<GraphObject<Mergeable.Dummy>> nodes = new ArrayList<>();
             for (Direction dir : Direction.values()) {
-                tryConnectTo(dir, type, false, false).ifPresent(nodes::add);
+                tryConnectTo(dir, type, false, false, false).ifPresent(nodes::add);
             }
             if (level instanceof ServerLevel serverLevel) {
                 ConduitGraphObject<?> thisNode = Objects.requireNonNull(bundle.getNodeForTypeExact(type), "no node found in conduit");
@@ -272,7 +272,7 @@ public class ConduitBlockEntity extends EnderBlockEntity {
         return action;
     }
 
-    public <T extends ConduitData<T>> Optional<GraphObject<Mergeable.Dummy>> tryConnectTo(Direction dir, ConduitType<T> type, boolean forceMerge, boolean shouldMergeGraph) {
+    public <T extends ConduitData<T>> Optional<GraphObject<Mergeable.Dummy>> tryConnectTo(Direction dir, ConduitType<T> type, boolean forceMerge, boolean shouldMergeGraph, boolean forceConnection) {
         if (level.getBlockEntity(getBlockPos().relative(dir)) instanceof ConduitBlockEntity conduit
             && conduit.connectTo(dir.getOpposite(), type, bundle.getNodeFor(type).getConduitData(), forceMerge)) {
             connect(dir, type);
@@ -305,8 +305,9 @@ public class ConduitBlockEntity extends EnderBlockEntity {
             }
 
             return Optional.of(conduit.bundle.getNodeFor(type));
-        } else if (type.getTicker().canConnectTo(level, getBlockPos(), dir)) {
-            if (bundle.getConnectionState(dir, type) instanceof DynamicConnectionState) { //Already connected
+        } else if (type.getTicker().canConnectTo(level, getBlockPos(), dir)
+            || (forceConnection && type.getTicker().canHaveConnection(level, getBlockPos(), dir))) {
+            if (bundle.getConnectionState(dir, type) instanceof DynamicConnectionState dyn && dyn.isConnection()) {  // Already connected
                 updateConnectionToData(type);
                 return Optional.empty();
             }

--- a/src/conduits/java/com/enderio/conduits/common/conduit/type/redstone/RedstoneConduitTicker.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/type/redstone/RedstoneConduitTicker.java
@@ -23,11 +23,17 @@ import java.util.Map;
 public class RedstoneConduitTicker implements IOAwareConduitTicker<RedstoneConduitData> {
 
     private final Map<ColorControl, Integer> activeColors = new EnumMap<>(ColorControl.class);
+
     @Override
     public boolean canConnectTo(Level level, BlockPos conduitPos, Direction direction) {
         BlockPos neighbor = conduitPos.relative(direction);
         BlockState blockState = level.getBlockState(neighbor);
         return blockState.is(ConduitTags.Blocks.REDSTONE_CONNECTABLE) || blockState.canRedstoneConnectTo(level, neighbor, direction);
+    }
+
+    @Override
+    public boolean canHaveConnection(Level level, BlockPos conduitPos, Direction direction) {
+        return true;
     }
 
     @Override

--- a/src/conduits/java/com/enderio/conduits/common/conduit/type/redstone/RedstoneConduitTicker.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/type/redstone/RedstoneConduitTicker.java
@@ -32,7 +32,7 @@ public class RedstoneConduitTicker implements IOAwareConduitTicker<RedstoneCondu
     }
 
     @Override
-    public boolean canHaveConnection(Level level, BlockPos conduitPos, Direction direction) {
+    public boolean canForceConnect(Level level, BlockPos conduitPos, Direction direction) {
         BlockPos neighbor = conduitPos.relative(direction);
         BlockState blockState = level.getBlockState(neighbor);
         return !blockState.isAir();

--- a/src/conduits/java/com/enderio/conduits/common/conduit/type/redstone/RedstoneConduitTicker.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/type/redstone/RedstoneConduitTicker.java
@@ -33,7 +33,9 @@ public class RedstoneConduitTicker implements IOAwareConduitTicker<RedstoneCondu
 
     @Override
     public boolean canHaveConnection(Level level, BlockPos conduitPos, Direction direction) {
-        return true;
+        BlockPos neighbor = conduitPos.relative(direction);
+        BlockState blockState = level.getBlockState(neighbor);
+        return !blockState.isAir();
     }
 
     @Override

--- a/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneNOTFilter.java
+++ b/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneNOTFilter.java
@@ -3,11 +3,20 @@ package com.enderio.conduits.common.redstone;
 import com.enderio.api.misc.ColorControl;
 import com.enderio.conduits.common.conduit.type.redstone.RedstoneConduitData;
 
-public class RedstoneNOTFilter implements RedstoneInsertFilter {
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+
+public class RedstoneNOTFilter implements RedstoneInsertFilter, RedstoneExtractFilter {
 
     public static final RedstoneNOTFilter INSTANCE = new RedstoneNOTFilter();
 
     private RedstoneNOTFilter() {
+    }
+
+    @Override
+    public int getInputSignal(Level level, BlockPos pos, Direction direction) {
+        return level.getSignal(pos, direction) == 0 ? 15 : 0;
     }
 
     @Override

--- a/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneSensorFilter.java
+++ b/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneSensorFilter.java
@@ -3,9 +3,8 @@ package com.enderio.conduits.common.redstone;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.ComparatorBlockEntity;
 
-public class RedstoneSensorFilter implements RedstoneExtractFilter{
+public class RedstoneSensorFilter implements RedstoneExtractFilter {
 
     public static final RedstoneSensorFilter INSTANCE = new RedstoneSensorFilter();
 
@@ -14,6 +13,6 @@ public class RedstoneSensorFilter implements RedstoneExtractFilter{
 
     @Override
     public int getInputSignal(Level level, BlockPos pos, Direction direction) {
-        return level.getBlockEntity(pos) instanceof ComparatorBlockEntity comp ? comp.getOutputSignal() : 0;
+        return level.getBlockState(pos).getAnalogOutputSignal(level, pos.relative(direction.getOpposite()));
     }
 }

--- a/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneTLatchFilter.java
+++ b/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneTLatchFilter.java
@@ -18,15 +18,15 @@ public class RedstoneTLatchFilter implements RedstoneInsertFilter {
 
     @Override
     public int getOutputSignal(RedstoneConduitData data, ColorControl control) {
-        boolean active1 = isActive();
+        boolean output = isActive();
         if (data.isActive(control) && isDeactivated()) {
-            active1 = !active1;
-            setState(active1, false);
+            output = !output;
+            setState(output, false);
         }
-        if (!data.isActive(control)) {
-            setState(active1, true);
+        if (!data.isActive(control) && !isDeactivated()) {
+            setState(output, true);
         }
-        return active1 ? 15 : 0;
+        return output ? 15 : 0;
     }
 
     public boolean isActive() {
@@ -36,7 +36,7 @@ public class RedstoneTLatchFilter implements RedstoneInsertFilter {
 
     public boolean isDeactivated() {
         CompoundTag tag = stack.getOrCreateTag();
-        return !tag.contains(KEY_DEACTIVATED) || tag.getBoolean(KEY_ACTIVE);
+        return !tag.contains(KEY_DEACTIVATED) || tag.getBoolean(KEY_DEACTIVATED);
     }
 
     public void setState(boolean active, boolean deactivated) {

--- a/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneTimerFilter.java
+++ b/src/conduits/java/com/enderio/conduits/common/redstone/RedstoneTimerFilter.java
@@ -31,14 +31,14 @@ public class RedstoneTimerFilter implements RedstoneExtractFilter {
         return 0;
     }
 
-    public int getMaxTicks() {
-        CompoundTag tag = stack.getOrCreateTag();
-        return tag.contains(KEY_TICKS) ? tag.getInt(KEY_TICKS) : 20;
-    }
-
     public int getTicks() {
         CompoundTag tag = stack.getOrCreateTag();
-        return tag.contains(KEY_MAX_TICKS) ? tag.getInt(KEY_MAX_TICKS) : 0;
+        return tag.contains(KEY_TICKS) ? tag.getInt(KEY_TICKS) : 0;
+    }
+
+    public int getMaxTicks() {
+        CompoundTag tag = stack.getOrCreateTag();
+        return tag.contains(KEY_MAX_TICKS) ? tag.getInt(KEY_MAX_TICKS) : 20;
     }
 
     public void setTimer(int ticks, int maxTicks) {


### PR DESCRIPTION
# Description

Allows the yeta wrench to force connections for redstone conduits, and custom conduits if they choose to. Currently redstone conduits can even connect to air blocks, but I'm not sure if that should remain that way.

Also fixes some redstone filters:
- NOT filter can be for both extract and insert instead of just insert
- Sensor filter actually extracts analog signal instead of limiting the conduit to reading comparators
- Timer filter reads its data correctly
- Toggle filter reads its data correctly and doesn't write unnecessarily

# Breaking Changes

The ConduitTicker interface has a new `canHaveConnection` method to determine if a forced connection is allowed. I'm not sure if this is actually breaking though, as it has a default that should effectively leave all existing implementations unchanged.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
