### PR TITLE
Use non-negative instead of positive int codec for count filter

### DIFF
--- a/enderio-conduits/src/main/java/com/enderio/conduits/common/redstone/RedstoneCountFilter.java
+++ b/enderio-conduits/src/main/java/com/enderio/conduits/common/redstone/RedstoneCountFilter.java
@@ -85,8 +85,8 @@ public class RedstoneCountFilter implements RedstoneInsertFilter {
     public record Component(DyeColor channel1, int maxCount, int count, boolean deactivated) {
         public static final Codec<Component> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(DyeColor.CODEC.fieldOf("channel1").forGetter(Component::channel1),
-                    ExtraCodecs.POSITIVE_INT.fieldOf("maxCount").forGetter(Component::maxCount),
-                    ExtraCodecs.POSITIVE_INT.fieldOf("ticks").forGetter(Component::count),
+                    ExtraCodecs.NON_NEGATIVE_INT.fieldOf("maxCount").forGetter(Component::maxCount),
+                    ExtraCodecs.NON_NEGATIVE_INT.fieldOf("ticks").forGetter(Component::count),
                     Codec.BOOL.fieldOf("deactivated").forGetter(Component::deactivated))
                 .apply(instance, Component::new)
         );


### PR DESCRIPTION
# Description

The positive int codec can not handle 0, so we need to use the non-negative one instead.

fixes: #859 

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
