### PR TITLE
Added Obelisk Voxel Shapes 

### DIFF
--- a/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
+++ b/src/machines/java/com/enderio/machines/common/block/MachineBlock.java
@@ -26,6 +26,9 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
@@ -33,10 +36,17 @@ import org.jetbrains.annotations.Nullable;
 public class MachineBlock extends BaseEntityBlock {
     private final BlockEntityEntry<? extends MachineBlockEntity> blockEntityType;
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
+    private static final VoxelShape DEFAULT_SHAPE = Shapes.box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0); // Full block shape
+    private final VoxelShape shape;
 
     public MachineBlock(Properties properties, BlockEntityEntry<? extends MachineBlockEntity> blockEntityType) {
+        this(properties, blockEntityType, DEFAULT_SHAPE);
+    }
+
+    public MachineBlock(Properties properties, BlockEntityEntry<? extends MachineBlockEntity> blockEntityType, VoxelShape shape) {
         super(properties);
         this.blockEntityType = blockEntityType;
+        this.shape = shape;
         BlockState any = this.getStateDefinition().any();
         this.registerDefaultState(any.hasProperty(FACING) ? any.setValue(FACING, Direction.NORTH) : any);
     }
@@ -156,5 +166,15 @@ public class MachineBlock extends BaseEntityBlock {
             return machineBlock.getLightEmission();
         }
         return super.getLightEmission(state, level, pos);
+    }
+
+    @Override
+    public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
+        return shape;
+    }
+
+    @Override
+    public VoxelShape getCollisionShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
+        return shape;
     }
 }

--- a/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
+++ b/src/machines/java/com/enderio/machines/common/init/MachineBlocks.java
@@ -36,6 +36,8 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.client.model.generators.loaders.CompositeModelBuilder;
 
 import java.util.HashMap;
@@ -45,6 +47,7 @@ import java.util.function.Supplier;
 
 public class MachineBlocks {
     private static final Registrate REGISTRATE = EnderIO.registrate();
+    private static final VoxelShape OBELISK_SHAPE = Shapes.box(0.32, 0.0, 0.32, 0.68, 0.375, 0.68); // Obelisk's Custom Voxel Shape
 
     public static final BlockEntry<MachineBlock> FLUID_TANK = REGISTRATE
         .block("fluid_tank", props -> new MachineBlock(props, MachineBlockEntities.FLUID_TANK))
@@ -223,7 +226,7 @@ public class MachineBlocks {
         .register();
 
     public static final BlockEntry<MachineBlock> XP_OBELISK = REGISTRATE
-        .block("xp_obelisk", props -> new MachineBlock(props, MachineBlockEntities.XP_OBELISK))
+        .block("xp_obelisk", props -> new MachineBlock(props, MachineBlockEntities.XP_OBELISK, OBELISK_SHAPE))
         .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion())
         .loot(MachinesLootTable::copyNBT)
         .tag(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)
@@ -235,7 +238,7 @@ public class MachineBlocks {
         .register();
 
     public static final BlockEntry<MachineBlock> AVERSION_OBELISK = REGISTRATE
-        .block("aversion_obelisk", props -> new MachineBlock(props, MachineBlockEntities.AVERSION_OBELISK))
+        .block("aversion_obelisk", props -> new MachineBlock(props, MachineBlockEntities.AVERSION_OBELISK, OBELISK_SHAPE))
         .properties(props -> props.strength(2.5f, 8).isViewBlocking((pState, pLevel, pPos) -> false).noOcclusion())
         .loot(MachinesLootTable::copyNBT)
         .tag(BlockTags.NEEDS_IRON_TOOL, BlockTags.MINEABLE_WITH_PICKAXE)


### PR DESCRIPTION
…21.1

# Description

In older versions of the mod, the voxel shapes and collision of an Obelisk aligned to the block, readded this functionality.

# TODO

- [ ] Port to 1.21.1 (my IDE is currently throws Gradle problems with the branch)

# Breaking Changes

None that I can find, my game launched fine and features worked as intended.

If we would rather a subclass for the Obelisks to prevent clutter in the main MachineBlock class that would also be understandable, I just felt it would make more sense to add an alternate constructor and cut down on an extra class file that would be just the voxel stuff. This approach also allows for other Voxels to be added to other "non-full" blocks.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
