### PR TITLE
Show advanced tooltips in JEI

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/ConduitBlockItem.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/ConduitBlockItem.java
@@ -27,7 +27,6 @@ import net.minecraft.client.gui.screens.Screen;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Properties;
 
 public class ConduitBlockItem extends BlockItem implements ICustomCreativeTabEntries {
 

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/ConduitBlockItem.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/ConduitBlockItem.java
@@ -23,9 +23,11 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
+import net.minecraft.client.gui.screens.Screen;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Properties;
 
 public class ConduitBlockItem extends BlockItem implements ICustomCreativeTabEntries {
 
@@ -120,10 +122,10 @@ public class ConduitBlockItem extends BlockItem implements ICustomCreativeTabEnt
         if (conduit != null) {
             conduit.value().addToTooltip(context, tooltipComponents::add, tooltipFlag);
 
-            boolean showDetailTooltip = !tooltipFlag.hasShiftDown()
+            boolean showDetailTooltip = !Screen.hasShiftDown()
                     && (conduit.value().hasAdvancedTooltip() || conduit.value().showDebugTooltip());
 
-            if (conduit.value().showDebugTooltip() && tooltipFlag.hasShiftDown()) {
+            if (conduit.value().showDebugTooltip() && Screen.hasShiftDown()) {
                 tooltipComponents.add(TooltipUtil.styledWithArgs(ConduitLang.GRAPH_TICK_RATE_TOOLTIP,
                         20 / conduit.value().networkTickRate()));
             }


### PR DESCRIPTION
# Description

Fixed Conduit BlockItem `<Hold Shift>` tooltip don't work on recipe viewers

<img width="348" height="142" alt="immagine" src="https://github.com/user-attachments/assets/21e475e2-cad2-4297-aebe-653ffce65420" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip visibility consistency for conduit items when holding Shift, ensuring detail tooltips appear reliably across different screens.
  * Fixed display condition for tick-rate info so the additional tooltip only shows when Shift is held, matching expected behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->