### PR TITLE
fix: VAT output duplication

### DIFF
--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1196.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1196.java
@@ -1,0 +1,71 @@
+package com.enderio.enderio.gametests.regressions.issues;
+
+import com.enderio.enderio.api.io.IOMode;
+import com.enderio.enderio.content.machines.vat.FermentingRecipe;
+import com.enderio.enderio.content.machines.vat.VatBlockEntity;
+import com.enderio.enderio.gametests.util.EnderGameTestHelper;
+import com.enderio.enderio.init.EIOBlocks;
+import com.enderio.enderio.init.EIOFluids;
+import com.enderio.enderio.init.EIORecipes;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestAssertException;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
+
+/**
+ * Test for Issue #1196 - Infinite Fluids form the VAT
+ * https://github.com/Team-EnderIO/EnderIO/issues/1196
+ */
+@ForEachTest(groups = "regression.issue1196")
+public class Issue1196 {
+    @GameTest
+    @TestHolder(description = "Ensures that the VAT doesn't produce infinite outputs.")
+    public static void testIssue1196(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(1, 1, 2)
+            .set(0, 0, 0, EIOBlocks.VAT.get().defaultBlockState())
+            .set(0, 0, 1, EIOBlocks.FLUID_TANK.get().defaultBlockState()));
+
+        test.onGameTest(EnderGameTestHelper.class, helper -> {
+            helper.startSequence()
+                // Setup VAT to push outputs to the fluid tank
+                .thenExecute(() -> helper.changeIoConfig(0, 1, 1, ioConfigurable -> {
+                    ioConfigurable.setIOMode(Direction.NORTH, IOMode.PULL);
+                }))
+                // Insert recipe for Cloud Seed.
+                .thenExecute(() -> {
+                    // Set VAT output tank to full
+                    var vat = helper.getBlockEntity(0, 1, 0, VatBlockEntity.class);
+                    VatBlockEntity.OUTPUT_TANK.setFluid(vat, new FluidStack(EIOFluids.CLOUD_SEED.source().get(), VatBlockEntity.TANK_CAPACITY));
+
+                    helper.fillContainer(0, 1, 0, Fluids.WATER, VatBlockEntity.TANK_CAPACITY);
+                    helper.insertIntoContainer(0, 1, 0, Items.PRISMARINE_SHARD, 1);
+                    helper.insertIntoContainer(0, 1, 0, Items.SNOW_BLOCK, 1);
+                })
+                // Make sure that after 5 seconds we have exactly 1 bucket of cloud seed, and no more.
+                .thenExecuteAfter(20 * 5, () -> {
+                    long storedInVat = helper.getAmountInHandler(0, 1, 0, EIOFluids.CLOUD_SEED.source().get());
+                    long storedInTank = helper.getAmountInHandler(0, 1, 1, EIOFluids.CLOUD_SEED.source().get());
+
+                    // Determine how much Cloud Seed is created per craft
+                    var recipeInput = new FermentingRecipe.Input(new ItemStack(Items.PRISMARINE_SHARD, 1), new ItemStack(Items.SNOW_BLOCK, 1), new FluidStack(Fluids.WATER, 1000));
+                    var recipe = helper.getLevel().getRecipeManager().getRecipeFor(EIORecipes.VAT_FERMENTING.type().get(), recipeInput, helper.getLevel()).orElseThrow();
+                    var outputs = recipe.value().craft(recipeInput, helper.getLevel().registryAccess());
+                    int amountCreated = outputs.getFirst().getFluid().getAmount();
+
+                    // Ensure no more fluid appeared out of thin air.
+                    // TODO: It appears the amount varies between 10000 and 9900 - it is unclear why.
+                    if (storedInVat + storedInTank > VatBlockEntity.TANK_CAPACITY + amountCreated) {
+                        throw new GameTestAssertException("Too much fluid output by Vat! Total: " + (storedInVat + storedInTank));
+                    }
+                })
+                .thenSucceed();
+        });
+    }
+}

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1196.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1196.java
@@ -20,7 +20,7 @@ import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 
 /**
- * Test for Issue #1196 - Infinite Fluids form the VAT
+ * Test for Issue #1196 - Infinite Fluids from the VAT
  * https://github.com/Team-EnderIO/EnderIO/issues/1196
  */
 @ForEachTest(groups = "regression.issue1196")
@@ -34,7 +34,7 @@ public class Issue1196 {
 
         test.onGameTest(EnderGameTestHelper.class, helper -> {
             helper.startSequence()
-                // Setup VAT to push outputs to the fluid tank
+                // Setup Fluid Tank to pull the VAT output
                 .thenExecute(() -> helper.changeIoConfig(0, 1, 1, ioConfigurable -> {
                     ioConfigurable.setIOMode(Direction.NORTH, IOMode.PULL);
                 }))

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1196.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1196.java
@@ -38,15 +38,15 @@ public class Issue1196 {
                 .thenExecute(() -> helper.changeIoConfig(0, 1, 1, ioConfigurable -> {
                     ioConfigurable.setIOMode(Direction.NORTH, IOMode.PULL);
                 }))
-                // Insert recipe for Cloud Seed.
+                // Insert recipe for Cloud Seed (using test recipe with dirt and cobblestone).
                 .thenExecute(() -> {
                     // Set VAT output tank to full
                     var vat = helper.getBlockEntity(0, 1, 0, VatBlockEntity.class);
                     VatBlockEntity.OUTPUT_TANK.setFluid(vat, new FluidStack(EIOFluids.CLOUD_SEED.source().get(), VatBlockEntity.TANK_CAPACITY));
 
                     helper.fillContainer(0, 1, 0, Fluids.WATER, VatBlockEntity.TANK_CAPACITY);
-                    helper.insertIntoContainer(0, 1, 0, Items.PRISMARINE_SHARD, 1);
-                    helper.insertIntoContainer(0, 1, 0, Items.SNOW_BLOCK, 1);
+                    helper.insertIntoContainer(0, 1, 0, Items.DIRT, 1);
+                    helper.insertIntoContainer(0, 1, 0, Items.COBBLESTONE, 1);
                 })
                 // Make sure that after 5 seconds we have exactly 1 bucket of cloud seed, and no more.
                 .thenExecuteAfter(20 * 5, () -> {
@@ -54,13 +54,12 @@ public class Issue1196 {
                     long storedInTank = helper.getAmountInHandler(0, 1, 1, EIOFluids.CLOUD_SEED.source().get());
 
                     // Determine how much Cloud Seed is created per craft
-                    var recipeInput = new FermentingRecipe.Input(new ItemStack(Items.PRISMARINE_SHARD, 1), new ItemStack(Items.SNOW_BLOCK, 1), new FluidStack(Fluids.WATER, 1000));
+                    var recipeInput = new FermentingRecipe.Input(new ItemStack(Items.DIRT, 1), new ItemStack(Items.COBBLESTONE, 1), new FluidStack(Fluids.WATER, 1000));
                     var recipe = helper.getLevel().getRecipeManager().getRecipeFor(EIORecipes.VAT_FERMENTING.type().get(), recipeInput, helper.getLevel()).orElseThrow();
                     var outputs = recipe.value().craft(recipeInput, helper.getLevel().registryAccess());
                     int amountCreated = outputs.getFirst().getFluid().getAmount();
 
                     // Ensure no more fluid appeared out of thin air.
-                    // TODO: It appears the amount varies between 10000 and 9900 - it is unclear why.
                     if (storedInVat + storedInTank > VatBlockEntity.TANK_CAPACITY + amountCreated) {
                         throw new GameTestAssertException("Too much fluid output by Vat! Total: " + (storedInVat + storedInTank));
                     }

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/util/EnderGameTestHelper.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/util/EnderGameTestHelper.java
@@ -84,6 +84,23 @@ public class EnderGameTestHelper extends ExtendedGameTestHelper {
         }
     }
 
+    public long getAmountInHandler(int x, int y, int z, Fluid fluid) {
+        var fluidHandler = getLevel().getCapability(Capabilities.FluidHandler.BLOCK, absolutePos(new BlockPos(x, y, z)),
+            null);
+        if (fluidHandler == null) {
+            throw new GameTestAssertException("No fluid handler at " + x + "," + y + "," + z);
+        }
+
+        long totalAmount = 0;
+        for (int i = 0; i < fluidHandler.getTanks(); i++) {
+            if (fluidHandler.getFluidInTank(i).is(fluid)) {
+                totalAmount += fluidHandler.getFluidInTank(i).getAmount();
+            }
+        }
+
+        return totalAmount;
+    }
+
     public void assertContainerHasExactly(int x, int y, int z, Fluid fluid, int amount) {
         var fluidHandler = getLevel().getCapability(Capabilities.FluidHandler.BLOCK, absolutePos(new BlockPos(x, y, z)),
             null);

--- a/enderio/src/gametest/resources/data/enderio_test/recipe/fermenting/fluid_cloud_seed_test.json
+++ b/enderio/src/gametest/resources/data/enderio_test/recipe/fermenting/fluid_cloud_seed_test.json
@@ -1,0 +1,14 @@
+{
+  "type": "enderio:vat_fermenting",
+  "input": {
+    "amount": 1000,
+    "tag": "minecraft:water"
+  },
+  "left_reagent": "enderio_test:test_reagent_left",
+  "output": {
+    "amount": 1000,
+    "id": "enderio:fluid_cloud_seed_still"
+  },
+  "right_reagent": "enderio_test:test_reagent_right",
+  "ticks": 20
+}

--- a/enderio/src/gametest/resources/data/enderio_test/tags/item/test_reagent_left.json
+++ b/enderio/src/gametest/resources/data/enderio_test/tags/item/test_reagent_left.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:dirt"
+  ]
+}

--- a/enderio/src/gametest/resources/data/enderio_test/tags/item/test_reagent_right.json
+++ b/enderio/src/gametest/resources/data/enderio_test/tags/item/test_reagent_right.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:cobblestone"
+  ]
+}

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/vat/FermentingRecipe.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/vat/FermentingRecipe.java
@@ -3,7 +3,6 @@ package com.enderio.enderio.content.machines.vat;
 import com.enderio.core.common.recipes.OutputStack;
 import com.enderio.enderio.foundation.MachineRecipe;
 import com.enderio.enderio.foundation.datamap.VatReagent;
-import com.enderio.enderio.foundation.io.fluid.MachineFluidTank;
 import com.enderio.enderio.init.EIORecipes;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
@@ -51,7 +50,7 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
 
     @Override
     public boolean matches(Input input, Level level) {
-        FluidStack inputTank = input.getInputTank().getFluid();
+        FluidStack inputTank = input.inputFluid();
         if (!this.input.test(inputTank) || inputTank.getAmount() < this.input.amount()) {
             return false;
         }
@@ -77,7 +76,7 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
         return EIORecipes.VAT_FERMENTING.type().get();
     }
 
-    public record Input(ItemStack leftReagent, ItemStack rightStack, MachineFluidTank inputTank)
+    public record Input(ItemStack leftReagent, ItemStack rightStack, FluidStack inputFluid)
             implements RecipeInput {
 
         @Override
@@ -93,11 +92,6 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
         public int size() {
             return 2;
         }
-
-        public MachineFluidTank getInputTank() {
-            return inputTank;
-        }
-
     }
 
     public static class Serializer implements RecipeSerializer<FermentingRecipe> {

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
@@ -187,10 +187,20 @@ public class VatBlockEntity extends MachineBlockEntity implements FluidTankUser,
 
         @Override
         protected boolean placeOutputs(List<OutputStack> outputs, boolean simulate) {
-            var action = simulate ? IFluidHandler.FluidAction.SIMULATE : IFluidHandler.FluidAction.EXECUTE;
             FluidStack output = outputs.getFirst().getFluid();
-            int filled = OUTPUT_TANK.getTank(fluidHandler).fill(output, action);
-            return filled == output.getAmount();
+
+            // Always simulate first to check if we can place the full amount
+            int simulatedFill = OUTPUT_TANK.getTank(fluidHandler).fill(output, IFluidHandler.FluidAction.SIMULATE);
+            if (simulatedFill != output.getAmount()) {
+                return false;
+            }
+
+            // Only execute if we're not simulating and the simulation succeeded
+            if (!simulate) {
+                OUTPUT_TANK.getTank(fluidHandler).fill(output, IFluidHandler.FluidAction.EXECUTE);
+            }
+
+            return true;
         }
 
         @Override

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
@@ -106,7 +106,7 @@ public class VatBlockEntity extends MachineBlockEntity implements FluidTankUser,
 
     private FermentingRecipe.Input createRecipeInput() {
         List<ItemStack> reagents = REAGENTS.getItemStacks(getInventory());
-        return new FermentingRecipe.Input(reagents.get(0), reagents.get(1), getInputTank());
+        return new FermentingRecipe.Input(reagents.get(0), reagents.get(1), INPUT_TANK.getFluid(this));
     }
 
     @Override
@@ -195,7 +195,7 @@ public class VatBlockEntity extends MachineBlockEntity implements FluidTankUser,
 
         @Override
         protected int makeProgress(int remainingProgress) {
-            return 1; // do nothing. VAT doesn't consume power
+            return 20; // do nothing. VAT doesn't consume power
         }
 
         @Override

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
@@ -205,7 +205,7 @@ public class VatBlockEntity extends MachineBlockEntity implements FluidTankUser,
 
         @Override
         protected int makeProgress(int remainingProgress) {
-            return 20; // do nothing. VAT doesn't consume power
+            return 1; // VAT doesn't consume power
         }
 
         @Override


### PR DESCRIPTION
# Description

Will fix an issue where the VATs outputs can be duplicated.

Fixes: #1196

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [x] Actually fix the issue.

# Breaking Changes

Changed VAT fermenting recipe input format.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented VAT fermenting from producing infinite/excess fluid by enforcing pre-transfer capacity checks.

* **Tests**
  * Added a regression test verifying VAT fermentation output limits and no fluid overflow.
  * Added test utilities and test data (fermenting recipe and reagent tags) to support the new test.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->