### PR TITLE
Make it so filters can't be moved when opened

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/common/menu/EntityFilterMenu.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/menu/EntityFilterMenu.java
@@ -5,6 +5,8 @@ import com.enderio.base.common.capability.EntityFilterCapability;
 import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.init.EIOMenus;
 import com.enderio.base.common.network.FilterUpdatePacket;
+import java.util.List;
+import javax.annotation.Nullable;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -14,9 +16,6 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 public class EntityFilterMenu extends AbstractContainerMenu {
 
@@ -37,17 +36,19 @@ public class EntityFilterMenu extends AbstractContainerMenu {
         List<StoredEntityData> items = capability.getEntries();
         for (int i = 0; i < items.size(); i++) {
             int pSlot = i;
-            addSlot(new EntityFilterSlot(data -> capability.setEntry(pSlot, data) ,i ,14 + ( i % 5) * 18, 35 + 20 * ( i / 5)));
+            addSlot(new EntityFilterSlot(data -> capability.setEntry(pSlot, data), i, 14 + (i % 5) * 18,
+                    35 + 20 * (i / 5)));
         }
-        addInventorySlots(14,119, inventory);
+        addInventorySlots(14, 119, inventory);
     }
 
     public EntityFilterMenu(int pContainerId, Inventory inventory, ItemStack stack) {
         this(EIOMenus.ENTITY_FILTER.get(), pContainerId, inventory, stack);
     }
 
-        public static EntityFilterMenu factory(int pContainerId, Inventory inventory, FriendlyByteBuf buf) {
-        return new EntityFilterMenu(EIOMenus.ENTITY_FILTER.get(), pContainerId, inventory, inventory.player.getMainHandItem());
+    public static EntityFilterMenu factory(int pContainerId, Inventory inventory, FriendlyByteBuf buf) {
+        return new EntityFilterMenu(EIOMenus.ENTITY_FILTER.get(), pContainerId, inventory,
+                inventory.player.getMainHandItem());
     }
 
     @Override

--- a/enderio-base/src/main/java/com/enderio/base/common/menu/EntityFilterMenu.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/menu/EntityFilterMenu.java
@@ -64,14 +64,26 @@ public class EntityFilterMenu extends AbstractContainerMenu {
 
         // Hotbar
         for (int x = 0; x < 9; x++) {
-            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58);
+            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58) {
+
+                @Override
+                public boolean mayPickup(Player player) {
+                    return !this.getItem().equals(EntityFilterMenu.this.stack);
+                }
+            };
             this.addSlot(ref);
         }
 
         // Inventory
         for (int y = 0; y < 3; y++) {
             for (int x = 0; x < 9; x++) {
-                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18);
+                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18) {
+
+                    @Override
+                    public boolean mayPickup(Player player) {
+                        return !this.getItem().equals(EntityFilterMenu.this.stack);
+                    }
+                };
                 this.addSlot(ref);
             }
         }

--- a/enderio-base/src/main/java/com/enderio/base/common/menu/FluidFilterMenu.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/menu/FluidFilterMenu.java
@@ -15,8 +15,6 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.network.PacketDistributor;
 
-import java.util.List;
-
 public class FluidFilterMenu extends AbstractContainerMenu {
 
     private final ItemStack stack;
@@ -62,14 +60,26 @@ public class FluidFilterMenu extends AbstractContainerMenu {
 
         // Hotbar
         for (int x = 0; x < 9; x++) {
-            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58);
+            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58) {
+
+                @Override
+                public boolean mayPickup(Player player) {
+                    return !this.getItem().equals(FluidFilterMenu.this.stack);
+                }
+            };
             this.addSlot(ref);
         }
 
         // Inventory
         for (int y = 0; y < 3; y++) {
             for (int x = 0; x < 9; x++) {
-                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18);
+                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18) {
+
+                    @Override
+                    public boolean mayPickup(Player player) {
+                        return !this.getItem().equals(FluidFilterMenu.this.stack);
+                    }
+                };
                 this.addSlot(ref);
             }
         }

--- a/enderio-base/src/main/java/com/enderio/base/common/menu/FluidFilterMenu.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/menu/FluidFilterMenu.java
@@ -33,9 +33,10 @@ public class FluidFilterMenu extends AbstractContainerMenu {
 
         for (int i = 0; i < capability.size(); i++) {
             int pSlot = i;
-            addSlot(new FluidFilterSlot(fluidStack -> capability.setEntry(pSlot, fluidStack) ,i ,14 + ( i % 5) * 18, 35 + 20 * ( i / 5)));
+            addSlot(new FluidFilterSlot(fluidStack -> capability.setEntry(pSlot, fluidStack), i, 14 + (i % 5) * 18,
+                    35 + 20 * (i / 5)));
         }
-        addInventorySlots(14,119, inventory);
+        addInventorySlots(14, 119, inventory);
     }
 
     public FluidFilterMenu(int pContainerId, Inventory inventory, ItemStack stack) {
@@ -43,7 +44,8 @@ public class FluidFilterMenu extends AbstractContainerMenu {
     }
 
     public static FluidFilterMenu factory(int pContainerId, Inventory inventory, FriendlyByteBuf buf) {
-        return new FluidFilterMenu(EIOMenus.FLUID_FILTER.get(), pContainerId, inventory, inventory.player.getMainHandItem());
+        return new FluidFilterMenu(EIOMenus.FLUID_FILTER.get(), pContainerId, inventory,
+                inventory.player.getMainHandItem());
     }
 
     @Override

--- a/enderio-base/src/main/java/com/enderio/base/common/menu/ItemFilterMenu.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/menu/ItemFilterMenu.java
@@ -63,14 +63,26 @@ public class ItemFilterMenu extends AbstractContainerMenu {
 
         // Hotbar
         for (int x = 0; x < 9; x++) {
-            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58);
+            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58) {
+
+                @Override
+                public boolean mayPickup(Player player) {
+                    return !this.getItem().equals(ItemFilterMenu.this.stack);
+                }
+            };
             this.addSlot(ref);
         }
 
         // Inventory
         for (int y = 0; y < 3; y++) {
             for (int x = 0; x < 9; x++) {
-                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18);
+                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18) {
+
+                    @Override
+                    public boolean mayPickup(Player player) {
+                        return !this.getItem().equals(ItemFilterMenu.this.stack);
+                    }
+                };
                 this.addSlot(ref);
             }
         }

--- a/enderio-base/src/main/java/com/enderio/base/common/menu/ItemFilterMenu.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/menu/ItemFilterMenu.java
@@ -4,6 +4,8 @@ import com.enderio.base.common.capability.ItemFilterCapability;
 import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.init.EIOMenus;
 import com.enderio.base.common.network.FilterUpdatePacket;
+import java.util.List;
+import javax.annotation.Nullable;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -13,9 +15,6 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 public class ItemFilterMenu extends AbstractContainerMenu {
 
@@ -36,9 +35,10 @@ public class ItemFilterMenu extends AbstractContainerMenu {
         List<ItemStack> items = capability.getEntries();
         for (int i = 0; i < items.size(); i++) {
             int pSlot = i;
-            addSlot(new ItemFilterSlot(() -> capability.getEntries().get(pSlot), stack2 -> capability.setEntry(pSlot, stack2) ,i ,14 + ( i % 5) * 18, 35 + 20 * ( i / 5)));
+            addSlot(new ItemFilterSlot(() -> capability.getEntries().get(pSlot),
+                    stack2 -> capability.setEntry(pSlot, stack2), i, 14 + (i % 5) * 18, 35 + 20 * (i / 5)));
         }
-        addInventorySlots(14,119, inventory);
+        addInventorySlots(14, 119, inventory);
     }
 
     public ItemFilterMenu(int pContainerId, Inventory inventory, ItemStack stack) {
@@ -46,7 +46,8 @@ public class ItemFilterMenu extends AbstractContainerMenu {
     }
 
     public static ItemFilterMenu factory(int pContainerId, Inventory inventory, FriendlyByteBuf buf) {
-        return new ItemFilterMenu(EIOMenus.ITEM_FILTER.get(), pContainerId, inventory, inventory.player.getMainHandItem());
+        return new ItemFilterMenu(EIOMenus.ITEM_FILTER.get(), pContainerId, inventory,
+                inventory.player.getMainHandItem());
     }
 
     @Override

--- a/enderio-conduits-modded/src/main/java/com/enderio/modconduits/mods/mekanism/ChemicalFilterMenu.java
+++ b/enderio-conduits-modded/src/main/java/com/enderio/modconduits/mods/mekanism/ChemicalFilterMenu.java
@@ -58,14 +58,26 @@ public class ChemicalFilterMenu extends AbstractContainerMenu {
 
         // Hotbar
         for (int x = 0; x < 9; x++) {
-            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58);
+            Slot ref = new Slot(inventory, x, xPos + x * 18, yPos + 58) {
+
+                @Override
+                public boolean mayPickup(Player player) {
+                    return !this.getItem().equals(ChemicalFilterMenu.this.stack);
+                }
+            };
             this.addSlot(ref);
         }
 
         // Inventory
         for (int y = 0; y < 3; y++) {
             for (int x = 0; x < 9; x++) {
-                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18);
+                Slot ref = new Slot(inventory, x + y * 9 + 9, xPos + x * 18, yPos + y * 18) {
+
+                    @Override
+                    public boolean mayPickup(Player player) {
+                        return !this.getItem().equals(ChemicalFilterMenu.this.stack);
+                    }
+                };
                 this.addSlot(ref);
             }
         }


### PR DESCRIPTION
# Description

Made it so open filters can't be moved in the inventory. Though 3rd parties may still be able to, unsure if we can/should fix that. Technically only the hotbarslots need this, but I made it apply on the full inventory.

fixes: #870 
<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
