### PR TITLE
Fix Issue #995 Voiding mended item in XP tank

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/fluid_tank/FluidTankBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/fluid_tank/FluidTankBlockEntity.java
@@ -331,14 +331,14 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
     private void tryMendTool() {
         FluidStack fluid = TANK.getFluid(this);
 
-        if (!fluid.isEmpty() && fluid.is(EIOTags.Fluids.EXPERIENCE)) {
+        if (!fluid.isEmpty() && fluid.is(EIOTags.Fluids.EXPERIENCE)
+                && FLUID_DRAIN_OUTPUT.getItemStack(this).isEmpty()) {
             ItemStack tool = FLUID_DRAIN_INPUT.getItemStack(this);
 
             var enchantmentsRecipe = level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
             var mendingEnchantment = enchantmentsRecipe.getOrThrow(Enchantments.MENDING);
 
-            if (tool.isDamageableItem() && tool.getEnchantmentLevel(mendingEnchantment) > 0
-                    && FLUID_DRAIN_OUTPUT.getItemStack(this).isEmpty()) {
+            if (tool.isDamageableItem() && tool.getEnchantmentLevel(mendingEnchantment) > 0) {
 
                 ItemStack repairedTool = tool.copy();
 

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/fluid_tank/FluidTankBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/fluid_tank/FluidTankBlockEntity.java
@@ -15,6 +15,8 @@ import com.enderio.machines.common.io.fluid.MachineFluidHandler;
 import com.enderio.machines.common.io.fluid.MachineFluidTank;
 import com.enderio.machines.common.io.fluid.MachineTankLayout;
 import com.enderio.machines.common.io.fluid.TankAccess;
+import java.util.List;
+import java.util.Optional;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
@@ -40,9 +42,6 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
 import org.apache.commons.lang3.NotImplementedException;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
-import java.util.Optional;
 
 // TODO: Rewrite this with tasks?
 //       Could implement a task for each thing it currently has in the If's
@@ -338,7 +337,8 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
             var enchantmentsRecipe = level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
             var mendingEnchantment = enchantmentsRecipe.getOrThrow(Enchantments.MENDING);
 
-            if (tool.isDamageableItem() && tool.getEnchantmentLevel(mendingEnchantment) > 0) {
+            if (tool.isDamageableItem() && tool.getEnchantmentLevel(mendingEnchantment) > 0
+                    && FLUID_DRAIN_OUTPUT.getItemStack(this).isEmpty()) {
 
                 ItemStack repairedTool = tool.copy();
 


### PR DESCRIPTION
# Description

Repairing a mending item in the XP tank would void any item already in the output slot.
Fixes #995 

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
