### PR TITLE
feat: Improve filtering & stacking of vials by filtering NBT.

### DIFF
--- a/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
+++ b/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
@@ -3,12 +3,13 @@ package com.enderio.base.api.soul;
 import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import io.netty.buffer.ByteBuf;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
@@ -17,6 +18,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Leashable;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Bee;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -27,21 +29,77 @@ import java.util.Optional;
  * Represents a stored soul, derived from a {@link LivingEntity}.
  * @param entityTag the entity's NBT tag.
  */
-public record Soul(CompoundTag entityTag) {
-    public static final Codec<Soul> CODEC = RecordCodecBuilder.create(
+public record Soul(@Nullable EntityType<?> entityType, CompoundTag entityTag) {
+    private static final Codec<Soul> NEW_CODEC = RecordCodecBuilder.create(
+        instance -> instance.group(
+            BuiltInRegistries.ENTITY_TYPE.byNameCodec().fieldOf("entity_type").forGetter(Soul::entityType),
+            CompoundTag.CODEC.fieldOf("entity_tag").forGetter(Soul::entityTag)
+        ).apply(instance, Soul::new));
+
+    private static final Codec<Soul> OLD_CODEC = RecordCodecBuilder.create(
         instance -> instance.group(
             CompoundTag.CODEC.fieldOf("entityTag").forGetter(Soul::entityTag)
         ).apply(instance, Soul::new));
 
-    public static final StreamCodec<ByteBuf, Soul> STREAM_CODEC = StreamCodec.composite(
+    public static final Codec<Soul> CODEC = Codec.withAlternative(NEW_CODEC, OLD_CODEC);
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, Soul> STREAM_CODEC = StreamCodec.composite(
+        ByteBufCodecs.registry(Registries.ENTITY_TYPE),
+        Soul::entityType,
         ByteBufCodecs.COMPOUND_TAG,
-        Soul::getEntityTag,
+        Soul::entityTag,
         Soul::new
     );
 
-    public static final StreamCodec<ByteBuf, Soul> OPTIONAL_STREAM_CODEC = new StreamCodec<>() {
+    // Keys that should not be compared or saved
+    // Note be careful adding new things to this list - it will affect saves.
+    private static final List<String> IGNORED_KEYS = List.of(
+        Entity.ID_TAG, // We store the entity type separately to the entity data.
+        "Air",
+        "Brain",
+        "DeathTime",
+        "FallDistance",
+        "FallFlying",
+        "HurtByTimestamp",
+        "HurtTime",
+        "Motion",
+        "OnGround",
+        "PortalCooldown",
+        "Pos",
+        "Rotation",
+        "SleepingX",
+        "SleepingY",
+        "SleepingZ",
+        Leashable.LEASH_TAG,
+        Entity.UUID_TAG
+    );
+
+    // Do not compare obviously unreasonable NBT Keys
+    private static final List<String> IGNORED_KEYS_DURING_COMPARISON = List.of(
+        // TODO: need to check for any other tags that should be ignored.
+        // Perhaps make this configurable?
+        Bee.TAG_CANNOT_ENTER_HIVE_TICKS,
+        Bee.TAG_TICKS_SINCE_POLLINATION,
+        Bee.TAG_CROPS_GROWN_SINCE_POLLINATION,
+        Bee.TAG_HIVE_POS,
+        LivingEntity.PASSENGERS_TAG
+    );
+
+    public Soul {
+        // Remove tags we don't want
+        IGNORED_KEYS.forEach(entityTag::remove);
+    }
+
+    // Legacy data support.
+    private Soul(CompoundTag tag) {
+        // Note: doesn't remove ID from the tag to ensure backwards compatibility.
+        // TODO: 1.22 - remove this.
+        this(BuiltInRegistries.ENTITY_TYPE.get(ResourceLocation.parse(tag.getString(Entity.ID_TAG))), tag);
+    }
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, Soul> OPTIONAL_STREAM_CODEC = new StreamCodec<>() {
         @Override
-        public Soul decode(ByteBuf byteBuf) {
+        public Soul decode(RegistryFriendlyByteBuf byteBuf) {
             boolean hasEntity = byteBuf.readBoolean();
             if (!hasEntity) {
                 return EMPTY;
@@ -51,7 +109,7 @@ public record Soul(CompoundTag entityTag) {
         }
 
         @Override
-        public void encode(ByteBuf o, Soul soul) {
+        public void encode(RegistryFriendlyByteBuf o, Soul soul) {
             o.writeBoolean(soul.hasEntity());
             if (soul.hasEntity()) {
                 STREAM_CODEC.encode(o, soul);
@@ -63,11 +121,7 @@ public record Soul(CompoundTag entityTag) {
 
     public static Soul of(LivingEntity entity) {
         var entityTag = new CompoundTag();
-        if (!serializeEntity(entity, entityTag)) {
-            // Cannot serialize!
-            return Soul.EMPTY;
-        }
-
+        entity.saveWithoutId(entityTag);
         return new Soul(entityTag);
     }
 
@@ -94,7 +148,7 @@ public record Soul(CompoundTag entityTag) {
     }
 
     public static boolean isSameEntitySameTag(Soul soul1, Soul soul2) {
-        return isSameTag(soul1.getEntityTag(), soul2.getEntityTag());
+        return isSameTag(soul1.entityTag(), soul2.entityTag());
     }
 
     public static boolean isSameEntitySameTag(Soul soul, LivingEntity livingEntity) {
@@ -103,11 +157,8 @@ public record Soul(CompoundTag entityTag) {
         }
 
         var entityTagToCompare = new CompoundTag();
-        if (!serializeEntity(livingEntity, entityTagToCompare)) {
-            return false;
-        }
-
-        return isSameTag(soul.getEntityTag(), entityTagToCompare);
+        livingEntity.saveWithoutId(entityTagToCompare);
+        return isSameTag(soul.entityTag(), entityTagToCompare);
     }
 
     private static boolean isSameTag(CompoundTag tag1, CompoundTag tag2) {
@@ -126,21 +177,11 @@ public record Soul(CompoundTag entityTag) {
     }
 
     public boolean hasEntity() {
-        if (!entityTag.contains(Entity.ID_TAG)) {
-            return false;
-        }
-
-        var id = ResourceLocation.tryParse(entityTag.getString(Entity.ID_TAG));
-        if (id == null) {
-            return false;
-        }
-
-        var entityType = BuiltInRegistries.ENTITY_TYPE.getOptional(id);
-        return entityType.isPresent();
+        return entityType != null;
     }
 
     public boolean isEmpty() {
-        return !hasEntity();
+        return entityType == null;
     }
 
     /**
@@ -152,19 +193,13 @@ public record Soul(CompoundTag entityTag) {
             throw new IllegalStateException("Cannot get Entity Type ID from empty StoredEntityData");
         }
 
-        return ResourceLocation.parse(entityTag.getString(Entity.ID_TAG));
+        return BuiltInRegistries.ENTITY_TYPE.getKey(entityType);
     }
 
-    /**
-     * @throws IllegalStateException if the soul is empty.
-     * @return
-     */
-    public EntityType<?> entityType() {
-        return BuiltInRegistries.ENTITY_TYPE.get(entityTypeId());
-    }
-
-    public CompoundTag getEntityTag() {
-        return entityTag;
+    public CompoundTag getEntityTagWithId() {
+        var tag = entityTag.copy();
+        tag.putString(Entity.ID_TAG, entityTypeId().toString());
+        return tag;
     }
 
     public Soul copy() {
@@ -204,51 +239,5 @@ public record Soul(CompoundTag entityTag) {
 
     public static Soul parseOptional(HolderLookup.Provider lookupProvider, CompoundTag tag) {
         return tag.isEmpty() ? EMPTY : parse(lookupProvider, tag).orElse(EMPTY);
-    }
-
-    // Keys that should not be compared or saved
-    private static final List<String> IGNORED_KEYS = List.of(
-        "Air",
-        "Brain",
-        "DeathTime",
-        "FallDistance",
-        "FallFlying",
-        "HurtByTimestamp",
-        "HurtTime",
-        "Motion",
-        "OnGround",
-        "PortalCooldown",
-        "Pos",
-        "Rotation",
-        "SleepingX",
-        "SleepingY",
-        "SleepingZ",
-        Leashable.LEASH_TAG,
-        Entity.UUID_TAG
-    );
-
-    // Do not compare obviously unreasonable NBT Keys
-    private static final List<String> IGNORED_KEYS_DURING_COMPARISON = List.of(
-        // TODO: need to check for any other tags that should be ignored.
-        // Perhaps make this configurable?
-        Bee.TAG_CANNOT_ENTER_HIVE_TICKS,
-        Bee.TAG_TICKS_SINCE_POLLINATION,
-        Bee.TAG_CROPS_GROWN_SINCE_POLLINATION,
-        Bee.TAG_HIVE_POS,
-        LivingEntity.PASSENGERS_TAG
-    );
-
-    private static boolean serializeEntity(Entity entity, CompoundTag tag) {
-        var encodeId = entity.getEncodeId();
-        if (encodeId == null) {
-            // Cannot encode!
-            return false;
-        }
-
-        var entityTag = new CompoundTag();
-        entityTag.putString(Entity.ID_TAG, encodeId);
-        entity.saveWithoutId(entityTag);
-        IGNORED_KEYS.forEach(entityTag::remove);
-        return true;
     }
 }

--- a/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
+++ b/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
@@ -62,16 +62,12 @@ public record Soul(CompoundTag entityTag) {
     public static final Soul EMPTY = new Soul(new CompoundTag());
 
     public static Soul of(LivingEntity entity) {
-        var encodeId = entity.getEncodeId();
-        if (encodeId == null) {
-            // Cannot encode!
+        var entityTag = new CompoundTag();
+        if (!serializeEntity(entity, entityTag)) {
+            // Cannot serialize!
             return Soul.EMPTY;
         }
 
-        var entityTag = new CompoundTag();
-        entityTag.putString(Entity.ID_TAG, encodeId);
-        entity.saveWithoutId(entityTag);
-        IGNORED_KEYS.forEach(entityTag::remove);
         return new Soul(entityTag);
     }
 
@@ -101,13 +97,17 @@ public record Soul(CompoundTag entityTag) {
         return isSameTag(soul1.getEntityTag(), soul2.getEntityTag());
     }
 
-    public static boolean isSameEntitySameTag(Soul soul, LivingEntity livingEntity, HolderLookup.Provider registries) {
+    public static boolean isSameEntitySameTag(Soul soul, LivingEntity livingEntity) {
         if (!isSameEntity(soul, livingEntity)) {
             return false;
         }
 
-        var entityTag = livingEntity.serializeNBT(registries);
-        return isSameTag(soul.getEntityTag(), entityTag);
+        var entityTagToCompare = new CompoundTag();
+        if (!serializeEntity(livingEntity, entityTagToCompare)) {
+            return false;
+        }
+
+        return isSameTag(soul.getEntityTag(), entityTagToCompare);
     }
 
     private static boolean isSameTag(CompoundTag tag1, CompoundTag tag2) {
@@ -237,4 +237,18 @@ public record Soul(CompoundTag entityTag) {
         Bee.TAG_HIVE_POS,
         LivingEntity.PASSENGERS_TAG
     );
+
+    private static boolean serializeEntity(Entity entity, CompoundTag tag) {
+        var encodeId = entity.getEncodeId();
+        if (encodeId == null) {
+            // Cannot encode!
+            return false;
+        }
+
+        var entityTag = new CompoundTag();
+        entityTag.putString(Entity.ID_TAG, encodeId);
+        entity.saveWithoutId(entityTag);
+        IGNORED_KEYS.forEach(entityTag::remove);
+        return true;
+    }
 }

--- a/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
+++ b/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
@@ -12,9 +12,11 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Leashable;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.neoforge.common.extensions.IEntityExtension;
+import net.minecraft.world.entity.animal.Bee;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -26,11 +28,6 @@ import java.util.Optional;
  * @param entityTag the entity's NBT tag.
  */
 public record Soul(CompoundTag entityTag) {
-    /**
-     * Should match key from {@link IEntityExtension#serializeNBT(HolderLookup.Provider)}.
-     */
-    public static final String KEY_ID = "id";
-
     public static final Codec<Soul> CODEC = RecordCodecBuilder.create(
         instance -> instance.group(
             CompoundTag.CODEC.fieldOf("entityTag").forGetter(Soul::entityTag)
@@ -65,12 +62,22 @@ public record Soul(CompoundTag entityTag) {
     public static final Soul EMPTY = new Soul(new CompoundTag());
 
     public static Soul of(LivingEntity entity) {
-        return new Soul(sanitizeEntityTag(entity.serializeNBT(entity.level().registryAccess())));
+        var encodeId = entity.getEncodeId();
+        if (encodeId == null) {
+            // Cannot encode!
+            return Soul.EMPTY;
+        }
+
+        var entityTag = new CompoundTag();
+        entityTag.putString(Entity.ID_TAG, encodeId);
+        entity.saveWithoutId(entityTag);
+        IGNORED_KEYS.forEach(entityTag::remove);
+        return new Soul(entityTag);
     }
 
     public static Soul of(ResourceLocation entityType) {
         CompoundTag tag = new CompoundTag();
-        tag.putString(KEY_ID, entityType.toString());
+        tag.putString(Entity.ID_TAG, entityType.toString());
         return new Soul(tag);
     }
 
@@ -103,24 +110,10 @@ public record Soul(CompoundTag entityTag) {
         return isSameTag(soul.getEntityTag(), entityTag);
     }
 
-    // Do not compare obviously unreasonable NBT Keys
-    private static final List<String> IGNORED_KEYS = List.of(
-        "Pos",
-        "Air",
-        "OnGround",
-        "Rotation",
-        "FallFlying",
-        "UUID",
-        "Motion",
-        "Brain",
-        "HurtByTimestamp",
-        "PortalCooldown",
-        "FallDistance"
-    );
-
     private static boolean isSameTag(CompoundTag tag1, CompoundTag tag2) {
         for (var key : tag1.getAllKeys()) {
-            if (IGNORED_KEYS.contains(key)) {
+            if (IGNORED_KEYS.contains(key) ||
+                IGNORED_KEYS_DURING_COMPARISON.contains(key)) {
                 continue;
             }
 
@@ -133,11 +126,11 @@ public record Soul(CompoundTag entityTag) {
     }
 
     public boolean hasEntity() {
-        if (!entityTag.contains(KEY_ID)) {
+        if (!entityTag.contains(Entity.ID_TAG)) {
             return false;
         }
 
-        var id = ResourceLocation.tryParse(entityTag.getString(KEY_ID));
+        var id = ResourceLocation.tryParse(entityTag.getString(Entity.ID_TAG));
         if (id == null) {
             return false;
         }
@@ -159,7 +152,7 @@ public record Soul(CompoundTag entityTag) {
             throw new IllegalStateException("Cannot get Entity Type ID from empty StoredEntityData");
         }
 
-        return ResourceLocation.parse(entityTag.getString(KEY_ID));
+        return ResourceLocation.parse(entityTag.getString(Entity.ID_TAG));
     }
 
     /**
@@ -213,13 +206,35 @@ public record Soul(CompoundTag entityTag) {
         return tag.isEmpty() ? EMPTY : parse(lookupProvider, tag).orElse(EMPTY);
     }
 
-    private static CompoundTag sanitizeEntityTag(CompoundTag tag) {
-        tag.remove("Pos");
-        tag.remove("Air");
-        tag.remove("OnGround");
-        tag.remove("Rotation");
-        tag.remove("UUID");
-        tag.remove("Motion");
-        return tag;
-    }
+    // Keys that should not be compared or saved
+    private static final List<String> IGNORED_KEYS = List.of(
+        "Air",
+        "Brain",
+        "DeathTime",
+        "FallDistance",
+        "FallFlying",
+        "HurtByTimestamp",
+        "HurtTime",
+        "Motion",
+        "OnGround",
+        "PortalCooldown",
+        "Pos",
+        "Rotation",
+        "SleepingX",
+        "SleepingY",
+        "SleepingZ",
+        Leashable.LEASH_TAG,
+        Entity.UUID_TAG
+    );
+
+    // Do not compare obviously unreasonable NBT Keys
+    private static final List<String> IGNORED_KEYS_DURING_COMPARISON = List.of(
+        // TODO: need to check for any other tags that should be ignored.
+        // Perhaps make this configurable?
+        Bee.TAG_CANNOT_ENTER_HIVE_TICKS,
+        Bee.TAG_TICKS_SINCE_POLLINATION,
+        Bee.TAG_CROPS_GROWN_SINCE_POLLINATION,
+        Bee.TAG_HIVE_POS,
+        LivingEntity.PASSENGERS_TAG
+    );
 }

--- a/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
+++ b/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.neoforge.common.extensions.IEntityExtension;
 import org.slf4j.Logger;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -64,7 +65,7 @@ public record Soul(CompoundTag entityTag) {
     public static final Soul EMPTY = new Soul(new CompoundTag());
 
     public static Soul of(LivingEntity entity) {
-        return new Soul(entity.serializeNBT(entity.level().registryAccess()));
+        return new Soul(sanitizeEntityTag(entity.serializeNBT(entity.level().registryAccess())));
     }
 
     public static Soul of(ResourceLocation entityType) {
@@ -90,7 +91,7 @@ public record Soul(CompoundTag entityTag) {
     }
 
     public static boolean isSameEntitySameTag(Soul soul1, Soul soul2) {
-        return Objects.equals(soul1.getEntityTag(), soul2.getEntityTag());
+        return isSameTag(soul1.getEntityTag(), soul2.getEntityTag());
     }
 
     public static boolean isSameEntitySameTag(Soul soul, LivingEntity livingEntity, HolderLookup.Provider registries) {
@@ -99,7 +100,36 @@ public record Soul(CompoundTag entityTag) {
         }
 
         var entityTag = livingEntity.serializeNBT(registries);
-        return Objects.equals(soul.getEntityTag(), entityTag);
+        return isSameTag(soul.getEntityTag(), entityTag);
+    }
+
+    // Do not compare obviously unreasonable NBT Keys
+    private static final List<String> IGNORED_KEYS = List.of(
+        "Pos",
+        "Air",
+        "OnGround",
+        "Rotation",
+        "FallFlying",
+        "UUID",
+        "Motion",
+        "Brain",
+        "HurtByTimestamp",
+        "PortalCooldown",
+        "FallDistance"
+    );
+
+    private static boolean isSameTag(CompoundTag tag1, CompoundTag tag2) {
+        for (var key : tag1.getAllKeys()) {
+            if (IGNORED_KEYS.contains(key)) {
+                continue;
+            }
+
+            if (!Objects.equals(tag1.get(key), tag2.get(key))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public boolean hasEntity() {
@@ -181,5 +211,15 @@ public record Soul(CompoundTag entityTag) {
 
     public static Soul parseOptional(HolderLookup.Provider lookupProvider, CompoundTag tag) {
         return tag.isEmpty() ? EMPTY : parse(lookupProvider, tag).orElse(EMPTY);
+    }
+
+    private static CompoundTag sanitizeEntityTag(CompoundTag tag) {
+        tag.remove("Pos");
+        tag.remove("Air");
+        tag.remove("OnGround");
+        tag.remove("Rotation");
+        tag.remove("UUID");
+        tag.remove("Motion");
+        return tag;
     }
 }

--- a/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
+++ b/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
@@ -126,13 +126,11 @@ public record Soul(@Nullable EntityType<?> entityType, CompoundTag entityTag) {
     }
 
     public static Soul of(ResourceLocation entityType) {
-        CompoundTag tag = new CompoundTag();
-        tag.putString(Entity.ID_TAG, entityType.toString());
-        return new Soul(tag);
+        return of(BuiltInRegistries.ENTITY_TYPE.get(entityType));
     }
 
     public static Soul of(EntityType<?> entityType) {
-        return of(BuiltInRegistries.ENTITY_TYPE.getKey(entityType));
+        return new Soul(entityType, new CompoundTag());
     }
 
     public static boolean isSameEntity(Soul soul1, Soul soul2) {
@@ -207,7 +205,7 @@ public record Soul(@Nullable EntityType<?> entityType, CompoundTag entityTag) {
             return EMPTY;
         }
 
-        return new Soul(entityTag.copy());
+        return new Soul(entityType(), entityTag.copy());
     }
 
     public Soul copyOnlyType() {

--- a/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
+++ b/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
@@ -84,7 +84,7 @@ public record Soul(@Nullable EntityType<?> entityType, CompoundTag entityTag) {
         Bee.TAG_TICKS_SINCE_POLLINATION,
         Bee.TAG_CROPS_GROWN_SINCE_POLLINATION,
         Bee.TAG_HIVE_POS,
-        LivingEntity.PASSENGERS_TAG
+        Entity.PASSENGERS_TAG
     );
 
     public Soul {
@@ -119,12 +119,12 @@ public record Soul(@Nullable EntityType<?> entityType, CompoundTag entityTag) {
         }
     };
 
-    public static final Soul EMPTY = new Soul(new CompoundTag());
+    public static final Soul EMPTY = new Soul(null, new CompoundTag());
 
     public static Soul of(LivingEntity entity) {
         var entityTag = new CompoundTag();
         entity.saveWithoutId(entityTag);
-        return new Soul(entityTag);
+        return new Soul(entity.getType(), entityTag);
     }
 
     public static Soul of(ResourceLocation entityType) {

--- a/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
+++ b/enderio-base/src/main/java/com/enderio/base/api/soul/Soul.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents a stored soul, derived from a {@link LivingEntity}.
@@ -160,7 +162,8 @@ public record Soul(@Nullable EntityType<?> entityType, CompoundTag entityTag) {
     }
 
     private static boolean isSameTag(CompoundTag tag1, CompoundTag tag2) {
-        for (var key : tag1.getAllKeys()) {
+        var allKeys = Stream.concat(tag1.getAllKeys().stream(), tag2.getAllKeys().stream()).collect(Collectors.toSet());
+        for (var key : allKeys) {
             if (IGNORED_KEYS.contains(key) ||
                 IGNORED_KEYS_DURING_COMPARISON.contains(key)) {
                 continue;

--- a/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/SpawnEggSoulBindable.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/SpawnEggSoulBindable.java
@@ -23,7 +23,7 @@ public class SpawnEggSoulBindable implements ISoulBindable {
         // Get custom entity data
         var customEntityData = spawnEgg.getOrDefault(DataComponents.ENTITY_DATA, CustomData.EMPTY);
         if (!customEntityData.isEmpty()) {
-            return new Soul(customEntityData.copyTag());
+            return new Soul(spawnEggItem.getType(spawnEgg), customEntityData.copyTag());
         }
 
         return Soul.of(spawnEggItem.getType(spawnEgg));

--- a/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/SpawnEggSoulHandler.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/compat/vanilla/SpawnEggSoulHandler.java
@@ -32,7 +32,7 @@ public class SpawnEggSoulHandler implements ISoulHandler {
         // Get custom entity data
         var customEntityData = spawnEgg.getOrDefault(DataComponents.ENTITY_DATA, CustomData.EMPTY);
         if (!customEntityData.isEmpty()) {
-            return new Soul(customEntityData.copyTag());
+            return new Soul(spawnEggItem.getType(spawnEgg), customEntityData.copyTag());
         }
 
         return Soul.of(spawnEggItem.getType(spawnEgg));

--- a/enderio-base/src/main/java/com/enderio/base/common/filter/item/general/EnderItemFilter.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/filter/item/general/EnderItemFilter.java
@@ -92,6 +92,17 @@ public record EnderItemFilter(NonNullList<ItemStack> matches, boolean isDenyList
             }
         }
 
+        // Ensure no additional components are present
+        for (var component : stack.getComponents()) {
+            if (IGNORED_COMPONENT_TYPES.contains(component.type())) {
+                continue;
+            }
+
+            if (!Objects.equals(referenceStack.get(component.type()), component.value())) {
+                return false;
+            }
+        }
+
         return true;
     }
 }

--- a/enderio-base/src/main/java/com/enderio/base/common/filter/soul/EnderSoulFilter.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/filter/soul/EnderSoulFilter.java
@@ -6,7 +6,6 @@ import com.enderio.core.common.serialization.OrderedListCodec;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.NonNullList;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -59,7 +58,7 @@ public record EnderSoulFilter(NonNullList<Soul> matches, boolean isDenyList, boo
     public boolean test(LivingEntity entity) {
         for (var match : matches) {
             if (match.hasEntity()) {
-                if (shouldCompareTags ? Soul.isSameEntitySameTag(match, entity, entity.level().registryAccess()) : Soul.isSameEntity(match, entity)) {
+                if (shouldCompareTags ? Soul.isSameEntitySameTag(match, entity) : Soul.isSameEntity(match, entity)) {
                     return !isDenyList;
                 } else {
                     return isDenyList;

--- a/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
@@ -299,7 +299,7 @@ public class SoulVialItem extends Item implements AdvancedTooltipProvider {
             Direction dispenserDirection = source.state().getValue(DispenserBlock.FACING);
             AtomicReference<ItemStack> resultStack = new AtomicReference<>();
             releaseEntity(source.level(), stack, dispenserDirection, source.pos(),
-                () -> this.consumeWithRemainder(source, stack, EIOItems.SOUL_VIAL.get().getDefaultInstance()));
+                () -> resultStack.set(this.consumeWithRemainder(source, stack, EIOItems.SOUL_VIAL.get().getDefaultInstance())));
 
             if (resultStack.get() != null) {
                 return resultStack.get();

--- a/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/item/tool/SoulVialItem.java
@@ -96,7 +96,7 @@ public class SoulVialItem extends Item implements AdvancedTooltipProvider {
             return;
         }
 
-        var entityTag = soul.getEntityTag();
+        var entityTag = soul.entityTag();
         if (entityTag.contains(KEY_HEALTH)) {
             float health = entityTag.getFloat(KEY_HEALTH);
             tooltips.add(TooltipUtil.styledWithArgs(EIOLang.SOUL_VIAL_TOOLTIP_HEALTH, health, maxHealth));
@@ -217,7 +217,7 @@ public class SoulVialItem extends Item implements AdvancedTooltipProvider {
             float rotation = Mth.wrapDegrees(level.getRandom().nextFloat() * 360.0f);
 
             // Try to get the entity NBT from the item.
-            Optional<Entity> entity = EntityType.create(storedSoul.getEntityTag(), level);
+            Optional<Entity> entity = EntityType.create(storedSoul.getEntityTagWithId(), level);
 
             // Position the entity and add it.
             entity.ifPresent(ent -> {

--- a/enderio-base/src/main/java/com/enderio/base/common/loot/BrokenSpawnerLootModifier.java
+++ b/enderio-base/src/main/java/com/enderio/base/common/loot/BrokenSpawnerLootModifier.java
@@ -9,6 +9,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -41,8 +42,8 @@ public class BrokenSpawnerLootModifier extends LootModifier {
                     CompoundTag entityTag = spawner.nextSpawnData.getEntityToSpawn();
 
                     // TODO: should we be copying the entire entity tag?
-                    if (entityTag.contains(Soul.KEY_ID)) {
-                        ResourceLocation type = ResourceLocation.parse(entityTag.getString(Soul.KEY_ID));
+                    if (entityTag.contains(Entity.ID_TAG)) {
+                        ResourceLocation type = ResourceLocation.parse(entityTag.getString(Entity.ID_TAG));
                         ItemStack brokenSpawner = BrokenSpawnerItem.forSoul(Soul.of(type));
                         generatedLoot.add(brokenSpawner);
                     }

--- a/enderio-base/src/test/java/com/enderio/base/tests/filters/EnderSoulFilterTests.java
+++ b/enderio-base/src/test/java/com/enderio/base/tests/filters/EnderSoulFilterTests.java
@@ -32,9 +32,8 @@ public class EnderSoulFilterTests {
     @Test
     public void testBasicAllowFilterWithComponentComparison() {
         CompoundTag tag = new CompoundTag();
-        tag.putString(Entity.ID_TAG, BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ALLAY).toString());
         tag.putInt("Health", 20);
-        var soulWithHealth = new Soul(tag);
+        var soulWithHealth = new Soul(EntityType.ALLAY, tag);
 
         var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, soulWithHealth), false, true);
 

--- a/enderio-base/src/test/java/com/enderio/base/tests/filters/EnderSoulFilterTests.java
+++ b/enderio-base/src/test/java/com/enderio/base/tests/filters/EnderSoulFilterTests.java
@@ -5,6 +5,7 @@ import com.enderio.base.common.filter.soul.EnderSoulFilter;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ public class EnderSoulFilterTests {
     @Test
     public void testBasicAllowFilterWithComponentComparison() {
         CompoundTag tag = new CompoundTag();
-        tag.putString(Soul.KEY_ID, BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ALLAY).toString());
+        tag.putString(Entity.ID_TAG, BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ALLAY).toString());
         tag.putInt("Health", 20);
         var soulWithHealth = new Soul(tag);
 

--- a/enderio-base/src/test/java/com/enderio/base/tests/soul/SoulCodecTests.java
+++ b/enderio-base/src/test/java/com/enderio/base/tests/soul/SoulCodecTests.java
@@ -1,0 +1,76 @@
+package com.enderio.base.tests.soul;
+
+import com.enderio.base.api.soul.Soul;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.EntityType;
+import net.neoforged.testframework.junit.EphemeralTestServerProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(EphemeralTestServerProvider.class)
+public class SoulCodecTests {
+    // 8.0.5+ format
+    private static final String NEW_FORMAT = """
+        {
+            "entity_type": "minecraft:allay",
+            "entity_tag": {
+                "id": "minecraft:allay",
+                "Health": 10.0
+            }
+        }
+        """;
+
+    @Test
+    public void testLoadNewFormat(MinecraftServer server) {
+        // Parse json
+        var json = JsonParser.parseString(NEW_FORMAT);
+
+        // Attempt to deserialize
+        var ops = server.registryAccess().createSerializationContext(JsonOps.INSTANCE);
+        var result = Soul.CODEC.parse(ops, json);
+
+        Assertions.assertTrue(result.isSuccess());
+
+        var soul = result.getOrThrow();
+        Assertions.assertNotNull(soul);
+
+        // Ensure data matches
+        Assertions.assertEquals(EntityType.ALLAY, soul.entityType());
+        Assertions.assertEquals(10d, soul.entityTag().getDouble("Health"));
+
+        // Ensure unwanted key is removed.
+        Assertions.assertFalse(soul.entityTag().contains("id"));
+    }
+
+    // Pre 8.0.5 format
+    private static final String OLD_FORMAT = """
+        {
+            "entityTag": {
+                "id": "minecraft:allay",
+                "Health": 10.0
+            }
+        }
+        """;
+
+    @Test
+    public void testLoadOldFormat(MinecraftServer server) {
+        // Parse json
+        var json = JsonParser.parseString(OLD_FORMAT);
+
+        // Attempt to deserialize
+        var ops = server.registryAccess().createSerializationContext(JsonOps.INSTANCE);
+        var result = Soul.CODEC.parse(ops, json);
+
+        Assertions.assertTrue(result.isSuccess());
+
+        var soul = result.getOrThrow();
+        Assertions.assertNotNull(soul);
+
+        // Ensure data matches
+        Assertions.assertEquals(EntityType.ALLAY, soul.entityType());
+        Assertions.assertEquals(10d, soul.entityTag().getDouble("Health"));
+    }
+}

--- a/enderio-machines/src/main/java/com/enderio/machines/common/blocks/powered_spawner/MobSpawnTask.java
+++ b/enderio-machines/src/main/java/com/enderio/machines/common/blocks/powered_spawner/MobSpawnTask.java
@@ -92,7 +92,7 @@ public class MobSpawnTask extends PoweredSpawnerTask {
                 switch (spawnMode()) {
                 case COPY -> {
                     // TODO: Stop using BE to get entity tag data...
-                    entity = EntityType.loadEntityRecursive(blockEntity.getBoundSoul().getEntityTag(), level,
+                    entity = EntityType.loadEntityRecursive(blockEntity.getBoundSoul().getEntityTagWithId(), level,
                             entity1 -> {
                                 entity1.moveTo(x, y, z, entity1.getYRot(), entity1.getXRot());
                                 entity1.setUUID(UUID.randomUUID());


### PR DESCRIPTION
# Description

Removes certain NBT keys from Souls to allow soul vials to stack better (more likely to collect multiple of the same mob and have the vials stack).

Also ignores certain NBT keys during tag comparison to improve the usefulness of tag comparisons using the soul filter.

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] Need to investigate whether removing these tags could have possible ramifications.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Soul now carries an optional entity type alongside entity data; supports both new and legacy formats for compatibility.

- Bug Fixes
  - More reliable entity matching with optional deep tag comparison and symmetric component checks.
  - Spawn eggs, soul vials and spawners now preserve entity type/ID and custom data during bind, restore and spawn paths.
  - Fixed loot ID handling for correct mob type on broken spawners.

- Tests
  - Added codec tests for new and legacy Soul formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->