### PR TITLE
Performance fix

### DIFF
--- a/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -166,7 +166,9 @@ public class EnderBlockEntity extends BlockEntity {
                 buf.writeInt(i);
                 dataSlots.get(i).write(buf);
             });
-            return buf.array();
+            byte[] data = new byte[buf.readableBytes()];
+            buf.readBytes(data);
+            return data;
         }finally {
             buf.release(); // release the buffer safely
         }
@@ -198,7 +200,9 @@ public class EnderBlockEntity extends BlockEntity {
             try{
                 buf.writeInt(dataSlots.indexOf(slot));
                 slot.write(buf, value);
-                PacketDistributor.sendToServer(new ClientboundDataSlotChange(getBlockPos(), buf.array()));
+                byte[] data = new byte[buf.readableBytes()];
+                buf.readBytes(data);
+                PacketDistributor.sendToServer(new ClientboundDataSlotChange(getBlockPos(), data));
             }finally {
                 buf.release(); // release the buffer safely
             }

--- a/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -62,6 +62,8 @@ public class EnderBlockEntity extends BlockEntity {
         blockEntity.endTick();
     }
 
+    private int nextTick = 0;
+
     /**
      * Perform server-side ticking
      */
@@ -69,7 +71,10 @@ public class EnderBlockEntity extends BlockEntity {
     public void serverTick() {
         // Perform syncing.
         if (level != null) {
-            sync();
+            if(nextTick-- == 0) { // do we really need to update it once a tick?
+                sync();
+                nextTick = 5;
+            }
         }
     }
 

--- a/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -160,14 +160,16 @@ public class EnderBlockEntity extends BlockEntity {
 
         // Fine to use a normal byte buf here, we're not using codecs in here.
         RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.buffer(), level.registryAccess());
-        buf.writeInt(needsUpdate.size());
-        needsUpdate.forEach(i -> {
-            buf.writeInt(i);
-            dataSlots.get(i).write(buf);
-        });
-        byte[] arr = buf.array();
-        buf.release();
-        return arr;
+        try{
+            buf.writeInt(needsUpdate.size());
+            needsUpdate.forEach(i -> {
+                buf.writeInt(i);
+                dataSlots.get(i).write(buf);
+            });
+            return buf.array();
+        }finally {
+            buf.release(); // release the buffer safely
+        }
     }
 
     @Deprecated(forRemoval = true, since = "7.1")
@@ -193,10 +195,13 @@ public class EnderBlockEntity extends BlockEntity {
 
         if (dataSlots.contains(slot)) {
             RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.buffer(), level.registryAccess());
-            buf.writeInt(dataSlots.indexOf(slot));
-            slot.write(buf, value);
-            PacketDistributor.sendToServer(new ClientboundDataSlotChange(getBlockPos(), buf.array()));
-            buf.release();
+            try{
+                buf.writeInt(dataSlots.indexOf(slot));
+                slot.write(buf, value);
+                PacketDistributor.sendToServer(new ClientboundDataSlotChange(getBlockPos(), buf.array()));
+            }finally {
+                buf.release(); // release the buffer safely
+            }
             level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_NEIGHBORS);
         }
     }

--- a/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
+++ b/endercore/src/main/java/com/enderio/core/common/blockentity/EnderBlockEntity.java
@@ -73,7 +73,7 @@ public class EnderBlockEntity extends BlockEntity {
         if (level != null) {
             if(nextTick-- == 0) { // do we really need to update it once a tick?
                 sync();
-                nextTick = 5;
+                nextTick = 4;
             }
         }
     }

--- a/endercore/src/main/java/com/enderio/core/common/network/ClientPayloadHandler.java
+++ b/endercore/src/main/java/com/enderio/core/common/network/ClientPayloadHandler.java
@@ -40,8 +40,11 @@ public class ClientPayloadHandler {
             if (be instanceof EnderBlockEntity enderBlockEntity) {
                 var buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(update.slotData()),
                         level.registryAccess());
-                enderBlockEntity.clientHandleBufferSync(buf);
-                buf.release();
+                try{
+                    enderBlockEntity.clientHandleBufferSync(buf);
+                } finally {
+                    buf.release(); // release the buffer safely
+                }
             }
         });
     }

--- a/endercore/src/main/java/com/enderio/core/common/network/ServerPayloadHandler.java
+++ b/endercore/src/main/java/com/enderio/core/common/network/ServerPayloadHandler.java
@@ -23,8 +23,11 @@ public class ServerPayloadHandler {
             if (be instanceof EnderBlockEntity enderBlockEntity) {
                 var buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(change.updateData()),
                         level.registryAccess());
-                enderBlockEntity.serverHandleBufferChange(buf);
-                buf.release();
+                try{
+                    enderBlockEntity.serverHandleBufferChange(buf);
+                }finally {
+                    buf.release(); // release the buffer safely
+                }
             }
         });
     }

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/capacitor_bank/CapacitorBankBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/capacitor_bank/CapacitorBankBlockEntity.java
@@ -274,7 +274,8 @@ public class CapacitorBankBlockEntity extends LegacyPoweredMachineBlockEntity im
         }
 
         // Get raw objects once - this is the expensive reflection call
-        Set<GraphObject<Mergeable.Dummy>> objects = getMap().keySet();
+        Map<GraphObject<Mergeable.Dummy>, ?> map = getMap();
+        Collection<GraphObject<Mergeable.Dummy>> objects = !map.isEmpty() ? map.keySet() : node.getGraph().getObjects();
         List<BlockPos> positions = new ArrayList<>(objects.size());
 
         for (GraphObject<Mergeable.Dummy> obj : objects) {

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/capacitor_bank/CapacitorBankBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/capacitor_bank/CapacitorBankBlockEntity.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -253,16 +254,17 @@ public class CapacitorBankBlockEntity extends LegacyPoweredMachineBlockEntity im
         clientConfigurables.addAll(list);
     }
 
-    private Map<GraphObject<Mergeable.Dummy>, ?> cachedMap;
-    private Graph<Mergeable.Dummy> cachedMapGraph;
+    private volatile Map<GraphObject<Mergeable.Dummy>, ?> cachedMap;
+    private volatile Graph<Mergeable.Dummy> cachedMapGraph;
 
     private Map<GraphObject<Mergeable.Dummy>, ?> getMap() {
         Graph<Mergeable.Dummy> graph = node.getGraph();
-        if(graph == null) return new HashMap<>();
+        if(graph == null) return Collections.emptyMap();
         if (cachedMap == null || cachedMapGraph != graph) {
             cachedMap = ReflectionUtil.getRawMap(graph);
             cachedMapGraph = graph;
         }
+        if (cachedMap == null) cachedMap = Collections.emptyMap();
         return cachedMap;
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/capacitor_bank/CapacitorBankBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/capacitor_bank/CapacitorBankBlockEntity.java
@@ -12,6 +12,7 @@ import com.enderio.enderio.foundation.block.entity.multienergy.MultiEnergyStorag
 import com.enderio.enderio.foundation.io.energy.ILargeMachineEnergyStorage;
 import com.enderio.enderio.foundation.io.energy.MachineEnergyStorage;
 import com.enderio.enderio.foundation.tag.EIOTags;
+import com.enderio.enderio.foundation.util.ReflectionUtil;
 import com.enderio.enderio.init.EIOBlockEntities;
 import dev.gigaherz.graph3.Graph;
 import dev.gigaherz.graph3.GraphObject;
@@ -31,9 +32,12 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class CapacitorBankBlockEntity extends LegacyPoweredMachineBlockEntity implements MultiConfigurable {
 
@@ -78,6 +82,7 @@ public class CapacitorBankBlockEntity extends LegacyPoweredMachineBlockEntity im
         addDataSlot(POSITION_LIST_DATA_SLOT_TYPE.create(this::getPositions, this::setPositions));
         addDataSlot(DISPLAY_MODE_MAP_DATA_SLOT_TYPE.create(() -> displayModes, displayModes::putAll));
     }
+
 
     @Override
     public NetworkDataSlot<?> createEnergyDataSlot() {
@@ -248,14 +253,30 @@ public class CapacitorBankBlockEntity extends LegacyPoweredMachineBlockEntity im
         clientConfigurables.addAll(list);
     }
 
+    private Map<GraphObject<Mergeable.Dummy>, ?> cachedMap;
+    private Graph<Mergeable.Dummy> cachedMapGraph;
+
+    private Map<GraphObject<Mergeable.Dummy>, ?> getMap() {
+        Graph<Mergeable.Dummy> graph = node.getGraph();
+        if(graph == null) return new HashMap<>();
+        if (cachedMap == null || cachedMapGraph != graph) {
+            cachedMap = ReflectionUtil.getRawMap(graph);
+            cachedMapGraph = graph;
+        }
+        return cachedMap;
+    }
+
     private List<BlockPos> getPositions() {
         if (node.getGraph() == null) {
             return List.of();
         }
 
-        List<BlockPos> positions = new ArrayList<>();
-        for (GraphObject<Mergeable.Dummy> object : node.getGraph().getObjects()) {
-            if (object instanceof MultiEnergyNode otherNode) {
+        // Get raw objects once - this is the expensive reflection call
+        Set<GraphObject<Mergeable.Dummy>> objects = getMap().keySet();
+        List<BlockPos> positions = new ArrayList<>(objects.size());
+
+        for (GraphObject<Mergeable.Dummy> obj : objects) {
+            if (obj instanceof MultiEnergyNode otherNode) {
                 positions.add(otherNode.pos);
             }
         }

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
@@ -46,15 +46,16 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
         return (int)Math.min(Integer.MAX_VALUE, getLargeEnergyStored());
     }
 
-    private Map<GraphObject<Mergeable.Dummy>, ?> cachedMap;
-    private Graph<Mergeable.Dummy> cachedMapGraph;
+    private volatile Map<GraphObject<Mergeable.Dummy>, ?> cachedMap;
+    private volatile Graph<Mergeable.Dummy> cachedMapGraph;
 
     private Map<GraphObject<Mergeable.Dummy>, ?> getMap() {
-        if(this.graph == null) return new HashMap<>();
+        if(this.graph == null) return Collections.emptyMap();
         if (cachedMap == null || cachedMapGraph != graph) {
             cachedMap = ReflectionUtil.getRawMap(graph);
             cachedMapGraph = graph;
         }
+        if(this.cachedMap == null) return Collections.emptyMap();
         return cachedMap;
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
@@ -4,14 +4,20 @@ import com.enderio.enderio.api.io.IOConfigurable;
 import com.enderio.enderio.api.io.energy.EnergyIOMode;
 import com.enderio.enderio.foundation.io.energy.ILargeMachineEnergyStorage;
 import com.enderio.enderio.foundation.io.energy.MachineEnergyStorage;
+import com.enderio.enderio.foundation.util.ReflectionUtil;
 import dev.gigaherz.graph3.Graph;
 import dev.gigaherz.graph3.GraphObject;
 import dev.gigaherz.graph3.Mergeable;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements ILargeMachineEnergyStorage {
@@ -40,22 +46,35 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
         return (int)Math.min(Integer.MAX_VALUE, getLargeEnergyStored());
     }
 
+    private Map<GraphObject<Mergeable.Dummy>, ?> cachedMap;
+    private Graph<Mergeable.Dummy> cachedMapGraph;
+
+    private Map<GraphObject<Mergeable.Dummy>, ?> getMap() {
+        if(this.graph == null) return new HashMap<>();
+        if (cachedMap == null || cachedMapGraph != graph) {
+            cachedMap = ReflectionUtil.getRawMap(graph);
+            cachedMapGraph = graph;
+        }
+        return cachedMap;
+    }
 
     @Override
     public long getLargeEnergyStored() {
         if (graph == null) {
             return 0;
         }
+        Set<GraphObject<Mergeable.Dummy>> objects = getMap().keySet();
+        long sum = 0;
 
-        long cumulativeEnergy = 0;
-        for (GraphObject<Mergeable.Dummy> object : graph.getObjects()) {
-            if (object instanceof MultiEnergyNode panelNode) {
-                cumulativeEnergy += panelNode.getInternal().get().getEnergyStored();
+        for (GraphObject<Mergeable.Dummy> obj : objects) {
+            if (obj instanceof MultiEnergyNode node) {
+                sum += node.getInternal().get().getEnergyStored();
             }
         }
 
-        return cumulativeEnergy;
+        return sum;
     }
+
     @Override
     public int getMaxEnergyStored() {
         return (int)(Math.min(getLargeMaxEnergyStored(), Integer.MAX_VALUE));

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
@@ -49,22 +49,23 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
     private volatile Map<GraphObject<Mergeable.Dummy>, ?> cachedMap;
     private volatile Graph<Mergeable.Dummy> cachedMapGraph;
 
-    private Map<GraphObject<Mergeable.Dummy>, ?> getMap() {
-        if(this.graph == null) return null;
-        if (cachedMap == null || cachedMapGraph != graph) {
-            cachedMap = ReflectionUtil.getRawMap(graph);
-            cachedMapGraph = graph;
+    private Map<GraphObject<Mergeable.Dummy>, ?> getMap(Graph<Mergeable.Dummy> graph) {
+        if(graph == null) return null;
+        if (this.cachedMap == null || this.cachedMapGraph != graph) {
+            this.cachedMap = ReflectionUtil.getRawMap(graph);
+            this.cachedMapGraph = graph;
         }
-        if(cachedMap == null) cachedMap = Collections.emptyMap();
-        return cachedMap;
+        if(this.cachedMap == null) this.cachedMap = Collections.emptyMap();
+        return this.cachedMap;
     }
 
     @Override
     public long getLargeEnergyStored() {
-        if (graph == null) {
+        Graph<Mergeable.Dummy> graphSnapshot = this.graph;
+        if (graphSnapshot == null) {
             return 0;
         }
-        Map<GraphObject<Mergeable.Dummy>, ?> map = getMap();
+        Map<GraphObject<Mergeable.Dummy>, ?> map = getMap(graphSnapshot);
         Collection<GraphObject<Mergeable.Dummy>> objects = !map.isEmpty() ? map.keySet() : graph.getObjects();
         long sum = 0;
 

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/multienergy/MultiEnergyStorageWrapper.java
@@ -50,12 +50,12 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
     private volatile Graph<Mergeable.Dummy> cachedMapGraph;
 
     private Map<GraphObject<Mergeable.Dummy>, ?> getMap() {
-        if(this.graph == null) return Collections.emptyMap();
+        if(this.graph == null) return null;
         if (cachedMap == null || cachedMapGraph != graph) {
             cachedMap = ReflectionUtil.getRawMap(graph);
             cachedMapGraph = graph;
         }
-        if(this.cachedMap == null) return Collections.emptyMap();
+        if(cachedMap == null) cachedMap = Collections.emptyMap();
         return cachedMap;
     }
 
@@ -64,7 +64,8 @@ public class MultiEnergyStorageWrapper extends MachineEnergyStorage implements I
         if (graph == null) {
             return 0;
         }
-        Set<GraphObject<Mergeable.Dummy>> objects = getMap().keySet();
+        Map<GraphObject<Mergeable.Dummy>, ?> map = getMap();
+        Collection<GraphObject<Mergeable.Dummy>> objects = !map.isEmpty() ? map.keySet() : graph.getObjects();
         long sum = 0;
 
         for (GraphObject<Mergeable.Dummy> obj : objects) {

--- a/enderio/src/main/java/com/enderio/enderio/foundation/util/ReflectionUtil.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/util/ReflectionUtil.java
@@ -24,6 +24,9 @@ public class ReflectionUtil {
 
     @SuppressWarnings("unchecked")
     public static Map<GraphObject<Mergeable.Dummy>, ?> getRawMap(Graph<Mergeable.Dummy> graph) {
+        if(GRAPH_OBJECTS_FIELD == null) {
+            return null;
+        }
         try {
             return (Map<GraphObject<Mergeable.Dummy>, ?>) GRAPH_OBJECTS_FIELD.get(graph);
         } catch (Exception ignored) {

--- a/enderio/src/main/java/com/enderio/enderio/foundation/util/ReflectionUtil.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/util/ReflectionUtil.java
@@ -1,0 +1,43 @@
+package com.enderio.enderio.foundation.util;
+
+import dev.gigaherz.graph3.Graph;
+import dev.gigaherz.graph3.GraphObject;
+import dev.gigaherz.graph3.Mergeable;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+
+public class ReflectionUtil {
+
+    private static final Field GRAPH_OBJECTS_FIELD = getGraphObjectsField();
+
+    private static Field getGraphObjectsField() {
+        try {
+            var f = Graph.class.getDeclaredField("objects");
+            f.setAccessible(true);
+            return f;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<GraphObject<Mergeable.Dummy>, ?> getRawMap(Graph<Mergeable.Dummy> graph) {
+        try {
+            return (Map<GraphObject<Mergeable.Dummy>, ?>) GRAPH_OBJECTS_FIELD.get(graph);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Collection<GraphObject<Mergeable.Dummy>> getRawObjects(Graph<Mergeable.Dummy> graph) {
+        try {
+            Map<GraphObject<Mergeable.Dummy>, ?> map = (Map<GraphObject<Mergeable.Dummy>, ?>) GRAPH_OBJECTS_FIELD.get(graph);
+            return map.keySet();
+        } catch (Exception ignored) {}
+        return graph.getObjects(); // fallback
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,8 @@ pluginManagement {
         }
 
         maven {
-            url = uri("https://maven.firstdarkdev.xyz/releases")
+            name = "FirstDarkDev"
+            url = uri("https://maven.firstdark.dev/releases")
         }
 
         maven {


### PR DESCRIPTION
# Description

- Entity update tick buffering: Updating every tick a lot of blocks will create performance issues and high tick times
- Graph Objects optimizations: Graph#getObjects creates an UnmodifiableSet, this creates an overhead, by using reflections (just at initialization time) we can directly access to the objects map in the object.

I've got from 6 tps to >19

# Breaking Changes

Should not have any

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced frequency of certain synchronisations to lower server load.
  * Faster energy-network operations via cached graph lookups.

* **Bug Fixes**
  * Guaranteed safe release of network buffers to prevent resource leaks on errors.

* **Refactor**
  * Internal caching and iteration improvements to streamline energy aggregation logic.

* **Chore**
  * Build repository endpoint updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->