### PR TITLE
Make wired charger use energy

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/wired_charger/WiredChargerBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/wired_charger/WiredChargerBlockEntity.java
@@ -56,7 +56,7 @@ public class WiredChargerBlockEntity extends PoweredMachineBlockEntity {
     @Override
     public void serverTick() {
         super.serverTick();
-        if (canAct()) {
+        if (isActive()) {
             chargeItem();
         } else {
             this.progress = 0;
@@ -65,7 +65,7 @@ public class WiredChargerBlockEntity extends PoweredMachineBlockEntity {
 
     @Override
     public boolean isActive() {
-        return canAct();
+        return hasEnergy() && canAct();
     }
 
     public boolean acceptItem(ItemStack item) {
@@ -93,8 +93,10 @@ public class WiredChargerBlockEntity extends PoweredMachineBlockEntity {
                         Math.max(getEnergyStorage().getEnergyStored(), getEnergyStorage().getMaxEnergyUse()));
 
                 if (energyToInsert > 0) {
-                    itemEnergyHandler.receiveEnergy(energyToInsert, false);
-                    getEnergyStorage().takeEnergy(energyToInsert);
+                    int taken = getEnergyStorage().consumeEnergy(energyToInsert, true);
+                    int accepted = itemEnergyHandler.receiveEnergy(taken, true);
+                    itemEnergyHandler.receiveEnergy(accepted, false);
+                    getEnergyStorage().consumeEnergy(accepted, false);
                     this.progress = (float) itemEnergyHandler.getEnergyStored()
                             / itemEnergyHandler.getMaxEnergyStored();
                 }


### PR DESCRIPTION
# Description

Currently, the wired charger does not check if it has power and simply fill the item up.

fixes: #894 
<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
