### PR TITLE
Allow creative only binding of machines

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/SpawnEggSoulHandler.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/SpawnEggSoulHandler.java
@@ -1,0 +1,55 @@
+package com.enderio.base.common.compat.vanilla;
+
+import com.enderio.base.api.soul.Soul;
+import com.enderio.base.api.soul.storage.ISoulHandler;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.SpawnEggItem;
+import net.minecraft.world.item.component.CustomData;
+
+public class SpawnEggSoulHandler implements ISoulHandler {
+    private final ItemStack spawnEgg;
+
+    public SpawnEggSoulHandler(ItemStack spawnEgg) {
+        this.spawnEgg = spawnEgg;
+    }
+
+    @Override
+    public int getSlots() {
+        return 1;
+    }
+
+    @Override
+    public Soul getSoulInSlot(int slot) {
+        if (slot > 0) {
+            return Soul.EMPTY;
+        }
+
+        if (!(spawnEgg.getItem() instanceof SpawnEggItem spawnEggItem)) {
+            return Soul.EMPTY;
+        }
+
+        // Get custom entity data
+        var customEntityData = spawnEgg.getOrDefault(DataComponents.ENTITY_DATA, CustomData.EMPTY);
+        if (!customEntityData.isEmpty()) {
+            return new Soul(customEntityData.copyTag());
+        }
+
+        return Soul.of(spawnEggItem.getType(spawnEgg));
+    }
+
+    @Override
+    public boolean tryInsertSoul(Soul soul, boolean isSimulate) {
+        return false;
+    }
+
+    @Override
+    public Soul tryExtractSoul(boolean isSimulate) {
+        return getSoulInSlot(0);
+    }
+
+    @Override
+    public boolean isSoulValid(int slot, Soul soul) {
+        return false;
+    }
+}

--- a/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/VanillaCompat.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/VanillaCompat.java
@@ -2,6 +2,7 @@ package com.enderio.base.common.compat.vanilla;
 
 import com.enderio.EnderIOBase;
 import com.enderio.base.api.soul.binding.ISoulBindable;
+import com.enderio.base.api.soul.storage.ISoulHandler;
 import com.enderio.base.common.init.EIOCapabilities;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.SpawnEggItem;
@@ -16,10 +17,14 @@ public class VanillaCompat {
     public static final ICapabilityProvider<ItemStack, Void, ISoulBindable> SPAWN_EGG_BINDABLE_PROVIDER =
         (stack, v) -> new SpawnEggSoulBindable(stack);
 
+    public static final ICapabilityProvider<ItemStack, Void, ISoulHandler> SPAWN_EGG_HANDLER_PROVIDER =
+        (stack, v) -> new SpawnEggSoulHandler(stack);
+
     @SubscribeEvent
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
         for (var spawnEgg : SpawnEggItem.eggs()) {
             event.registerItem(EIOCapabilities.SoulBindable.ITEM, SPAWN_EGG_BINDABLE_PROVIDER, spawnEgg);
+            event.registerItem(EIOCapabilities.SoulHandler.ITEM, SPAWN_EGG_HANDLER_PROVIDER, spawnEgg);
         }
     }
 }

--- a/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
@@ -4,22 +4,12 @@ import com.enderio.EnderIOBase;
 import com.enderio.base.api.EnderIO;
 import com.enderio.base.api.soul.Soul;
 import com.enderio.base.api.soul.SoulBoundUtils;
-import com.enderio.base.api.soul.binding.ComponentSoulBindable;
-import com.enderio.base.api.soul.binding.ISoulBindable;
-import com.enderio.base.api.soul.storage.ISoulHandler;
-import com.enderio.base.api.soul.storage.SingleComponentSoulHandler;
-import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.init.EIODataComponents;
 import com.enderio.base.common.init.EIOItems;
 import com.enderio.base.common.lang.EIOLang;
 import com.enderio.base.common.util.EntityCaptureUtils;
 import com.enderio.core.client.item.AdvancedTooltipProvider;
 import com.enderio.core.common.util.TooltipUtil;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.dispenser.BlockSource;
@@ -35,7 +25,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.animal.Wolf;
-import net.minecraft.world.entity.animal.horse.AbstractChestedHorse;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
 import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.npc.WanderingTrader;
 import net.minecraft.world.entity.player.Player;
@@ -48,9 +38,14 @@ import net.minecraft.world.phys.AABB;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 @EventBusSubscriber(modid = EnderIOBase.MODULE_MOD_ID)
 public class SoulVialItem extends Item implements AdvancedTooltipProvider {
@@ -267,7 +262,7 @@ public class SoulVialItem extends Item implements AdvancedTooltipProvider {
         }
 
         if (stack.is(EIOItems.SOUL_VIAL.get())) {
-            if (event.getTarget() instanceof AbstractChestedHorse || event.getTarget() instanceof Villager
+            if (event.getTarget() instanceof AbstractHorse || event.getTarget() instanceof Villager
                     || event.getTarget() instanceof WanderingTrader || event.getTarget() instanceof Wolf) {
                 stack.interactLivingEntity(event.getEntity(), (LivingEntity) event.getTarget(), event.getHand());
             }

--- a/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
@@ -8,6 +8,7 @@ import com.enderio.base.api.soul.binding.ComponentSoulBindable;
 import com.enderio.base.api.soul.binding.ISoulBindable;
 import com.enderio.base.api.soul.storage.ISoulHandler;
 import com.enderio.base.api.soul.storage.SingleComponentSoulHandler;
+import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.init.EIODataComponents;
 import com.enderio.base.common.init.EIOItems;
 import com.enderio.base.common.lang.EIOLang;
@@ -149,6 +150,7 @@ public class SoulVialItem extends Item implements AdvancedTooltipProvider {
         if (player == null) {
             return InteractionResult.FAIL;
         }
+
         return releaseEntity(pContext.getLevel(), pContext.getItemInHand(), pContext.getClickedFace(),
                 pContext.getClickedPos(), emptyVial -> player.setItemInHand(pContext.getHand(), emptyVial));
     }

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/block/MachineBlock.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/block/MachineBlock.java
@@ -1,13 +1,19 @@
 package com.enderio.machines.common.blocks.base.block;
 
+import com.enderio.base.api.soul.Soul;
+import com.enderio.base.api.soul.binding.ISoulBindable;
+import com.enderio.base.api.soul.storage.ISoulHandler;
 import com.enderio.base.common.block.EIOEntityBlock;
+import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.machines.common.blocks.base.blockentity.MachineBlockEntity;
 import com.mojang.serialization.MapCodec;
 import java.util.function.Supplier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -97,5 +103,28 @@ public class MachineBlock<T extends MachineBlockEntity> extends EIOEntityBlock<T
         if (placer instanceof Player player && level.getBlockEntity(pos) instanceof MachineBlockEntity machine) {
             machine.setMachineOwner(player.getUUID());
         }
+    }
+
+    @Override
+    protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
+        BlockHitResult hitResult) {
+        if (!player.getAbilities().instabuild) {
+            return super.useItemOn(stack, state, level, pos, player, hand, hitResult);
+        }
+
+        ISoulBindable soulBindable = level.getCapability(EIOCapabilities.SoulBindable.BLOCK, pos);
+        if (soulBindable != null && soulBindable.canBind()) {
+            ISoulHandler soulHandler = stack.getCapability(EIOCapabilities.SoulHandler.ITEM);
+            if (soulHandler != null) {
+                for (int i = 0; i < soulHandler.getSlots(); i++) {
+                    Soul soul = soulHandler.getSoulInSlot(i);
+                    if (soulBindable.isSoulValid(soul)) {
+                        soulBindable.bindSoul(soul.copy());
+                        return ItemInteractionResult.SUCCESS;
+                    }
+                }
+            }
+        }
+        return super.useItemOn(stack, state, level, pos, player, hand, hitResult);
     }
 }

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/blockentity/MachineBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/base/blockentity/MachineBlockEntity.java
@@ -5,6 +5,7 @@ import com.enderio.base.api.capability.SideConfig;
 import com.enderio.base.api.io.IOConfigurable;
 import com.enderio.base.api.io.IOMode;
 import com.enderio.base.api.misc.RedstoneControl;
+import com.enderio.base.api.soul.binding.ISoulBindable;
 import com.enderio.base.common.block.EIOBlockEntity;
 import com.enderio.base.common.blockentity.Wrenchable;
 import com.enderio.machines.common.MachineNBTKeys;
@@ -67,6 +68,9 @@ public abstract class MachineBlockEntity extends EIOBlockEntity
 
     public static final ICapabilityProvider<MachineBlockEntity, Direction, IItemHandler> ITEM_HANDLER_PROVIDER = (be,
             side) -> be.inventory != null ? be.inventory.getForSide(side) : null;
+
+    public static final ICapabilityProvider<MachineBlockEntity, Void, ISoulBindable> SOUL_BINDABLE = (be, ctx)
+        -> be instanceof ISoulBindable bindable ? bindable : null;
 
     private static final ModelProperty<IOConfigurable> IO_CONFIG_PROPERTY = LegacyMachineBlockEntity.IO_CONFIG_PROPERTY;
 

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/farming_station/FarmingStationBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/farming_station/FarmingStationBlockEntity.java
@@ -9,6 +9,7 @@ import com.enderio.base.api.farm.FarmTaskManager;
 import com.enderio.base.api.farm.FarmingStation;
 import com.enderio.base.api.io.energy.EnergyIOMode;
 import com.enderio.base.api.soul.Soul;
+import com.enderio.base.api.soul.binding.ISoulBindable;
 import com.enderio.base.common.init.EIODataComponents;
 import com.enderio.base.common.tag.EIOTags;
 import com.enderio.machines.common.MachineNBTKeys;
@@ -63,7 +64,7 @@ import org.jetbrains.annotations.Nullable;
 
 ;
 
-public class FarmingStationBlockEntity extends PoweredMachineBlockEntity implements RangedActor, FarmingStation {
+public class FarmingStationBlockEntity extends PoweredMachineBlockEntity implements RangedActor, FarmingStation, ISoulBindable {
     public static final String CONSUMED = "Consumed";
     private static final QuadraticScalable ENERGY_CAPACITY = new QuadraticScalable(CapacitorModifier.ENERGY_CAPACITY,
             MachinesConfig.COMMON.ENERGY.FARM_CAPACITY);
@@ -420,8 +421,25 @@ public class FarmingStationBlockEntity extends PoweredMachineBlockEntity impleme
         return boundSoul.hasEntity() ? boundSoul.entityType() : null;
     }
 
-    public void setEntityType(ResourceLocation entityType) {
-        boundSoul = Soul.of(entityType);
+    @Override
+    public Soul getBoundSoul() {
+        return boundSoul;
+    }
+
+    @Override
+    public boolean canBind() {
+        return true;
+    }
+
+    @Override
+    public boolean isSoulValid(Soul soul) {
+        return FarmSoul.FARM.matches(soul.entityTypeId()).isPresent();
+    }
+
+    @Override
+    public void bindSoul(Soul newSoul) {
+        this.boundSoul = newSoul;
+        this.soulData = FarmSoul.FARM.matches(newSoul.entityTypeId()).get();
     }
 
     @SubscribeEvent

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/powered_spawner/PoweredSpawnerBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/powered_spawner/PoweredSpawnerBlockEntity.java
@@ -6,11 +6,13 @@ import com.enderio.base.api.soul.Soul;
 import com.enderio.base.api.capacitor.CapacitorModifier;
 import com.enderio.base.api.capacitor.QuadraticScalable;
 import com.enderio.base.api.io.energy.EnergyIOMode;
+import com.enderio.base.api.soul.binding.ISoulBindable;
 import com.enderio.base.common.init.EIOCapabilities;
 import com.enderio.base.common.init.EIODataComponents;
 import com.enderio.base.common.init.EIOItems;
 import com.enderio.base.common.particle.RangeParticleData;
 import com.enderio.machines.common.MachineNBTKeys;
+import com.enderio.machines.common.blocks.base.blockentity.MachineBlockEntity;
 import com.enderio.machines.common.blocks.base.blockentity.PoweredMachineBlockEntity;
 import com.enderio.machines.common.blocks.base.blockentity.flags.CapacitorSupport;
 import com.enderio.machines.common.blocks.base.inventory.MachineInventoryLayout;
@@ -24,12 +26,14 @@ import com.enderio.machines.common.init.MachineAttachments;
 import com.enderio.machines.common.init.MachineBlockEntities;
 import com.enderio.machines.common.init.MachineDataComponents;
 import com.enderio.machines.common.lang.MachineLang;
+import com.enderio.machines.common.souldata.SoulDataReloadListener;
 import com.enderio.machines.common.souldata.SpawnerSoul;
 import com.enderio.machines.common.tag.MachineTags;
 import com.mojang.datafixers.util.Either;
 import java.util.Objects;
 import java.util.Optional;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -46,10 +50,12 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import net.neoforged.neoforge.common.extensions.IOwnedSpawner;
+import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.Nullable;
 
-public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity implements IOwnedSpawner {
+public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity implements IOwnedSpawner, ISoulBindable {
 
     public static final SingleSlotAccess INPUT = new SingleSlotAccess();
     public static final SingleSlotAccess OUTPUT = new SingleSlotAccess();
@@ -278,8 +284,25 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity impleme
         return boundSoul.hasEntity() ? boundSoul.entityType() : null;
     }
 
+    @Override
     public Soul getBoundSoul() {
         return boundSoul;
+    }
+
+    @Override
+    public boolean canBind() {
+        return true;
+    }
+
+    @Override
+    public boolean isSoulValid(Soul soul) {
+        return SpawnerSoul.SPAWNER.matches(soul.entityTypeId()).isPresent();
+    }
+
+    @Override
+    public void bindSoul(Soul newSoul) {
+        this.boundSoul = newSoul;
+        taskHost.newTaskAvailable();
     }
 
     // TODO: I want a better way to handle this, but unsure what that could be.

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_engine/SoulEngineBlockEntity.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/soul_engine/SoulEngineBlockEntity.java
@@ -6,6 +6,7 @@ import com.enderio.base.api.capacitor.FixedScalable;
 import com.enderio.base.api.capacitor.LinearScalable;
 import com.enderio.base.api.capacitor.QuadraticScalable;
 import com.enderio.base.api.io.energy.EnergyIOMode;
+import com.enderio.base.api.soul.binding.ISoulBindable;
 import com.enderio.base.common.init.EIODataComponents;
 import com.enderio.machines.EnderIOMachines;
 import com.enderio.machines.common.MachineNBTKeys;
@@ -53,7 +54,7 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import org.jetbrains.annotations.Nullable;
 
 @EventBusSubscriber(modid = EnderIOMachines.MODULE_MOD_ID)
-public class SoulEngineBlockEntity extends PoweredMachineBlockEntity implements FluidTankUser {
+public class SoulEngineBlockEntity extends PoweredMachineBlockEntity implements FluidTankUser, ISoulBindable {
 
     private static final QuadraticScalable CAPACITY = new QuadraticScalable(CapacitorModifier.ENERGY_CAPACITY,
             MachinesConfig.COMMON.ENERGY.SOUL_ENGINE_CAPACITY);
@@ -109,6 +110,27 @@ public class SoulEngineBlockEntity extends PoweredMachineBlockEntity implements 
     @Nullable
     public EntityType<?> getEntityType() {
         return boundSoul.hasEntity() ? boundSoul.entityType() : null;
+    }
+
+    @Override
+    public Soul getBoundSoul() {
+        return boundSoul;
+    }
+
+    @Override
+    public boolean canBind() {
+        return true;
+    }
+
+    @Override
+    public boolean isSoulValid(Soul soul) {
+        return EngineSoul.ENGINE.matches(soul.entityTypeId()).isPresent();
+    }
+
+    @Override
+    public void bindSoul(Soul newSoul) {
+        this.boundSoul = newSoul;
+        this.soulData = EngineSoul.ENGINE.matches(newSoul.entityTypeId()).get();
     }
 
     @Override

--- a/enderio-machines/src/main/java/com/enderio/machines/common/init/MachineBlockEntities.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/init/MachineBlockEntities.java
@@ -146,7 +146,8 @@ public class MachineBlockEntities {
 
     public static final RegiliteBlockEntity<PoweredSpawnerBlockEntity> POWERED_SPAWNER = register("powered_spawner",
             PoweredSpawnerBlockEntity::new, MachineBlocks.POWERED_SPAWNER)
-                    .apply(MachineBlockEntities::poweredMachineBlockEntityCapabilities);
+                    .apply(MachineBlockEntities::poweredMachineBlockEntityCapabilities)
+                    .apply(MachineBlockEntities::soulBoundCapability);
 
     public static final Map<SolarPanelTier, RegiliteBlockEntity<SolarPanelBlockEntity>> SOLAR_PANELS = Util.make(() -> {
         Map<SolarPanelTier, RegiliteBlockEntity<SolarPanelBlockEntity>> map = new HashMap<>();
@@ -155,7 +156,8 @@ public class MachineBlockEntities {
                     register(tier.name().toLowerCase(Locale.ROOT) + "_photovoltaic_cell",
                             (worldPosition, blockState) -> new SolarPanelBlockEntity(worldPosition, blockState, tier),
                             () -> MachineBlocks.SOLAR_PANELS.get(tier).get())
-                                    .apply(MachineBlockEntities::legacyPoweredMachineBlockEntityCapabilities));
+                                    .apply(MachineBlockEntities::legacyPoweredMachineBlockEntityCapabilities))
+            ;
         }
         return ImmutableMap.copyOf(map);
     });
@@ -177,7 +179,8 @@ public class MachineBlockEntities {
     public static final RegiliteBlockEntity<SoulEngineBlockEntity> SOUL_ENGINE = register("soul_engine",
             SoulEngineBlockEntity::new, MachineBlocks.SOUL_ENGINE)
                     .apply(MachineBlockEntities::poweredMachineBlockEntityCapabilities)
-                    .apply(MachineBlockEntities::fluidHandlerCapability);
+                    .apply(MachineBlockEntities::fluidHandlerCapability)
+                    .apply(MachineBlockEntities::soulBoundCapability);
 
     public static final RegiliteBlockEntity<XPObeliskBlockEntity> XP_OBELISK = register("xp_obelisk",
             XPObeliskBlockEntity::new, MachineBlocks.XP_OBELISK)
@@ -218,7 +221,8 @@ public class MachineBlockEntities {
     public static final RegiliteBlockEntity<FarmingStationBlockEntity> FARMING_STATION = register("farming_station",
             FarmingStationBlockEntity::new, MachineBlocks.FARMING_STATION)
                     .apply(MachineBlockEntities::poweredMachineBlockEntityCapabilities)
-                    .apply(MachineBlockEntities::fluidHandlerCapability);
+                    .apply(MachineBlockEntities::fluidHandlerCapability)
+                    .apply(MachineBlockEntities::soulBoundCapability);
 
     @SafeVarargs
     private static <B extends BlockEntity> RegiliteBlockEntity<B> register(String name,
@@ -252,6 +256,10 @@ public class MachineBlockEntities {
 
     private static void fluidHandlerCapability(RegiliteBlockEntity<? extends MachineBlockEntity> blockEntity) {
         blockEntity.addCapability(Capabilities.FluidHandler.BLOCK, FluidTankUser.FLUID_HANDLER_PROVIDER);
+    }
+
+    private static void soulBoundCapability(RegiliteBlockEntity<? extends MachineBlockEntity> blockEntity) {
+        blockEntity.addCapability(EIOCapabilities.SoulBindable.BLOCK, MachineBlockEntity.SOUL_BINDABLE);
     }
 
     public static void register(IEventBus bus) {


### PR DESCRIPTION
Soul vials and spawn eggs can be used to bind soul machines in creative

Also fixed horse not working with soul vials


<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced soul binding capabilities for spawn eggs, allowing extraction and management of soul data from spawn egg items.
  - Added soul binding support to Powered Spawner, Soul Engine, and Farming Station blocks, enabling these machines to bind, validate, and manage souls.
  - Creative mode players can now bind souls to compatible machines directly via item interaction.

- **Improvements**
  - Expanded soul vial interactions to include all horse types, not just chested horses.

- **Refactor**
  - Streamlined internal capability registration and management for soul binding across relevant blocks and items.
  - Cleaned up unused imports for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->