### PR TITLE
Fix - Update maven dependency; athena-ctm -> stitch

### DIFF
--- a/enderio/build.gradle.kts
+++ b/enderio/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
 //    runtimeOnly("cc.tweaked:cc-tweaked-$cctMinecraftVersion-forge:$cctVersion")
 
     //Athena ctm
-    runtimeOnly("maven.modrinth:athena-ctm:${athenaVersion}")
+    runtimeOnly("maven.modrinth:stitch:${athenaVersion}")
 
     // AE2
     runtimeOnly("appeng:appliedenergistics2:${ae2Version}")

--- a/enderio/build.gradle.kts
+++ b/enderio/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     // TODO: Does not start on latest NeoForge
 //    runtimeOnly("cc.tweaked:cc-tweaked-$cctMinecraftVersion-forge:$cctVersion")
 
-    //Athena ctm
+    // Athena ctm - renamed to "Stitch"
     runtimeOnly("maven.modrinth:stitch:${athenaVersion}")
 
     // AE2


### PR DESCRIPTION
# Description

[Athena recently updated its name to "Stitch,"](https://modrinth.com/mod/stitch) this broke the build process as Athena is no longer listed in the maven repository anymore under `athena-ctm`.  I had considered renaming all mentions of Athena, however, the mod still calls itself Athena internally so I decided against that.

# Breaking Changes

This shouldn't break anything.  

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated a runtime dependency to use a new library name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->