### PR TITLE
Make smelting recipe wrapper work with no namespace

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/mixin/RecipeManagerMixin.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/mixin/RecipeManagerMixin.java
@@ -9,11 +9,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiFunction;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -31,11 +26,19 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
 @SuppressWarnings("ClassWithOnlyPrivateConstructors")
 @Mixin(value = RecipeManager.class, priority = 1_098)
 public abstract class RecipeManagerMixin extends SimpleJsonResourceReloadListener {
 
     private static Logger LOGGER;
+    @Unique
+    private static final ResourceLocation SMELTING = ResourceLocation.parse("minecraft:smelting");
 
     private RecipeManagerMixin(Gson gson, String directory) {
         super(gson, directory);
@@ -67,7 +70,7 @@ public abstract class RecipeManagerMixin extends SimpleJsonResourceReloadListene
     @Unique
     private void enderio$handleRecipe(RegistryOps<JsonElement> registryOps, ResourceLocation recipeId,
             JsonObject recipeJson, BiFunction<ResourceLocation, JsonElement, JsonElement> recipeCallback) {
-        if (!recipeJson.has("type") || !recipeJson.get("type").getAsString().equals("minecraft:smelting")) {
+        if (!recipeJson.has("type") || !ResourceLocation.parse(recipeJson.get("type").getAsString()).equals(SMELTING)) {
             return;
         }
 


### PR DESCRIPTION
# Description

We now look for the raw string, but technically, no namespace is also valid as it falls back to "minecraft". Here I made into a RL as to not have that issue.

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
