### PR TITLE
Fix unused count in sized tag output

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/sag_mill/SagMillingRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/sag_mill/SagMillingRecipe.java
@@ -213,7 +213,7 @@ public record SagMillingRecipe(Ingredient input, List<OutputItem> outputs, int e
                             SizedTagOutput::itemTag, ByteBufCodecs.INT, SizedTagOutput::count, SizedTagOutput::new);
 
             public ItemStack getItemStack() {
-                return TagUtil.getOptionalItem(itemTag).map(ItemStack::new).orElse(ItemStack.EMPTY);
+                return TagUtil.getOptionalItem(itemTag).map(item -> new ItemStack(item, count)).orElse(ItemStack.EMPTY);
             }
         }
     }


### PR DESCRIPTION
# Description

This pull request fixes the unused count property in the `SizedTagOutput`. Right now it's only used in the codec and not made use of. Thus, tag outputs can never have a higher count than 1.

# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.
