### PR TITLE
Change visibility of OutputItem codecs

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/machines/sag_mill/SagMillingRecipe.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/sag_mill/SagMillingRecipe.java
@@ -171,13 +171,13 @@ public record SagMillingRecipe(Ingredient input, List<OutputItem> outputs, int e
 
     public record OutputItem(Either<ItemStack, SizedTagOutput> output, float chance, boolean isOptional) {
 
-        private static final Codec<OutputItem> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        public static final Codec<OutputItem> CODEC = RecordCodecBuilder.create(instance -> instance.group(
                 Codec.either(ItemStack.CODEC, SizedTagOutput.CODEC).fieldOf("item").forGetter(OutputItem::output),
                 Codec.FLOAT.optionalFieldOf("chance", 1f).forGetter(OutputItem::chance),
                 Codec.BOOL.optionalFieldOf("optional", false).forGetter(OutputItem::isOptional))
                 .apply(instance, OutputItem::new));
 
-        private static final StreamCodec<RegistryFriendlyByteBuf, OutputItem> STREAM_CODEC = StreamCodec.composite(
+        public static final StreamCodec<RegistryFriendlyByteBuf, OutputItem> STREAM_CODEC = StreamCodec.composite(
                 ByteBufCodecs.either(ItemStack.STREAM_CODEC, SizedTagOutput.STREAM_CODEC), OutputItem::output,
                 ByteBufCodecs.FLOAT, OutputItem::chance, ByteBufCodecs.BOOL, OutputItem::isOptional, OutputItem::new);
 


### PR DESCRIPTION
# Description

This pull request changes the visibility of the `SagMillingRecipe$OutputItem` codecs to be public. This aligns with other codecs within the source and add-ons need access to this information.

# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.

- Refactor
  - Adjusted internal visibility of components related to recipe data handling for the SAG Mill.
  - No changes to gameplay, behaviour, or UI.

- Chores
  - Minor API surface adjustments to enable broader access where needed.
  - Existing save data and compatibility remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->