### PR TITLE
add soul binding recipes for infestation

### DIFF
--- a/enderio-base/src/main/resources/META-INF/accesstransformer.cfg
+++ b/enderio-base/src/main/resources/META-INF/accesstransformer.cfg
@@ -43,3 +43,5 @@ public-f net.minecraft.client.renderer.block.model.BakedQuad sprite
 public net.minecraft.client.renderer.LevelRenderer renderShape(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/world/phys/shapes/VoxelShape;DDDFFFF)V # renderShape
 
 public net.minecraft.client.renderer.LevelRenderer viewArea # viewArea
+
+public net.minecraft.world.level.block.InfestedBlock BLOCK_BY_HOST_BLOCK # BLOCK_BY_HOST_BLOCK

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/animal_token.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/animal_token.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 12800,
   "experience": 1,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/ender_crystal.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/ender_crystal.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 76800,
   "entity_type": "minecraft:enderman",
   "experience": 6,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/energetic_photovoltaic_module.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/energetic_photovoltaic_module.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 12800,
   "entity_type": "minecraft:phantom",
   "experience": 8,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/enticing_crystal.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/enticing_crystal.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:villager",
   "experience": 4,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/frank_n_zombie.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/frank_n_zombie.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:zombie",
   "experience": 4,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_chiseled_stone_bricks.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_chiseled_stone_bricks.json
@@ -1,0 +1,13 @@
+{
+  "type": "enderio:soul_binding",
+  "energy": 10000,
+  "entity_type": "minecraft:silverfish",
+  "experience": 0,
+  "input": {
+    "item": "minecraft:chiseled_stone_bricks"
+  },
+  "output": {
+    "count": 1,
+    "id": "minecraft:infested_chiseled_stone_bricks"
+  }
+}

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_cobblestone.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_cobblestone.json
@@ -1,0 +1,13 @@
+{
+  "type": "enderio:soul_binding",
+  "energy": 10000,
+  "entity_type": "minecraft:silverfish",
+  "experience": 0,
+  "input": {
+    "item": "minecraft:cobblestone"
+  },
+  "output": {
+    "count": 1,
+    "id": "minecraft:infested_cobblestone"
+  }
+}

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_cracked_stone_bricks.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_cracked_stone_bricks.json
@@ -1,0 +1,13 @@
+{
+  "type": "enderio:soul_binding",
+  "energy": 10000,
+  "entity_type": "minecraft:silverfish",
+  "experience": 0,
+  "input": {
+    "item": "minecraft:cracked_stone_bricks"
+  },
+  "output": {
+    "count": 1,
+    "id": "minecraft:infested_cracked_stone_bricks"
+  }
+}

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_deepslate.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_deepslate.json
@@ -1,0 +1,13 @@
+{
+  "type": "enderio:soul_binding",
+  "energy": 10000,
+  "entity_type": "minecraft:silverfish",
+  "experience": 0,
+  "input": {
+    "item": "minecraft:deepslate"
+  },
+  "output": {
+    "count": 1,
+    "id": "minecraft:infested_deepslate"
+  }
+}

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_mossy_stone_bricks.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_mossy_stone_bricks.json
@@ -1,0 +1,13 @@
+{
+  "type": "enderio:soul_binding",
+  "energy": 10000,
+  "entity_type": "minecraft:silverfish",
+  "experience": 0,
+  "input": {
+    "item": "minecraft:mossy_stone_bricks"
+  },
+  "output": {
+    "count": 1,
+    "id": "minecraft:infested_mossy_stone_bricks"
+  }
+}

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_stone.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_stone.json
@@ -1,0 +1,13 @@
+{
+  "type": "enderio:soul_binding",
+  "energy": 10000,
+  "entity_type": "minecraft:silverfish",
+  "experience": 0,
+  "input": {
+    "item": "minecraft:stone"
+  },
+  "output": {
+    "count": 1,
+    "id": "minecraft:infested_stone"
+  }
+}

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_stone_bricks.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/infested_stone_bricks.json
@@ -1,0 +1,13 @@
+{
+  "type": "enderio:soul_binding",
+  "energy": 10000,
+  "entity_type": "minecraft:silverfish",
+  "experience": 0,
+  "input": {
+    "item": "minecraft:stone_bricks"
+  },
+  "output": {
+    "count": 1,
+    "id": "minecraft:infested_stone_bricks"
+  }
+}

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/monster_token.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/monster_token.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 12800,
   "experience": 1,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/player_token.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/player_token.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 12800,
   "entity_type": "minecraft:villager",
   "experience": 1,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/prescient_crystal.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/prescient_crystal.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 100000,
   "entity_type": "minecraft:shulker",
   "experience": 8,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/pulsating_photovoltaic_module.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/pulsating_photovoltaic_module.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:phantom",
   "experience": 12,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/sentient_ender.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/sentient_ender.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 51200,
   "entity_type": "minecraft:witch",
   "experience": 4,

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/soul_engine.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/soul_engine.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 188000,
   "experience": 5,
   "input": {

--- a/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/vibrant_photovoltaic_module.json
+++ b/enderio-machines/src/generated/resources/data/enderio/recipe/soulbinding/vibrant_photovoltaic_module.json
@@ -1,6 +1,5 @@
 {
   "type": "enderio:soul_binding",
-  "copyInputComponents": false,
   "energy": 288000,
   "entity_type": "minecraft:phantom",
   "experience": 14,

--- a/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/data/recipes/SoulBindingRecipeProvider.java
@@ -8,6 +8,8 @@ import com.enderio.machines.common.blocks.soul_binder.SoulBindingRecipe;
 import com.enderio.machines.common.init.MachineBlocks;
 import com.enderio.machines.common.souldata.EngineSoul;
 import com.enderio.machines.common.souldata.FarmSoul;
+
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import net.minecraft.core.HolderLookup;
@@ -19,9 +21,13 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.InfestedBlock;
 import net.neoforged.neoforge.common.Tags;
 
 public class SoulBindingRecipeProvider extends RecipeProvider {
@@ -65,6 +71,11 @@ public class SoulBindingRecipeProvider extends RecipeProvider {
                 Ingredient.of(MachineBlocks.SOLAR_PANELS.get(SolarPanelTier.VIBRANT)), 288000, 14, EntityType.PHANTOM,
                 recipeOutput);
 
+        InfestedBlock.BLOCK_BY_HOST_BLOCK.forEach((original, infested) -> buildInfested(infested, original, recipeOutput));
+    }
+
+    protected void buildInfested(ItemLike infestedItem, ItemLike original, RecipeOutput recipeOutput) {
+        build(infestedItem, Ingredient.of(original), 10000, 0, EntityType.SILVERFISH, recipeOutput);
     }
 
     protected void build(ItemLike output, Ingredient input, int energy, int exp,


### PR DESCRIPTION
add recipes for silverfish infested blocks

# Description

Adds a recipe to infest stone like blocks with a silverfish, recipe is cheap regarding power and requires no xp, feedback on the values are welcome. 

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new soul binding recipes for infested blocks, allowing users to bind infested variants to their original blocks.

- **Chores**
  - Updated internal configuration to support new recipe functionality for infested blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->