### PR TITLE
Update to Create 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,8 @@ void exclusiveRepo(RepositoryHandler handler, String url, Consumer<InclusiveRepo
 }
 
 repositories { RepositoryHandler handler ->
-    exclusiveRepo(handler, 'https://maven.tterrag.com/', 'com.tterrag.registrate', 'com.jozufozu.flywheel')
+    exclusiveRepo(handler, 'https://maven.tterrag.com/', 'com.tterrag.registrate')
+    exclusiveRepo(handler, 'https://maven.createmod.net/', 'dev.engine-room.flywheel')
     exclusiveRepo(handler, "https://modmaven.dev/", "mezz.jei", "mcjty.theoneprobe", "appeng", "mekanism")
     exclusiveRepo(handler, 'https://cursemaven.com', 'curse.maven')
     exclusiveRepo(handler, 'https://maven.blamejared.com', 'vazkii.patchouli', 'net.darkhax.bookshelf', 'net.darkhax.enchdesc', 'com.almostreliable.mods')
@@ -281,8 +282,8 @@ dependencies {
     //fluxnetworks
     localRuntime fg.deobf("curse.maven:fluxnetworks-248020:4651164")
 
-    //Flywheel
-    compileOnly fg.deobf("com.jozufozu.flywheel:flywheel-forge-1.20.1:0.6.9-5") // REMOVE When crash is fixed
+    // Flywheel -- REMOVE When crash is fixed
+    compileOnly fg.deobf("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:1.0.1")
 
     // Almost Unified
     compileOnly fg.deobf("com.almostreliable.mods:almostunified-forge:${minecraft_version}-${almostunified_version}")

--- a/src/core/java/com/enderio/core/common/compat/FlywheelCompat.java
+++ b/src/core/java/com/enderio/core/common/compat/FlywheelCompat.java
@@ -1,6 +1,6 @@
 package com.enderio.core.common.compat;
 
-import com.jozufozu.flywheel.core.virtual.VirtualRenderWorld;
+import dev.engine_room.flywheel.api.visualization.VisualizationLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -10,7 +10,7 @@ public class FlywheelCompat {
 
     @Nullable
     public static BlockEntity getExistingBlockEntity(BlockGetter level, BlockPos pos) {
-        if (level instanceof VirtualRenderWorld) {
+        if (level instanceof VisualizationLevel) {
             return level.getBlockEntity(pos);
         }
         return level.getExistingBlockEntity(pos);

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -49,3 +49,10 @@ modId="kubejs_enderio"
 mandatory=false
 versionRange="[1.20.1-0.6.0,)"
 side="BOTH"
+
+# Flywheel breaking changes
+[[dependencies.enderio]]
+modId="create"
+mandatory=false
+versionRange="[6.0.0,)"
+side="BOTH"


### PR DESCRIPTION
# Description

I'm actually unsure if this workaround is even required after Create 6, as we've not had this workaround in 1.21.1 for a while - but I feel its probably best to keep it.

~~Changes FlywheelCompat -> CreateCompat as the VirtualRenderWorld moved from Flywheel to Create.~~
Also declares a non-mandatory dependency on Create 6 to prevent use with older versions.

Closes #1019 

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
