### PR TITLE
fix: Handle missing BLOCK_ENTITY in BrokenSpawnerLootModifier (#1199)

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/broken_spawner/BrokenSpawnerLootModifier.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/broken_spawner/BrokenSpawnerLootModifier.java
@@ -33,7 +33,10 @@ public class BrokenSpawnerLootModifier extends LootModifier {
 
     @Override
     protected ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
-        BlockEntity entity = context.getParam(LootContextParams.BLOCK_ENTITY);
+        BlockEntity entity = context.getParamOrNull(LootContextParams.BLOCK_ENTITY);
+        if (entity == null) {
+            return generatedLoot;
+        }
         if (entity instanceof SpawnerBlockEntity spawnerBlockEntity) {
             if (!context.getParam(LootContextParams.TOOL).is(EIOTags.Items.BROKEN_SPAWNER_BLACKLIST)) {
                 if (context.getRandom().nextFloat() < BaseConfig.COMMON.BLOCKS.BROKEN_SPAWNER_DROP_CHANCE.get()) {


### PR DESCRIPTION
# Description

When spawners are broken via non-standard methods (e.g., EvilCraft broom), the BLOCK_ENTITY loot parameter may not be present, causing a crash. This change uses getParamOrNull and returns early if the parameter is missing, allowing the spawner to drop normally without the mod's custom loot modification.

Closes #1199.

# Breaking Changes

None

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced broken spawner loot drop reliability by implementing more robust null safety checks during loot generation. The system now gracefully handles edge cases where block entity data is unavailable, preventing potential errors and ensuring consistent, predictable loot drops across all gameplay situations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->