### PR TITLE
[1.20.1] Fix some conduit issues

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
@@ -451,6 +451,18 @@ public class ConduitBlock extends Block implements EntityBlock, SimpleWaterlogge
     }
 
     @Override
+    public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+        if (!state.is(newState.getBlock())) {
+            // Not a conduit anymore, destroy all the connections
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof ConduitBlockEntity conduit) {
+                conduit.destroyAllConnections();
+            }
+        }
+        super.onRemove(state, level, pos, newState, movedByPiston);
+    }
+
+    @Override
     public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid) {
         HitResult hit = player.pick(player.getBlockReach() + 5, 1, false);
         BlockEntity be = level.getBlockEntity(pos);

--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlockEntity.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlockEntity.java
@@ -364,6 +364,15 @@ public class ConduitBlockEntity extends EnderBlockEntity {
         return shouldRemove;
     }
 
+    public void destroyAllConnections() {
+        var typesToRemove = List.copyOf(bundle.getTypes());
+        for (var type : typesToRemove) {
+            bundle.removeType(level, type);
+            removeNeighborConnections(type);
+        }
+        updateShape();
+    }
+
     public void updateEmptyDynConnection() {
         for (Direction dir : Direction.values()) {
             for (int i = 0; i < ConduitBundle.MAX_CONDUIT_TYPES; i++) {

--- a/src/conduits/java/com/enderio/conduits/common/conduit/type/fluid/FluidConduitData.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/type/fluid/FluidConduitData.java
@@ -2,9 +2,13 @@ package com.enderio.conduits.common.conduit.type.fluid;
 
 import com.enderio.EnderIO;
 import com.enderio.api.conduit.ConduitData;
+import com.enderio.api.conduit.ConduitType;
 import com.enderio.conduits.ConduitNBTKeys;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -14,7 +18,7 @@ import java.util.Objects;
 
 public class FluidConduitData implements ConduitData<FluidConduitData> {
 
-    public final boolean isMultiFluid;
+    public boolean isMultiFluid;
 
     @Nullable
     private Fluid lockedFluid = null;
@@ -39,6 +43,17 @@ public class FluidConduitData implements ConduitData<FluidConduitData> {
 
     public void setShouldReset(boolean shouldReset) {
         this.shouldReset = shouldReset;
+    }
+
+    @Override
+    public void onCreated(ConduitType<?> type, Level level, BlockPos pos, @Nullable Player player) {
+        if (type instanceof FluidConduitType fluidType) {
+            this.isMultiFluid = fluidType.isMultiFluid();
+            if (this.isMultiFluid) {
+                // remove locked fluid
+                setShouldReset(true);
+            }
+        }
     }
 
     @Override

--- a/src/conduits/java/com/enderio/conduits/common/conduit/type/fluid/FluidConduitType.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/type/fluid/FluidConduitType.java
@@ -70,4 +70,8 @@ public class FluidConduitType extends TieredConduit<FluidConduitData> {
             tooltipAdder.accept(ConduitLang.MULTI_FLUID_TOOLTIP);
         }
     }
+
+    public boolean isMultiFluid() {
+        return isMultiFluid;
+    }
 }

--- a/src/conduits/java/com/enderio/conduits/common/init/ConduitItems.java
+++ b/src/conduits/java/com/enderio/conduits/common/init/ConduitItems.java
@@ -18,6 +18,7 @@ import com.enderio.conduits.common.redstone.RedstoneSensorFilter;
 import com.enderio.conduits.common.redstone.RedstoneTLatchFilter;
 import com.enderio.conduits.common.redstone.RedstoneTimerFilter;
 import com.enderio.conduits.common.redstone.RedstoneXNORFilter;
+import com.enderio.conduits.common.redstone.RedstoneXORFilter;
 import com.tterrag.registrate.Registrate;
 import com.tterrag.registrate.util.entry.ItemEntry;
 import net.minecraft.resources.ResourceLocation;
@@ -75,7 +76,7 @@ public class ConduitItems {
     public static final ItemEntry<RedstoneFilterItem> NAND_FILTER = createRedstoneFilter("redstone_nand_filter", "Redstone NAND Filter",
         RedstoneNANDFilter::new, ConduitMenus.REDSTONE_DOUBLE_CHANNEL_FILTER::get);
     public static final ItemEntry<RedstoneFilterItem> XOR_FILTER = createRedstoneFilter("redstone_xor_filter", "Redstone XOR Filter",
-        RedstoneXNORFilter::new, ConduitMenus.REDSTONE_DOUBLE_CHANNEL_FILTER::get);
+        RedstoneXORFilter::new, ConduitMenus.REDSTONE_DOUBLE_CHANNEL_FILTER::get);
     public static final ItemEntry<RedstoneFilterItem> XNOR_FILTER = createRedstoneFilter("redstone_xnor_filter", "Redstone XNOR Filter",
         RedstoneXNORFilter::new, ConduitMenus.REDSTONE_DOUBLE_CHANNEL_FILTER::get);
     public static final ItemEntry<RedstoneFilterItem> TLATCH_FILTER = createRedstoneFilter("redstone_toggle_filter", "Redstone Toggle Filter",


### PR DESCRIPTION
This PR fixes some issues with the legacy conduit implementation on 1.20.1.

* Implement `onRemove` on conduit blocks so that the network updates when a block is removed for any reason.
* Fix fluid conduits permanently caching the multifluid mode in their conduit data and not updating it if the type changes
* Fix typo that prevented redstone XOR filter from working as intended

The code changes should all be self-explanatory. https://github.com/Team-EnderIO/EnderIO/pull/880 does not address any of the issues fixed here, the PRs shouldn't conflict.