### PR TITLE
Powered machines not updating state correctly

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/blockentity/MachineBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/blockentity/MachineBlockEntity.java
@@ -115,7 +115,8 @@ public abstract class MachineBlockEntity extends EIOBlockEntity
 
         // Every 5 ticks, ensure active state is up-to-date.
         // Doing this every 5 ticks instead of every tick should reduce visual flicker.
-        if (canAct(5)) {
+        if (level != null && level.getGameTime() % 5 == 0) {
+
             boolean isActive = isActive();
             boolean needBlockStateUpdate = supportsActiveState
                     && getBlockState().getValue(ProgressMachineBlock.POWERED) != isActive;


### PR DESCRIPTION
# Description

State was only being updated when canUse returned true. This meant that if the state changed so that canUse went from true to false the state change was not applied.
An example of this occurring is turning on 'only active with redstone signal'. This results in canUse returning false so the the check fails and the state update is not made. This results, for example, the StirlingGen block still showing its active 'running' block on the client when it has been disabled.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved machine update processing to enhance system stability and prevent potential runtime issues during regular operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->