### PR TITLE
Fix some memory leaks

### DIFF
--- a/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -172,7 +172,9 @@ public class EnderBlockEntity extends BlockEntity {
             buf.writeInt(i);
             dataSlots.get(i).write(buf);
         });
-        return buf.array();
+        byte[] arr = buf.array();
+        buf.release();
+        return arr;
     }
 
     @Deprecated(forRemoval = true, since = "7.1")
@@ -201,6 +203,7 @@ public class EnderBlockEntity extends BlockEntity {
             buf.writeInt(dataSlots.indexOf(slot));
             slot.write(buf, value);
             PacketDistributor.sendToServer(new ClientboundDataSlotChange(getBlockPos(), buf.array()));
+            buf.release();
             level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_NEIGHBORS);
         }
     }

--- a/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import me.liliandev.ensure.ensures.EnsureSide;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -38,8 +39,8 @@ public class EnderBlockEntity extends BlockEntity {
 
     public static final String DATA = "Data";
     public static final String INDEX = "Index";
-    private final List<NetworkDataSlot<?>> dataSlots = new ArrayList<>();
-    private final List<Runnable> afterDataSync = new ArrayList<>();
+    private final List<NetworkDataSlot<?>> dataSlots = new CopyOnWriteArrayList<>();
+    private final List<Runnable> afterDataSync = new CopyOnWriteArrayList<>();
     private boolean isChangedDeferred = true;
 
     private final Map<BlockCapability<?, ?>, EnumMap<Direction, BlockCapabilityCache<?, ?>>> selfCapabilities = new HashMap<>();

--- a/endercore/src/main/java/com/enderio/core/common/network/ClientPayloadHandler.java
+++ b/endercore/src/main/java/com/enderio/core/common/network/ClientPayloadHandler.java
@@ -41,6 +41,7 @@ public class ClientPayloadHandler {
                 var buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(update.slotData()),
                         level.registryAccess());
                 enderBlockEntity.clientHandleBufferSync(buf);
+                buf.release();
             }
         });
     }
@@ -54,6 +55,7 @@ public class ClientPayloadHandler {
                     }
                 }
             }
+
         });
     }
 }

--- a/endercore/src/main/java/com/enderio/core/common/network/ServerPayloadHandler.java
+++ b/endercore/src/main/java/com/enderio/core/common/network/ServerPayloadHandler.java
@@ -24,6 +24,7 @@ public class ServerPayloadHandler {
                 var buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(change.updateData()),
                         level.registryAccess());
                 enderBlockEntity.serverHandleBufferChange(buf);
+                buf.release();
             }
         });
     }

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/capacitorbank/CapacitorBankBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/capacitorbank/CapacitorBankBlockEntity.java
@@ -17,10 +17,6 @@ import com.enderio.machines.common.menu.CapacitorBankMenu;
 import dev.gigaherz.graph3.Graph;
 import dev.gigaherz.graph3.GraphObject;
 import dev.gigaherz.graph3.Mergeable;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -34,6 +30,11 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 
 public class CapacitorBankBlockEntity extends LegacyPoweredMachineBlockEntity implements MultiConfigurable {
 

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/capacitorbank/CapacitorBankBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blockentity/capacitorbank/CapacitorBankBlockEntity.java
@@ -17,6 +17,10 @@ import com.enderio.machines.common.menu.CapacitorBankMenu;
 import dev.gigaherz.graph3.Graph;
 import dev.gigaherz.graph3.GraphObject;
 import dev.gigaherz.graph3.Mergeable;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -30,11 +34,6 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
 
 public class CapacitorBankBlockEntity extends LegacyPoweredMachineBlockEntity implements MultiConfigurable {
 


### PR DESCRIPTION
# Description

- Releasing all the bytebufs that we created (not releasing causes some memory leaks and gc being slower)

With this patch i somehow got an improvement of ~+4 TPS on a NeoForge server with big capacitors (1100+ blocks)
From an average of ~13.5 to ~17.6 (~30% improvement)

# Breaking Changes

Nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread safety for certain internal lists to enhance stability during concurrent operations.
  - Enhanced resource management to prevent potential memory leaks during network data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->