### PR TITLE
fix(jei): avoid modifying itemstack instance

### DIFF
--- a/enderio-machines/src/main/java/com/enderio/machines/common/integrations/jei/util/WrappedEnchanterRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/integrations/jei/util/WrappedEnchanterRecipe.java
@@ -39,7 +39,7 @@ public class WrappedEnchanterRecipe implements Recipe<EnchanterRecipe.Input> {
 
     public List<ItemStack> getLapis() {
         return Arrays.stream(Ingredient.of(Tags.Items.GEMS_LAPIS).getItems())
-                .peek(item -> item.setCount(recipe.value().getLapisForLevel(level)))
+                .peek(item -> item.copyWithCount(recipe.value().getLapisForLevel(level)))
                 .toList();
     }
 

--- a/enderio-machines/src/main/java/com/enderio/machines/common/integrations/jei/util/WrappedEnchanterRecipe.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/integrations/jei/util/WrappedEnchanterRecipe.java
@@ -39,7 +39,7 @@ public class WrappedEnchanterRecipe implements Recipe<EnchanterRecipe.Input> {
 
     public List<ItemStack> getLapis() {
         return Arrays.stream(Ingredient.of(Tags.Items.GEMS_LAPIS).getItems())
-                .peek(item -> item.copyWithCount(recipe.value().getLapisForLevel(level)))
+                .map(item -> item.copyWithCount(recipe.value().getLapisForLevel(level)))
                 .toList();
     }
 


### PR DESCRIPTION
# Description

Hello 👋 , I'm making this PR to this mod to add compatibility to a feature (Ingredient Deduplication) on my mod (AllTheLeaks) that relies heavily on modders to not modify the inner stack of those ingredients.

I would greatly appreciate it if you could accept this PR.

Thanks.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved item handling to prevent unintended changes when displaying lapis requirements in recipes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->