### PR TITLE
Bug in redstone control on load

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/common/block/EIOBlockEntity.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/block/EIOBlockEntity.java
@@ -27,7 +27,7 @@ public class EIOBlockEntity extends EnderBlockEntity {
 
         if (level != null && !level.isClientSide()) {
             if (isRedstoneDirty) {
-                updateRedstonePower();
+                updateRedstonePower(false);
             }
         }
     }
@@ -37,7 +37,7 @@ public class EIOBlockEntity extends EnderBlockEntity {
         super.onLoad();
 
         if (supportsRedstonePower()) {
-            updateRedstonePower();
+            updateRedstonePower(true);
         }
     }
 
@@ -60,13 +60,13 @@ public class EIOBlockEntity extends EnderBlockEntity {
         return isRedstonePowered;
     }
 
-    private void updateRedstonePower() {
+    private void updateRedstonePower(boolean forceUpdate) {
         boolean hasPower = level.hasNeighborSignal(worldPosition);
         boolean didChange = isRedstonePowered != hasPower;
         isRedstonePowered = hasPower;
         isRedstoneDirty = false;
 
-        if (didChange) {
+        if (didChange || forceUpdate) {
             onRedstonePowerChanged();
         }
     }

--- a/enderio-base/src/main/java/com/enderio/base/common/block/EIOBlockEntity.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/block/EIOBlockEntity.java
@@ -37,7 +37,7 @@ public class EIOBlockEntity extends EnderBlockEntity {
         super.onLoad();
 
         if (supportsRedstonePower()) {
-            onRedstonePowerChanged();
+            updateRedstonePower();
         }
     }
 
@@ -60,18 +60,11 @@ public class EIOBlockEntity extends EnderBlockEntity {
         return isRedstonePowered;
     }
 
-    private void updateRedstonePower() {
+    protected void updateRedstonePower() {
         boolean hasPower = level.hasNeighborSignal(worldPosition);
         boolean didChange = isRedstonePowered != hasPower;
         isRedstonePowered = hasPower;
         isRedstoneDirty = false;
-
-        if (didChange) {
-            onRedstonePowerChanged();
-        }
-    }
-
-    protected void onRedstonePowerChanged() {
     }
 
     // endregion

--- a/enderio-base/src/main/java/com/enderio/base/common/block/EIOBlockEntity.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/block/EIOBlockEntity.java
@@ -27,7 +27,7 @@ public class EIOBlockEntity extends EnderBlockEntity {
 
         if (level != null && !level.isClientSide()) {
             if (isRedstoneDirty) {
-                updateRedstonePower(false);
+                updateRedstonePower();
             }
         }
     }
@@ -37,7 +37,7 @@ public class EIOBlockEntity extends EnderBlockEntity {
         super.onLoad();
 
         if (supportsRedstonePower()) {
-            updateRedstonePower(true);
+            onRedstonePowerChanged();
         }
     }
 
@@ -60,13 +60,13 @@ public class EIOBlockEntity extends EnderBlockEntity {
         return isRedstonePowered;
     }
 
-    private void updateRedstonePower(boolean forceUpdate) {
+    private void updateRedstonePower() {
         boolean hasPower = level.hasNeighborSignal(worldPosition);
         boolean didChange = isRedstonePowered != hasPower;
         isRedstonePowered = hasPower;
         isRedstoneDirty = false;
 
-        if (didChange || forceUpdate) {
+        if (didChange) {
             onRedstonePowerChanged();
         }
     }

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/blockentity/MachineBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/blockentity/MachineBlockEntity.java
@@ -442,7 +442,8 @@ public abstract class MachineBlockEntity extends EIOBlockEntity
     }
 
     @Override
-    protected void onRedstonePowerChanged() {
+    protected void updateRedstonePower() {
+        super.updateRedstonePower();
         checkIsRedstoneBlocked();
     }
 


### PR DESCRIPTION
# Description

If a machine is set to only active with redstone this is ignored when a world is reloaded.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x ] I have made corresponding changes to the documentation.
- [x ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the processing of redstone power events in both blocks and machines, delivering a more consistent and predictable experience in redstone interactions.
  - The update mechanism has been reorganised to ensure that essential functionality runs before additional checks, improving the overall reliability of redstone signal handling.
  - These changes optimise in-game redstone mechanics for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->