### PR TITLE
Add Round Robin, Self Feed, and Priority to Conduit Probe Copy/Paste

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/items/ConduitProbeItem.java
+++ b/src/conduits/java/com/enderio/conduits/common/items/ConduitProbeItem.java
@@ -7,7 +7,7 @@ import com.enderio.conduits.common.conduit.ConduitBundle;
 import com.enderio.conduits.common.conduit.block.ConduitBlockEntity;
 import com.enderio.conduits.common.conduit.connection.ConnectionState;
 import com.enderio.conduits.common.conduit.connection.DynamicConnectionState;
-import com.enderio.conduits.common.conduit.type.item.ItemConduitData;
+import com.enderio.conduits.common.conduit.type.item.ItemConduitData.ItemSidedData;
 import com.enderio.conduits.common.conduit.type.item.ItemConduitType;
 import com.enderio.conduits.common.network.C2SSyncProbeState;
 import com.enderio.conduits.common.util.InteractionUtil;
@@ -111,7 +111,7 @@ public class ConduitProbeItem extends Item {
                 typeTag.putInt(REDSTONE_CHANNEL, dynamic.redstoneChannel().ordinal());
 
                 if (conduitType instanceof ItemConduitType itemConduitType) {
-                    ItemConduitData.ItemSidedData sidedData = bundle.getNodeFor(itemConduitType).getConduitData().get(face);
+                    ItemSidedData sidedData = bundle.getNodeFor(itemConduitType).getConduitData().get(face);
                     typeTag.putBoolean(ROUND_ROBIN, sidedData.isRoundRobin);
                     typeTag.putBoolean(SELF_FEED, sidedData.isSelfFeed);
                     typeTag.putInt(PRIORITY, sidedData.getPriority());
@@ -147,7 +147,7 @@ public class ConduitProbeItem extends Item {
             conduitBlock.handleConnectionStateUpdate(face, conduitType, newState);
 
             if (conduitType instanceof ItemConduitType itemConduitType && typeTag.contains(ROUND_ROBIN)) {
-                ItemConduitData.ItemSidedData sidedData = bundle.getNodeFor(itemConduitType).getConduitData().compute(face);
+                ItemSidedData sidedData = bundle.getNodeFor(itemConduitType).getConduitData().compute(face);
                 sidedData.isRoundRobin = typeTag.getBoolean(ROUND_ROBIN);
                 sidedData.isSelfFeed = typeTag.getBoolean(SELF_FEED);
                 sidedData.setPriority(typeTag.getInt(PRIORITY));

--- a/src/conduits/java/com/enderio/conduits/common/items/ConduitProbeItem.java
+++ b/src/conduits/java/com/enderio/conduits/common/items/ConduitProbeItem.java
@@ -7,6 +7,8 @@ import com.enderio.conduits.common.conduit.ConduitBundle;
 import com.enderio.conduits.common.conduit.block.ConduitBlockEntity;
 import com.enderio.conduits.common.conduit.connection.ConnectionState;
 import com.enderio.conduits.common.conduit.connection.DynamicConnectionState;
+import com.enderio.conduits.common.conduit.type.item.ItemConduitData;
+import com.enderio.conduits.common.conduit.type.item.ItemConduitType;
 import com.enderio.conduits.common.network.C2SSyncProbeState;
 import com.enderio.conduits.common.util.InteractionUtil;
 import com.enderio.core.common.network.CoreNetwork;
@@ -37,6 +39,9 @@ public class ConduitProbeItem extends Item {
     public static final String EXTRACT_CHANNEL = "EXTRACT_CHANNEL";
     public static final String REDSTONE_CONTROL = "REDSTONE_CONTROL";
     public static final String REDSTONE_CHANNEL = "REDSTONE_CHANNEL";
+    public static final String ROUND_ROBIN = "ROUND_ROBIN";
+    public static final String SELF_FEED = "SELF_FEED";
+    public static final String PRIORITY = "PRIORITY";
     
     public ConduitProbeItem(Properties properties) {
         super(properties);
@@ -104,6 +109,13 @@ public class ConduitProbeItem extends Item {
                 typeTag.putInt(EXTRACT_CHANNEL, dynamic.extractChannel().ordinal());
                 typeTag.putInt(REDSTONE_CONTROL, dynamic.control().ordinal());
                 typeTag.putInt(REDSTONE_CHANNEL, dynamic.redstoneChannel().ordinal());
+
+                if (conduitType instanceof ItemConduitType itemConduitType) {
+                    ItemConduitData.ItemSidedData sidedData = bundle.getNodeFor(itemConduitType).getConduitData().get(face);
+                    typeTag.putBoolean(ROUND_ROBIN, sidedData.isRoundRobin);
+                    typeTag.putBoolean(SELF_FEED, sidedData.isSelfFeed);
+                    typeTag.putInt(PRIORITY, sidedData.getPriority());
+                }
             } else {
                 typeTag.putBoolean(IS_INSERT, false);
                 typeTag.putBoolean(IS_EXTRACT, false);
@@ -133,6 +145,13 @@ public class ConduitProbeItem extends Item {
                 wasConnected ? connectionState.filterExtract() : ItemStack.EMPTY, wasConnected ? connectionState.upgradeExtract() : ItemStack.EMPTY
             );
             conduitBlock.handleConnectionStateUpdate(face, conduitType, newState);
+
+            if (conduitType instanceof ItemConduitType itemConduitType && typeTag.contains(ROUND_ROBIN)) {
+                ItemConduitData.ItemSidedData sidedData = bundle.getNodeFor(itemConduitType).getConduitData().compute(face);
+                sidedData.isRoundRobin = typeTag.getBoolean(ROUND_ROBIN);
+                sidedData.isSelfFeed = typeTag.getBoolean(SELF_FEED);
+                sidedData.setPriority(typeTag.getInt(PRIORITY));
+            }
         });
         conduitBlock.setChanged();
         conduitBlock.updateClient();


### PR DESCRIPTION
# Description

Add ItemConduitData data (round-robin, self-feed, and priority) to the conduit probe's copy/paste function. #1105 

[It seems like priority and round robin (and probably self-feed too?) should stay in ItemConduitData](https://github.com/Team-EnderIO/EnderIO/issues/588#issuecomment-2717565274).
So, the code grabs data directly from `ItemConduitData.ItemSidedData` through `bundle.getNodeFor(type).getConduitData().get(direction)` after checking that `conduitType` is `itemConduitType`, instead of adding these properties to DynamicConnectionState.

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [x] Check for bugs with bundled cables

# Breaking Changes

None.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Conduit Probe copy/paste now preserves per‑face item conduit settings, including Round Robin, Self‑Feed, and Priority, ensuring consistent configurations across faces.
  - Settings are captured from the face you copy from and applied to the corresponding face on paste.
  - Paste only applies these item‑specific settings when available, preventing unintended changes to other conduit types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->