### PR TITLE
[1.21.1] Fix item loss during transfer in Item Conduits

### DIFF
--- a/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/item/ItemConduitTicker.java
+++ b/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/item/ItemConduitTicker.java
@@ -6,6 +6,7 @@ import com.enderio.conduits.api.ConduitNetwork;
 import com.enderio.conduits.api.ticker.CapabilityAwareConduitTicker;
 import com.enderio.conduits.common.components.ExtractionSpeedUpgrade;
 import com.enderio.conduits.common.init.ConduitTypes;
+import java.util.List;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
@@ -14,26 +15,18 @@ import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
 
-import java.util.List;
-
 public class ItemConduitTicker extends CapabilityAwareConduitTicker<ItemConduit, IItemHandler> {
 
     @Override
-    protected void tickCapabilityGraph(
-        ServerLevel level,
-        ItemConduit conduit,
-        List<CapabilityConnection> inserts,
-        List<CapabilityConnection> extracts,
-        ConduitNetwork graph,
-        ColoredRedstoneProvider coloredRedstoneProvider) {
+    protected void tickCapabilityGraph(ServerLevel level, ItemConduit conduit, List<CapabilityConnection> inserts,
+            List<CapabilityConnection> extracts, ConduitNetwork graph,
+            ColoredRedstoneProvider coloredRedstoneProvider) {
 
-        toNextExtract:
-        for (CapabilityConnection extract: extracts) {
+        toNextExtract: for (CapabilityConnection extract : extracts) {
             IItemHandler extractHandler = extract.capability();
             int extracted = 0;
 
-            nextItem:
-            for (int i = 0; i < extractHandler.getSlots(); i++) {
+            nextItem: for (int i = 0; i < extractHandler.getSlots(); i++) {
                 int speed = conduit.transferRatePerCycle();
                 if (extract.upgrade() instanceof ExtractionSpeedUpgrade speedUpgrade) {
                     speed *= (int) Math.pow(2, speedUpgrade.tier());
@@ -50,7 +43,9 @@ public class ItemConduitTicker extends CapabilityAwareConduitTicker<ItemConduit,
                     }
                 }
 
-                ItemConduitData.ItemSidedData sidedExtractData = extract.node().getOrCreateData(ConduitTypes.Data.ITEM.get()).compute(extract.direction());
+                ItemConduitData.ItemSidedData sidedExtractData = extract.node()
+                        .getOrCreateData(ConduitTypes.Data.ITEM.get())
+                        .compute(extract.direction());
                 if (sidedExtractData.isRoundRobin) {
                     if (inserts.size() <= sidedExtractData.rotatingIndex) {
                         sidedExtractData.rotatingIndex = 0;
@@ -63,9 +58,8 @@ public class ItemConduitTicker extends CapabilityAwareConduitTicker<ItemConduit,
                     int insertIndex = j % inserts.size();
                     CapabilityConnection insert = inserts.get(insertIndex);
 
-                    if (!sidedExtractData.isSelfFeed
-                        && extract.direction() == insert.direction()
-                        && extract.pos() == insert.pos()) {
+                    if (!sidedExtractData.isSelfFeed && extract.direction() == insert.direction()
+                            && extract.pos() == insert.pos()) {
                         continue;
                     }
 

--- a/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/item/ItemConduitTicker.java
+++ b/enderio-conduits/src/main/java/com/enderio/conduits/common/conduit/type/item/ItemConduitTicker.java
@@ -76,10 +76,11 @@ public class ItemConduitTicker extends CapabilityAwareConduitTicker<ItemConduit,
                     }
 
                     ItemStack notInserted = ItemHandlerHelper.insertItem(insert.capability(), extractedItem, false);
+                    int successfullyInserted = extractedItem.getCount() - notInserted.getCount();
 
-                    if (notInserted.getCount() < extractedItem.getCount()) {
-                        extracted += extractedItem.getCount() - notInserted.getCount();
-                        extractHandler.extractItem(i, extracted, false);
+                    if (successfullyInserted > 0) {
+                        extracted += successfullyInserted;
+                        extractHandler.extractItem(i, successfullyInserted, false);
                         if (extracted >= speed) {
                             if (sidedExtractData.isRoundRobin) {
                                 sidedExtractData.rotatingIndex = insertIndex + 1;


### PR DESCRIPTION
- resolves issue where items were lost during transfer

# Description

This PR fixes [Issue #898](https://github.com/Team-EnderIO/EnderIO/issues/898), where items were lost during transfer via item conduits. The fix ensures synchronization between the extracted and inserted item amounts, preventing losses.

# Breaking Changes

Adjusted logic in `com/enderio/conduits/common/conduit/type/item/ItemConduitTicker.java:79` to account for `notInserted` values correctly.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
