### PR TITLE
Fixed using the wrench to break legacy machine blocks not working.

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/LegacyMachineBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/LegacyMachineBlockEntity.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -533,7 +532,6 @@ public abstract class LegacyMachineBlockEntity extends EnderBlockEntity
         return pPlayer.canInteractWithBlock(this.worldPosition, 1.5);
     }
 
-    @EnsureSide(EnsureSide.Side.CLIENT)
     @Override
     public ItemInteractionResult onWrenched(@Nullable Player player, @Nullable Direction side) {
         if (player == null || level == null) {

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/LegacyMachineBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/base/LegacyMachineBlockEntity.java
@@ -532,6 +532,9 @@ public abstract class LegacyMachineBlockEntity extends EnderBlockEntity
         return pPlayer.canInteractWithBlock(this.worldPosition, 1.5);
     }
 
+    // TODO: should be enabled once the client side call in WrenchableBlockHandler
+    // is removed
+    // @EnsureSide(EnsureSide.Side.SERVER)
     @Override
     public ItemInteractionResult onWrenched(@Nullable Player player, @Nullable Direction side) {
         if (player == null || level == null) {


### PR DESCRIPTION
# Description

Breaking any legacy machine blocks with a wrench threw exceptions. This was caused by a side only annotation on a method that checked for server side specific code. 

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
