### PR TITLE
Add validator to soul binding serializer for mutual exclusivity

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/machines/soul_binder/SoulBindingRecipe.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/soul_binder/SoulBindingRecipe.java
@@ -11,6 +11,7 @@ import com.enderio.enderio.foundation.util.ExperienceUtil;
 import com.enderio.enderio.init.EIOItems;
 import com.enderio.enderio.init.EIORecipes;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.NonNullList;
@@ -163,7 +164,7 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
 
     public static class Serializer implements RecipeSerializer<SoulBindingRecipe> {
 
-        private static final MapCodec<SoulBindingRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
+        private static final MapCodec<SoulBindingRecipe> CODEC = RecordCodecBuilder.<SoulBindingRecipe>mapCodec(instance -> instance
                 .group(ItemStack.CODEC.fieldOf("output").forGetter(SoulBindingRecipe::output),
                         Ingredient.CODEC_NONEMPTY.fieldOf("input").forGetter(SoulBindingRecipe::input),
                         Codec.INT.fieldOf("energy").forGetter(SoulBindingRecipe::energy),
@@ -173,7 +174,16 @@ public record SoulBindingRecipe(ItemStack output, Ingredient input, int energy, 
                         Codec.STRING.optionalFieldOf("soul_data").forGetter(SoulBindingRecipe::soulData),
                         Codec.BOOL.optionalFieldOf("copyInputComponents", false)
                                 .forGetter(SoulBindingRecipe::copyInputComponents))
-                .apply(instance, SoulBindingRecipe::new));
+                .apply(instance, SoulBindingRecipe::new))
+                .validate(recipe -> {
+                    int entityType = recipe.entityType().isPresent() ? 1 : 0;
+                    int mobCategory = recipe.mobCategory().isPresent() ? 1 : 0;
+                    int soulData = recipe.soulData().isPresent() ? 1 : 0;
+                    if (entityType + mobCategory + soulData > 1) {
+                        return DataResult.error(() -> "Soul Binding recipe properties entity_type, mob_category and soul_data are mutually exclusive.");
+                    }
+                    return DataResult.success(recipe);
+                });
 
         public static final StreamCodec<RegistryFriendlyByteBuf, SoulBindingRecipe> STREAM_CODEC = MassiveStreamCodec
                 .composite(ItemStack.STREAM_CODEC, SoulBindingRecipe::output, Ingredient.CONTENTS_STREAM_CODEC,


### PR DESCRIPTION
# Description

This pull request adds a recipe validator to the Soul Binder serializer. It ensures that all three soul data properties are mutually exclusive while remaining completely optional.

The built-in codec validation system will throw an `IllegalStateException` when the check fails.

Because codecs are a generic mess, it's required to specify the exact recipe type in the `RecordCodecBuilder` for the validator function to get the right type.

I tested this change by modifying the `SoulBindingRecipeProvider` locally:
```
build(Items.STICK, Ingredient.of(Items.APPLE), 1000, 0, Optional.of(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.PHANTOM)), Optional.of(MobCategory.AXOLOTLS), Optional.empty(), false, recipeOutput);
```
This throws the correct exception.

# Breaking Changes

None

# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevents invalid Soul Binding recipes with conflicting options from being accepted.
  - Displays clearer error messages when loading data packs with malformed Soul Binding recipes.
  - Improves stability and consistency when parsing custom content related to Soul Binding.

- Tests
  - None

- Chores
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->