### PR TITLE
fix: Unify conduit placement logic (1.20.1)

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/conduit/ConduitBlockItem.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/ConduitBlockItem.java
@@ -2,6 +2,7 @@ package com.enderio.conduits.common.conduit;
 
 import com.enderio.api.conduit.ConduitType;
 import com.enderio.base.client.tooltip.TooltipHandler;
+import com.enderio.conduits.common.conduit.block.ConduitBlock;
 import com.enderio.conduits.common.conduit.block.ConduitBlockEntity;
 import com.enderio.conduits.common.init.ConduitLang;
 import com.enderio.core.common.util.TooltipUtil;
@@ -22,6 +23,7 @@ import net.minecraft.world.level.gameevent.GameEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class ConduitBlockItem extends BlockItem {
@@ -45,32 +47,13 @@ public class ConduitBlockItem extends BlockItem {
     @Override
     public InteractionResult place(BlockPlaceContext context) {
         Level level = context.getLevel();
-        @Nullable
-        Player player = context.getPlayer();
-        BlockPos blockpos = context.getClickedPos();
-        ItemStack itemstack = context.getItemInHand();
 
         // Handle placing into an existing block
-        if (level.getBlockEntity(blockpos) instanceof ConduitBlockEntity conduit) {
-            if (conduit.hasType(type.get())) {
-                // Pass through to block
-                return level.getBlockState(blockpos).use(level, player, context.getHand(), context.getHitResult());
+        if (level.getBlockState(context.getClickedPos()).getBlock() instanceof ConduitBlock conduitBlock) {
+            Optional<InteractionResult> result = conduitBlock.handleBlockPlace(context);
+            if (result.isPresent()) {
+                return result.get();
             }
-
-            conduit.addType(type.get(), player);
-            if (level.isClientSide()) {
-                conduit.updateClient();
-            }
-
-            BlockState blockState = level.getBlockState(blockpos);
-            SoundType soundtype = blockState.getSoundType(level, blockpos, context.getPlayer());
-            level.playSound(player, blockpos, this.getPlaceSound(blockState, level, blockpos, context.getPlayer()), SoundSource.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
-            level.gameEvent(GameEvent.BLOCK_PLACE, blockpos, GameEvent.Context.of(player, blockState));
-
-            if (!player.getAbilities().instabuild) {
-                itemstack.shrink(1);
-            }
-            return InteractionResult.sidedSuccess(level.isClientSide());
         }
 
         return super.place(context);

--- a/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/block/ConduitBlock.java
@@ -237,6 +237,19 @@ public class ConduitBlock extends Block implements EntityBlock, SimpleWaterlogge
         return Optional.of(result);
     }
 
+    public Optional<InteractionResult> handleBlockPlace(BlockPlaceContext context) {
+        Level level = context.getLevel();
+        @Nullable
+        Player player = context.getPlayer();
+        BlockPos blockpos = context.getClickedPos();
+        ItemStack itemstack = context.getItemInHand();
+
+        if (player != null && level.getBlockEntity(blockpos) instanceof ConduitBlockEntity conduit) {
+            return addConduit(conduit, player, itemstack, level.isClientSide);
+        }
+        return Optional.empty();
+    }
+
     private Optional<InteractionResult> handleYeta(ConduitBlockEntity conduit, Player player, ItemStack stack, BlockHitResult hit, boolean isClientSide) {
         if (stack.is(EIOTags.Items.WRENCH)) {
             @Nullable ConduitType<?> type = conduit.getShape().getConduit(hit.getBlockPos(), hit);


### PR DESCRIPTION
# Description

ConduitBlockItem logic was out of sync with ConduitBlock, causing items to be deleted. Both classes now use ConduitBlock's logic.

Fixes #986 (1.20.1 only)

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
