### PR TITLE
Rebinding a powered spawner loses it's capacitor and settings

### DIFF
--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/animal_token.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/animal_token.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 12800,
   "experience": 1,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/broken_spawner.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/broken_spawner.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 288000,
   "experience": 8,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/ender_crystal.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/ender_crystal.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 76800,
   "entity_type": "minecraft:enderman",
   "experience": 6,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/energetic_photovoltaic_module.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/energetic_photovoltaic_module.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 12800,
   "entity_type": "minecraft:phantom",
   "experience": 8,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/enticing_crystal.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/enticing_crystal.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:villager",
   "experience": 4,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/frank_n_zombie.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/frank_n_zombie.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:zombie",
   "experience": 4,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/monster_token.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/monster_token.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 12800,
   "experience": 1,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/player_token.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/player_token.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 12800,
   "entity_type": "minecraft:villager",
   "experience": 1,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/powered_spawner.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/powered_spawner.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": true,
   "energy": 288000,
   "experience": 8,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/prescient_crystal.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/prescient_crystal.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 100000,
   "entity_type": "minecraft:shulker",
   "experience": 8,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/pulsating_photovoltaic_module.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/pulsating_photovoltaic_module.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:phantom",
   "experience": 12,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/sentient_ender.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/sentient_ender.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:witch",
   "experience": 4,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/soul_engine.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/soul_engine.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 188000,
   "experience": 5,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/vibrant_photovoltaic_module.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/vibrant_photovoltaic_module.json
@@ -1,5 +1,6 @@
 {
   "type": "enderio:soul_binding",
+  "copyInputComponents": false,
   "energy": 288000,
   "entity_type": "minecraft:phantom",
   "experience": 14,

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
@@ -34,7 +34,7 @@ import net.neoforged.neoforge.fluids.FluidStack;
 
 public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, int experience,
         Optional<ResourceLocation> entityType, Optional<MobCategory> mobCategory, Optional<String> soulData,
-        boolean copyInputComponents) implements MachineRecipe<SoulBindingRecipe.Input> {
+        Optional<Boolean> copyInputComponents) implements MachineRecipe<SoulBindingRecipe.Input> {
 
     public Ingredient getInput() {
         return input;
@@ -51,7 +51,7 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
         List<OutputStack> results = getResultStacks(registryAccess);
         ItemStack result = results.getFirst().getItem();
 
-        if (copyInputComponents) {
+        if (copyInputComponents.isPresent() && copyInputComponents.get()) {
             result = new ItemStack(result.getItem().builtInRegistryHolder(), result.getCount(),
                     input.itemToBind.getComponentsPatch());
             results = List.of(OutputStack.of(result),
@@ -178,7 +178,8 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
                         ResourceLocation.CODEC.optionalFieldOf("entity_type").forGetter(SoulBindingRecipe::entityType),
                         MobCategory.CODEC.optionalFieldOf("mob_category").forGetter(SoulBindingRecipe::mobCategory),
                         Codec.STRING.optionalFieldOf("soul_data").forGetter(SoulBindingRecipe::soulData),
-                        Codec.BOOL.fieldOf("copyInputComponents").forGetter(SoulBindingRecipe::copyInputComponents))
+                        Codec.BOOL.optionalFieldOf("copyInputComponents")
+                                .forGetter(SoulBindingRecipe::copyInputComponents))
                 .apply(instance, SoulBindingRecipe::new));
 
         public static final StreamCodec<RegistryFriendlyByteBuf, SoulBindingRecipe> STREAM_CODEC = MassiveStreamCodec
@@ -191,8 +192,8 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
                                 name -> ((StringRepresentable.EnumCodec<MobCategory>) MobCategory.CODEC).byName(name),
                                 MobCategory::getName).apply(ByteBufCodecs::optional),
                         SoulBindingRecipe::mobCategory, ByteBufCodecs.STRING_UTF8.apply(ByteBufCodecs::optional),
-                        SoulBindingRecipe::soulData, ByteBufCodecs.BOOL, SoulBindingRecipe::copyInputComponents,
-                        SoulBindingRecipe::new);
+                        SoulBindingRecipe::soulData, ByteBufCodecs.BOOL.apply(ByteBufCodecs::optional),
+                        SoulBindingRecipe::copyInputComponents, SoulBindingRecipe::new);
 
         @Override
         public MapCodec<SoulBindingRecipe> codec() {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
@@ -1,6 +1,7 @@
 package com.enderio.machines.common.blocks.soul_binder;
 
 import com.enderio.base.api.attachment.StoredEntityData;
+import com.enderio.base.api.network.MassiveStreamCodec;
 import com.enderio.base.common.init.EIODataComponents;
 import com.enderio.base.common.init.EIOItems;
 import com.enderio.base.common.recipe.FluidRecipeInput;
@@ -8,7 +9,6 @@ import com.enderio.base.common.tag.EIOTags;
 import com.enderio.base.common.util.ExperienceUtil;
 import com.enderio.core.common.recipes.OutputStack;
 import com.enderio.machines.common.blocks.base.MachineRecipe;
-import com.enderio.machines.common.init.MachineBlocks;
 import com.enderio.machines.common.init.MachineRecipes;
 import com.enderio.machines.common.souldata.SoulDataReloadListener;
 import com.mojang.serialization.Codec;
@@ -31,23 +31,10 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.fluids.FluidStack;
-import net.neoforged.neoforge.network.codec.NeoForgeStreamCodecs;
 
 public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, int experience,
-        Optional<ResourceLocation> entityType, Optional<MobCategory> mobCategory, Optional<String> soulData)
-        implements MachineRecipe<SoulBindingRecipe.Input> {
-
-    public SoulBindingRecipe(ItemStack output, Ingredient input, int energy, int exp, ResourceLocation entityType) {
-        this(output, input, energy, exp, Optional.of(entityType), Optional.empty(), Optional.empty());
-    }
-
-    public SoulBindingRecipe(ItemStack output, Ingredient input, int energy, int exp, MobCategory mobCategory) {
-        this(output, input, energy, exp, Optional.empty(), Optional.of(mobCategory), Optional.empty());
-    }
-
-    public SoulBindingRecipe(ItemStack output, Ingredient input, int energy, int exp, String souldata) {
-        this(output, input, energy, exp, Optional.empty(), Optional.empty(), Optional.of(souldata));
-    }
+        Optional<ResourceLocation> entityType, Optional<MobCategory> mobCategory, Optional<String> soulData,
+        boolean copyInputComponents) implements MachineRecipe<SoulBindingRecipe.Input> {
 
     public Ingredient getInput() {
         return input;
@@ -63,12 +50,10 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
         ItemStack vial = input.getItem(0);
         List<OutputStack> results = getResultStacks(registryAccess);
         ItemStack result = results.getFirst().getItem();
-        if (MachineBlocks.POWERED_SPAWNER.getRegisteredName()
-                .equals(BuiltInRegistries.ITEM.wrapAsHolder(input.itemToBind.getItem()).getRegisteredName())) {
-            // Copy the input stack instead of the output defined in the recipe so extra
-            // data stored in the input is not lost.
-            // If not done the powered spawner loses all its settings, capacitor etc
-            result = input.itemToBind.copy();
+
+        if (copyInputComponents) {
+            result = new ItemStack(result.getItem().builtInRegistryHolder(), result.getCount(),
+                    input.itemToBind.getComponentsPatch());
             results = List.of(OutputStack.of(result),
                     OutputStack.of(EIOItems.EMPTY_SOUL_VIAL.get().getDefaultInstance()));
         }
@@ -192,10 +177,11 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
                         Codec.INT.fieldOf("experience").forGetter(SoulBindingRecipe::experience),
                         ResourceLocation.CODEC.optionalFieldOf("entity_type").forGetter(SoulBindingRecipe::entityType),
                         MobCategory.CODEC.optionalFieldOf("mob_category").forGetter(SoulBindingRecipe::mobCategory),
-                        Codec.STRING.optionalFieldOf("soul_data").forGetter(SoulBindingRecipe::soulData))
+                        Codec.STRING.optionalFieldOf("soul_data").forGetter(SoulBindingRecipe::soulData),
+                        Codec.BOOL.fieldOf("copyInputComponents").forGetter(SoulBindingRecipe::copyInputComponents))
                 .apply(instance, SoulBindingRecipe::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, SoulBindingRecipe> STREAM_CODEC = NeoForgeStreamCodecs
+        public static final StreamCodec<RegistryFriendlyByteBuf, SoulBindingRecipe> STREAM_CODEC = MassiveStreamCodec
                 .composite(ItemStack.STREAM_CODEC, SoulBindingRecipe::output, Ingredient.CONTENTS_STREAM_CODEC,
                         SoulBindingRecipe::input, ByteBufCodecs.INT, SoulBindingRecipe::energy, ByteBufCodecs.INT,
                         SoulBindingRecipe::experience, ResourceLocation.STREAM_CODEC.apply(ByteBufCodecs::optional),
@@ -205,7 +191,8 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
                                 name -> ((StringRepresentable.EnumCodec<MobCategory>) MobCategory.CODEC).byName(name),
                                 MobCategory::getName).apply(ByteBufCodecs::optional),
                         SoulBindingRecipe::mobCategory, ByteBufCodecs.STRING_UTF8.apply(ByteBufCodecs::optional),
-                        SoulBindingRecipe::soulData, SoulBindingRecipe::new);
+                        SoulBindingRecipe::soulData, ByteBufCodecs.BOOL, SoulBindingRecipe::copyInputComponents,
+                        SoulBindingRecipe::new);
 
         @Override
         public MapCodec<SoulBindingRecipe> codec() {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
@@ -34,7 +34,7 @@ import net.neoforged.neoforge.fluids.FluidStack;
 
 public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, int experience,
         Optional<ResourceLocation> entityType, Optional<MobCategory> mobCategory, Optional<String> soulData,
-        Optional<Boolean> copyInputComponents) implements MachineRecipe<SoulBindingRecipe.Input> {
+        boolean copyInputComponents) implements MachineRecipe<SoulBindingRecipe.Input> {
 
     public Ingredient getInput() {
         return input;
@@ -51,7 +51,7 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
         List<OutputStack> results = getResultStacks(registryAccess);
         ItemStack result = results.getFirst().getItem();
 
-        if (copyInputComponents.isPresent() && copyInputComponents.get()) {
+        if (copyInputComponents) {
             result = new ItemStack(result.getItem().builtInRegistryHolder(), result.getCount(),
                     input.itemToBind.getComponentsPatch());
             results = List.of(OutputStack.of(result),
@@ -178,7 +178,7 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
                         ResourceLocation.CODEC.optionalFieldOf("entity_type").forGetter(SoulBindingRecipe::entityType),
                         MobCategory.CODEC.optionalFieldOf("mob_category").forGetter(SoulBindingRecipe::mobCategory),
                         Codec.STRING.optionalFieldOf("soul_data").forGetter(SoulBindingRecipe::soulData),
-                        Codec.BOOL.optionalFieldOf("copyInputComponents")
+                        Codec.BOOL.optionalFieldOf("copyInputComponents", false)
                                 .forGetter(SoulBindingRecipe::copyInputComponents))
                 .apply(instance, SoulBindingRecipe::new));
 
@@ -192,8 +192,8 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
                                 name -> ((StringRepresentable.EnumCodec<MobCategory>) MobCategory.CODEC).byName(name),
                                 MobCategory::getName).apply(ByteBufCodecs::optional),
                         SoulBindingRecipe::mobCategory, ByteBufCodecs.STRING_UTF8.apply(ByteBufCodecs::optional),
-                        SoulBindingRecipe::soulData, ByteBufCodecs.BOOL.apply(ByteBufCodecs::optional),
-                        SoulBindingRecipe::copyInputComponents, SoulBindingRecipe::new);
+                        SoulBindingRecipe::soulData, ByteBufCodecs.BOOL, SoulBindingRecipe::copyInputComponents,
+                        SoulBindingRecipe::new);
 
         @Override
         public MapCodec<SoulBindingRecipe> codec() {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
@@ -8,11 +8,14 @@ import com.enderio.base.common.tag.EIOTags;
 import com.enderio.base.common.util.ExperienceUtil;
 import com.enderio.core.common.recipes.OutputStack;
 import com.enderio.machines.common.blocks.base.MachineRecipe;
+import com.enderio.machines.common.init.MachineBlocks;
 import com.enderio.machines.common.init.MachineRecipes;
 import com.enderio.machines.common.souldata.SoulDataReloadListener;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import java.util.Optional;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -29,9 +32,6 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.network.codec.NeoForgeStreamCodecs;
-
-import java.util.List;
-import java.util.Optional;
 
 public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, int experience,
         Optional<ResourceLocation> entityType, Optional<MobCategory> mobCategory, Optional<String> soulData)
@@ -63,6 +63,15 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
         ItemStack vial = input.getItem(0);
         List<OutputStack> results = getResultStacks(registryAccess);
         ItemStack result = results.getFirst().getItem();
+        if (MachineBlocks.POWERED_SPAWNER.getRegisteredName()
+                .equals(BuiltInRegistries.ITEM.wrapAsHolder(input.itemToBind.getItem()).getRegisteredName())) {
+            // Copy the input stack instead of the output defined in the recipe so extra
+            // data stored in the input is not lost.
+            // If not done the powered spawner loses all its settings, capacitor etc
+            result = input.itemToBind.copy();
+            results = List.of(OutputStack.of(result),
+                    OutputStack.of(EIOItems.EMPTY_SOUL_VIAL.get().getDefaultInstance()));
+        }
 
         var storedEntityData = vial.getOrDefault(EIODataComponents.STORED_ENTITY, StoredEntityData.EMPTY);
         if (result.is(EIOTags.Items.ENTITY_STORAGE)) {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_binder/SoulBindingRecipe.java
@@ -52,10 +52,7 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
         ItemStack result = results.getFirst().getItem();
 
         if (copyInputComponents) {
-            result = new ItemStack(result.getItem().builtInRegistryHolder(), result.getCount(),
-                    input.itemToBind.getComponentsPatch());
-            results = List.of(OutputStack.of(result),
-                    OutputStack.of(EIOItems.EMPTY_SOUL_VIAL.get().getDefaultInstance()));
+            result.applyComponents(input.itemToBind.getComponents());
         }
 
         var storedEntityData = vial.getOrDefault(EIODataComponents.STORED_ENTITY, StoredEntityData.EMPTY);

--- a/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
@@ -42,7 +42,8 @@ public class SoulBindingRecipeProvider extends RecipeProvider {
         build(EIOItems.SENTIENT_ENDER, Ingredient.of(EIOItems.ENDER_RESONATOR), 51200, 4, EntityType.WITCH,
                 recipeOutput);
         build(EIOItems.BROKEN_SPAWNER, Ingredient.of(EIOItems.BROKEN_SPAWNER), 288000, 8, recipeOutput);
-        build(MachineBlocks.POWERED_SPAWNER, Ingredient.of(MachineBlocks.POWERED_SPAWNER), 288000, 8, recipeOutput);
+        build(MachineBlocks.POWERED_SPAWNER, Ingredient.of(MachineBlocks.POWERED_SPAWNER), 288000, 8, true,
+                recipeOutput);
         build(MachineBlocks.SOUL_ENGINE, Ingredient.of(MachineBlocks.SOUL_ENGINE), 188000, 5, EngineSoul.NAME,
                 recipeOutput);
         build(EIOItems.PLAYER_TOKEN, Ingredient.of(EIOItems.DARK_STEEL_BALL), 12800, 1, EntityType.VILLAGER,
@@ -66,27 +67,37 @@ public class SoulBindingRecipeProvider extends RecipeProvider {
     protected void build(ItemLike output, Ingredient input, int energy, int exp,
             EntityType<? extends Entity> entityType, RecipeOutput recipeOutput) {
         build(output, input, energy, exp, Optional.of(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)),
-                Optional.empty(), Optional.empty(), recipeOutput);
+                Optional.empty(), Optional.empty(), false, recipeOutput);
     }
 
     protected void build(ItemLike output, Ingredient input, int energy, int exp, MobCategory mobCategory,
             RecipeOutput recipeOutput) {
-        build(output, input, energy, exp, Optional.empty(), Optional.of(mobCategory), Optional.empty(), recipeOutput);
+        build(output, input, energy, exp, Optional.empty(), Optional.of(mobCategory), Optional.empty(), false,
+                recipeOutput);
     }
 
     protected void build(ItemLike output, Ingredient input, int energy, int exp, String souldata,
             RecipeOutput recipeOutput) {
-        build(output, input, energy, exp, Optional.empty(), Optional.empty(), Optional.of(souldata), recipeOutput);
+        build(output, input, energy, exp, Optional.empty(), Optional.empty(), Optional.of(souldata), false,
+                recipeOutput);
     }
 
     protected void build(ItemLike output, Ingredient input, int energy, int exp, RecipeOutput recipeOutput) {
-        build(output, input, energy, exp, Optional.empty(), Optional.empty(), Optional.empty(), recipeOutput);
+        build(output, input, energy, exp, Optional.empty(), Optional.empty(), Optional.empty(), false, recipeOutput);
+    }
+
+    protected void build(ItemLike output, Ingredient input, int energy, int exp, boolean copyInputData,
+            RecipeOutput recipeOutput) {
+        build(output, input, energy, exp, Optional.empty(), Optional.empty(), Optional.empty(), copyInputData,
+                recipeOutput);
     }
 
     protected void build(ItemLike output, Ingredient input, int energy, int exp, Optional<ResourceLocation> entityType,
-            Optional<MobCategory> mobCategory, Optional<String> souldata, RecipeOutput recipeOutput) {
+            Optional<MobCategory> mobCategory, Optional<String> souldata, boolean copyInputData,
+            RecipeOutput recipeOutput) {
         recipeOutput.accept(EnderIO.loc("soulbinding/" + BuiltInRegistries.ITEM.getKey(output.asItem()).getPath()),
-                new SoulBindingRecipe(new ItemStack(output), input, energy, exp, entityType, mobCategory, souldata),
+                new SoulBindingRecipe(new ItemStack(output), input, energy, exp, entityType, mobCategory, souldata,
+                        copyInputData),
                 null);
     }
 

--- a/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
@@ -97,7 +97,7 @@ public class SoulBindingRecipeProvider extends RecipeProvider {
             RecipeOutput recipeOutput) {
         recipeOutput.accept(EnderIO.loc("soulbinding/" + BuiltInRegistries.ITEM.getKey(output.asItem()).getPath()),
                 new SoulBindingRecipe(new ItemStack(output), input, energy, exp, entityType, mobCategory, souldata,
-                        copyInputData),
+                        Optional.of(copyInputData)),
                 null);
     }
 

--- a/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
@@ -97,7 +97,7 @@ public class SoulBindingRecipeProvider extends RecipeProvider {
             RecipeOutput recipeOutput) {
         recipeOutput.accept(EnderIO.loc("soulbinding/" + BuiltInRegistries.ITEM.getKey(output.asItem()).getPath()),
                 new SoulBindingRecipe(new ItemStack(output), input, energy, exp, entityType, mobCategory, souldata,
-                        Optional.of(copyInputData)),
+                        copyInputData),
                 null);
     }
 


### PR DESCRIPTION
# Description

When rebinding a powered spawner it's capacitor and all its settings are lost.
The fix for this is very hard coded but I can't see any other way around it.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
