### PR TITLE
Fix StackOverflow when loading large conduit networks

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/network/ConduitSavedData.java
+++ b/src/conduits/java/com/enderio/conduits/common/network/ConduitSavedData.java
@@ -94,11 +94,22 @@ public class ConduitSavedData extends SavedData {
                         connections.add(new Pair<>(graphObjects.get(connectionTag.getInt("0")), graphObjects.get(connectionTag.getInt("1"))));
                     }
 
-                    ConduitGraphObject<?> graphObject = graphObjects.get(0);
-                    Graph.integrate(graphObject, List.of());
-                    merge(graphObject, connections);
+                    for (ConduitGraphObject<?> graphObject : graphObjects) {
+                        // Find neighbors
+                        var neighbors = connections
+                            .stream()
+                            .filter(pair -> (pair.getFirst() == graphObject || pair.getSecond() == graphObject))
+                            .map(pair -> pair.getFirst() == graphObject ? pair.getSecond() : pair.getFirst())
+                            .distinct()
+                            .toList();
 
-                    networks.computeIfAbsent(value, ignored -> new ArrayList<>()).add(graphObject.getGraph());
+                        Graph.integrate(graphObject, neighbors);
+                    }
+
+                    // Get the graph from the loaded data
+                    var firstGraphObject = graphObjects.get(0);
+                    var graph = firstGraphObject.getGraph();
+                    networks.computeIfAbsent(value, ignored -> new ArrayList<>()).add(graph);
                 }
             }
         }
@@ -208,23 +219,6 @@ public class ConduitSavedData extends SavedData {
     }
 
     // endregion
-
-    private void merge(GraphObject<Mergeable.Dummy> object, List<Pair<GraphObject<Mergeable.Dummy>, GraphObject<Mergeable.Dummy>>> connections) {
-        var filteredConnections = connections.stream().filter(pair -> (pair.getFirst() == object || pair.getSecond() == object)).toList();
-        List<GraphObject<Mergeable.Dummy>> neighbors = filteredConnections
-            .stream()
-            .map(pair -> pair.getFirst() == object ? pair.getSecond() : pair.getFirst())
-            .toList();
-
-        for (GraphObject<Mergeable.Dummy> neighbor : neighbors) {
-            Graph.connect(object, neighbor);
-        }
-
-        connections = connections.stream().filter(v -> !filteredConnections.contains(v)).toList();
-        if (!connections.isEmpty()) {
-            merge(connections.get(0).getFirst(), connections);
-        }
-    }
 
     @Nullable
     public <T extends ConduitData<T>> ConduitGraphObject<T> takeUnloadedNodeIdentifier(ConduitType<T> type, BlockPos pos) {


### PR DESCRIPTION
# Description

Untested! Pending testing from a user affected by this bug.

This should not impact loading of conduits in any breaking way, except perhaps make it faster.

Will need to be ported to 1.21.1 if this solves the problem.

If you have experienced this problem, please test using this build:
[EnderIO-1.20.1-6.2-dev-conduit-recursion-fffdda3a2-all.jar.zip](https://github.com/user-attachments/files/18856045/EnderIO-1.20.1-6.2-dev-conduit-recursion-fffdda3a2-all.jar.zip)

Closes: GH-1004

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
