### PR TITLE
Revert to old recipe manager mixin now KubeJS doesn't break it

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/mixin/RecipeManagerMixin.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/mixin/RecipeManagerMixin.java
@@ -3,21 +3,18 @@ package com.enderio.machines.mixin;
 import com.enderio.base.api.EnderIO;
 import com.enderio.machines.common.blocks.alloy.AlloySmeltingRecipe;
 import com.enderio.machines.common.config.MachinesConfig;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.mojang.serialization.DataResult;
-import com.mojang.serialization.JsonOps;
-import net.minecraft.resources.RegistryOps;
+import com.enderio.machines.common.init.MachineRecipes;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import java.util.List;
+import java.util.Optional;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
-import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.SmeltingRecipe;
+import net.neoforged.neoforge.common.conditions.WithConditions;
 import net.neoforged.neoforge.common.crafting.SizedIngredient;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
@@ -26,74 +23,28 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiFunction;
-
-@SuppressWarnings("ClassWithOnlyPrivateConstructors")
-@Mixin(value = RecipeManager.class, priority = 1_098)
-public abstract class RecipeManagerMixin extends SimpleJsonResourceReloadListener {
+@Mixin(value = RecipeManager.class)
+public abstract class RecipeManagerMixin {
 
     private static Logger LOGGER;
-    @Unique
-    private static final ResourceLocation SMELTING = ResourceLocation.parse("minecraft:smelting");
 
-    private RecipeManagerMixin(Gson gson, String directory) {
-        super(gson, directory);
-    }
+    @Inject(method = "lambda$apply$0", at = @At("TAIL"))
+    private static void collectRecipe(ResourceLocation recipeId,
+            ImmutableMultimap.Builder<RecipeType<?>, RecipeHolder<?>> byType,
+            ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> byName,
+            WithConditions<Recipe<?>> recipeWithConditions, CallbackInfo ci) {
+        if (recipeWithConditions.carrier() instanceof SmeltingRecipe smeltingRecipe) {
 
-    @Inject(method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V", at = @At("HEAD"))
-    private void onRecipeReload(Map<ResourceLocation, JsonElement> recipes, ResourceManager resourceManager,
-            ProfilerFiller profiler, CallbackInfo ci) {
-        RegistryOps<JsonElement> registryOps = makeConditionalOps();
-        Map<ResourceLocation, JsonElement> inheritedRecipes = new HashMap<>();
-
-        for (var e : recipes.entrySet()) {
-            ResourceLocation recipeId = e.getKey();
-            if (recipeId.getPath().startsWith("_")) {
-                continue;
-            }
-
-            JsonElement jsonElement = e.getValue();
-            if (!jsonElement.isJsonObject()) {
-                continue;
-            }
-
-            enderio$handleRecipe(registryOps, recipeId, jsonElement.getAsJsonObject(), inheritedRecipes::put);
-        }
-
-        recipes.putAll(inheritedRecipes);
-    }
-
-    @Unique
-    private void enderio$handleRecipe(RegistryOps<JsonElement> registryOps, ResourceLocation recipeId,
-            JsonObject recipeJson, BiFunction<ResourceLocation, JsonElement, JsonElement> recipeCallback) {
-        if (!recipeJson.has("type") || !ResourceLocation.parse(recipeJson.get("type").getAsString()).equals(SMELTING)) {
-            return;
-        }
-
-        try {
-            var decoded = Recipe.CONDITIONAL_CODEC.parse(registryOps, recipeJson).getOrThrow(JsonParseException::new);
-            if (decoded.isPresent() && decoded.get().carrier() instanceof SmeltingRecipe smeltingRecipe) {
-                var convertedHolder = enderio$convertSmeltingRecipe(recipeId, smeltingRecipe);
-                if (convertedHolder.isEmpty()) {
-                    return;
-                }
-
-                DataResult<JsonElement> result = Recipe.CODEC.encodeStart(JsonOps.INSTANCE,
-                        convertedHolder.get().value());
-                recipeCallback.apply(convertedHolder.get().id(), result.getOrThrow());
-            }
-        } catch (Exception exception) {
-            LOGGER.error("[EnderIO] Skipping inheritance of smelting recipe {}: {}", recipeId, exception);
+            enderio$convertSmeltingRecipe(recipeId, smeltingRecipe).ifPresent(convertedHolder -> {
+                byType.put(MachineRecipes.ALLOY_SMELTING.type().get(), convertedHolder);
+                byName.put(convertedHolder.id(), convertedHolder);
+            });
         }
     }
 
     @Unique
-    private Optional<RecipeHolder<AlloySmeltingRecipe>> enderio$convertSmeltingRecipe(ResourceLocation originalId,
-            SmeltingRecipe smeltingRecipe) {
+    private static Optional<RecipeHolder<AlloySmeltingRecipe>> enderio$convertSmeltingRecipe(
+            ResourceLocation originalId, SmeltingRecipe smeltingRecipe) {
         AbstractCookingRecipeAccessor accessor = (AbstractCookingRecipeAccessor) smeltingRecipe;
 
         if (accessor.getResult().isEmpty()) {


### PR DESCRIPTION
# Description

This build has been tested in Enigmatica 10 (and resolves #972).

I would love some input from @rlnt as to whether this breaks Kube JS scripts for existing modpacks or not, as I'm unsure if this change will have an effect on the order of things, thanks!

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
