### PR TITLE
fix(ci): Don't try to use the branch name if it is null.

### DIFF
--- a/buildSrc/src/main/kotlin/mod-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mod-common-conventions.gradle.kts
@@ -67,6 +67,7 @@ publishing {
     }
 }
 
+// TODO: Make this work outside of a git context.
 val versionDetails: groovy.lang.Closure<VersionDetails> by extra
 var details = versionDetails()
 
@@ -77,6 +78,8 @@ var tagVersion = versionRegex.find(details.lastTag)?.value ?: "1.0.0"
 
 if (details.commitDistance == 0 && details.isCleanTag) {
     version = tagVersion
-} else {
+} else if (details.branchName != null) {
     version = "$tagVersion.${details.commitDistance}-${details.branchName.replace("/", "-")}+${details.gitHash}"
+} else {
+    version = "$tagVersion.${details.commitDistance}-dev+${details.gitHash}"
 }


### PR DESCRIPTION
# Description

Trying to fix failing PR builds as a result of the new gradle setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved build version labelling: branch builds now include branch name and commit info; non-branch builds use a -dev suffix with commit info for clearer identification.
- Chores
  - Exposed version details to the build system to support enhanced version strings.
  - Added a note to address future support for environments without Git.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->