### PR TITLE
feat: Add helpful tooltip for unconfigured filters (#1067)

### DIFF
--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/client/EIOLanguageProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/client/EIOLanguageProvider.java
@@ -264,6 +264,7 @@ public class EIOLanguageProvider extends LanguageProvider {
 
     private void addFiltersLang() {
         add(FiltersLang.CONFIGURED, "Configured");
+        add(FiltersLang.UNCONFIGURED_HINT, "Use while crouching to configure");
         add(FiltersLang.FILTER_CONFIG_NOT_ALLOWED_COMPONENT_MATCH, "This filter uses component matching which is no longer available to this item. Clear this filter using the crafting grid to remove this warning.");
 
         add(FiltersLang.FILTER_ALLOW_LIST, "Allow List");

--- a/enderio/src/generated/resources/assets/enderio/lang/en_us.json
+++ b/enderio/src/generated/resources/assets/enderio/lang/en_us.json
@@ -570,6 +570,7 @@
   "tooltip.enderio.energy_equivalence": "A unit of energy, equivalent to FE.",
   "tooltip.enderio.filter.configured": "Configured",
   "tooltip.enderio.filter.not_allowed_component_match": "This filter uses component matching which is no longer available to this item. Clear this filter using the crafting grid to remove this warning.",
+  "tooltip.enderio.filter.unconfigured_hint": "Use while crouching to configure",
   "tooltip.enderio.fluid_tank.contents_tooltip": "%d/%d mb of %s",
   "tooltip.enderio.fluid_tank.empty_tooltip": "Empty tank",
   "tooltip.enderio.glass.blocks_light": "Blocks Light",

--- a/enderio/src/main/java/com/enderio/enderio/api/filter/RedstoneFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/filter/RedstoneFilter.java
@@ -1,0 +1,15 @@
+package com.enderio.enderio.api.filter;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public interface RedstoneFilter {
+
+    /**
+     * Returns whether this filter has been configured by the player.
+     * Used to determine whether to show configuration hints in tooltips.
+     *
+     * @return true if the filter has been configured, false if it's in its default state
+     */
+    boolean isConfigured();
+}

--- a/enderio/src/main/java/com/enderio/enderio/api/filter/RedstoneInputFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/filter/RedstoneInputFilter.java
@@ -6,7 +6,7 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Experimental
-public interface RedstoneInputFilter {
+public interface RedstoneInputFilter extends RedstoneFilter {
 
     // TODO: Should we wrap level, pos and direction with a RedstoneInputContext?
     int getInputSignal(Level level, BlockPos pos, Direction direction);

--- a/enderio/src/main/java/com/enderio/enderio/api/filter/RedstoneOutputFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/filter/RedstoneOutputFilter.java
@@ -4,7 +4,7 @@ import net.minecraft.world.item.DyeColor;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Experimental
-public interface RedstoneOutputFilter {
+public interface RedstoneOutputFilter extends RedstoneFilter {
 
     int getOutputSignal(RedstoneOutputFilterContext context, DyeColor control);
 }

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/AbstractFilterItem.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/AbstractFilterItem.java
@@ -89,6 +89,9 @@ public abstract class AbstractFilterItem<T> extends Item implements FilterMenuPr
         var filter = stack.getOrDefault(dataComponentType(), defaultFilter());
         if (!filter.equals(defaultFilter())) {
             tooltipComponents.add(FiltersLang.CONFIGURED);
+        } else {
+            // Add helpful hint for unconfigured filters
+            tooltipComponents.add(FiltersLang.UNCONFIGURED_HINT);
         }
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/FiltersLang.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/FiltersLang.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.MutableComponent;
 public class FiltersLang {
 
     public static final MutableComponent CONFIGURED = tooltip("configured");
+    public static final MutableComponent UNCONFIGURED_HINT = tooltip("unconfigured_hint").withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC);
     public static final MutableComponent FILTER_CONFIG_NOT_ALLOWED_COMPONENT_MATCH = tooltip("not_allowed_component_match").withStyle(ChatFormatting.RED);
 
     public static final Component FILTER_ALLOW_LIST = gui("allow_list");

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/DoubleRedstoneChannel.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/DoubleRedstoneChannel.java
@@ -1,5 +1,6 @@
 package com.enderio.enderio.content.filters.redstone;
 
+import com.enderio.enderio.api.filter.RedstoneFilter;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.ByteBuf;
@@ -8,7 +9,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 
-public class DoubleRedstoneChannel {
+public class DoubleRedstoneChannel implements RedstoneFilter {
 
     public static final Component INSTANCE = new Component(DyeColor.GREEN, DyeColor.BROWN);
 
@@ -38,6 +39,12 @@ public class DoubleRedstoneChannel {
 
     public void setChannels(DyeColor channel1, DyeColor channel2) {
         stack.set(componentType, new Component(channel1, channel2));
+    }
+
+    @Override
+    public boolean isConfigured() {
+        Component current = stack.get(componentType);
+        return current != null && !current.equals(INSTANCE);
     }
 
     public record Component(DyeColor channel1, DyeColor channel2) {

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneCountFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneCountFilter.java
@@ -88,6 +88,12 @@ public class RedstoneCountFilter implements RedstoneOutputFilter {
                 new Component(channel, component.maxCount, component.count, component.deactivated));
     }
 
+    @Override
+    public boolean isConfigured() {
+        Component current = stack.get(EIODataComponents.REDSTONE_COUNT_FILTER);
+        return current != null && !current.equals(INSTANCE);
+    }
+
     public record Component(DyeColor channel1, int maxCount, int count, boolean deactivated) {
         public static final Codec<Component> CODEC = RecordCodecBuilder.create(instance -> instance
                 .group(DyeColor.CODEC.fieldOf("channel1").forGetter(Component::channel1),

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneFilterItem.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneFilterItem.java
@@ -1,7 +1,10 @@
 package com.enderio.enderio.content.filters.redstone;
 
+import com.enderio.enderio.api.EnderIOCapabilities;
+import com.enderio.enderio.api.filter.RedstoneFilter;
 import com.enderio.enderio.api.filter.RedstoneInputFilter;
 import com.enderio.enderio.api.filter.RedstoneOutputFilter;
+import com.enderio.enderio.content.filters.FiltersLang;
 import com.enderio.enderio.init.EIODataComponents;
 import com.enderio.enderio.init.EIOMenus;
 import net.minecraft.network.chat.Component;
@@ -15,10 +18,12 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -64,7 +69,7 @@ public class RedstoneFilterItem extends Item {
     @Override
     public InteractionResultHolder<ItemStack> use(Level pLevel, Player pPlayer, InteractionHand pUsedHand) {
         var menu = type.menu();
-        if (pPlayer instanceof ServerPlayer serverPlayer && menu != null) {
+        if (pPlayer instanceof ServerPlayer serverPlayer && menu != null && pPlayer.isSteppingCarefully()) {
             openMenu(serverPlayer);
         }
         return super.use(pLevel, pPlayer, pUsedHand);
@@ -82,6 +87,25 @@ public class RedstoneFilterItem extends Item {
                 return type.menu().create(pContainerId, pInventory);
             }
         });
+    }
+
+    @Override
+    public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltipComponents, TooltipFlag tooltipFlag) {
+        super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
+        
+        // Create a filter instance to check if it's configured
+        RedstoneFilter filter = stack.getCapability(EnderIOCapabilities.REDSTONE_EXTRACT_FILTER, null);
+        if (filter == null) {
+            filter = stack.getCapability(EnderIOCapabilities.REDSTONE_INSERT_FILTER, null);
+        }
+
+        if (filter != null) {
+            if (filter.isConfigured()) {
+                tooltipComponents.add(FiltersLang.CONFIGURED);
+            } else if (type.menu() != null) {
+                tooltipComponents.add(FiltersLang.UNCONFIGURED_HINT);
+            }
+        }
     }
 
     public enum Type {

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneFilterItem.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneFilterItem.java
@@ -94,9 +94,9 @@ public class RedstoneFilterItem extends Item {
         super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
         
         // Create a filter instance to check if it's configured
-        RedstoneFilter filter = stack.getCapability(EnderIOCapabilities.REDSTONE_EXTRACT_FILTER, null);
+        RedstoneFilter filter = stack.getCapability(EnderIOCapabilities.REDSTONE_INSERT_FILTER, null);
         if (filter == null) {
-            filter = stack.getCapability(EnderIOCapabilities.REDSTONE_INSERT_FILTER, null);
+            filter = stack.getCapability(EnderIOCapabilities.REDSTONE_EXTRACT_FILTER, null);
         }
 
         if (filter != null) {

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneNOTFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneNOTFilter.java
@@ -24,4 +24,10 @@ public class RedstoneNOTFilter implements RedstoneOutputFilter, RedstoneInputFil
     public int getInputSignal(Level level, BlockPos pos, Direction direction) {
         return level.getSignal(pos, direction) == 0 ? 15 : 0;
     }
+
+    @Override
+    public boolean isConfigured() {
+        // NOT filter has no configuration
+        return false;
+    }
 }

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneSensorFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneSensorFilter.java
@@ -16,4 +16,10 @@ public class RedstoneSensorFilter implements RedstoneInputFilter {
     public int getInputSignal(Level level, BlockPos pos, Direction direction) {
         return level.getBlockState(pos).getAnalogOutputSignal(level, pos);
     }
+
+    @Override
+    public boolean isConfigured() {
+        // SENSOR filter has no configuration
+        return false;
+    }
 }

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneTLatchFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneTLatchFilter.java
@@ -47,6 +47,12 @@ public class RedstoneTLatchFilter implements RedstoneOutputFilter {
         stack.set(EIODataComponents.REDSTONE_TLATCH_FILTER, new Component(active, deactivated));
     }
 
+    @Override
+    public boolean isConfigured() {
+        // TLATCH filter has no user configuration - it maintains internal state
+        return false;
+    }
+
     public record Component(boolean active, boolean deactivated) {
         public static final Codec<Component> CODEC = RecordCodecBuilder.create(instance -> instance
                 .group(Codec.BOOL.fieldOf("deactivated").forGetter(Component::active),

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneTimerFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneTimerFilter.java
@@ -52,6 +52,12 @@ public class RedstoneTimerFilter implements RedstoneInputFilter {
         stack.set(EIODataComponents.REDSTONE_TIMER_FILTER, new Component(0, maxTicks));
     }
 
+    @Override
+    public boolean isConfigured() {
+        Component current = stack.get(EIODataComponents.REDSTONE_TIMER_FILTER);
+        return current != null && !current.equals(INSTANCE);
+    }
+
     public record Component(int ticks, int maxTicks) {
         public static final Codec<Component> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(ExtraCodecs.POSITIVE_INT.fieldOf("ticks").forGetter(r -> r.maxTicks),

--- a/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneXNORFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/redstone/RedstoneXNORFilter.java
@@ -17,5 +17,4 @@ public class RedstoneXNORFilter extends DoubleRedstoneChannel implements Redston
         boolean b = context.isActive(getFirstChannel()) ^ context.isActive(getSecondChannel());
         return b ? 0 : 15;
     }
-
 }


### PR DESCRIPTION
# Description

Adds a gray, italicized tooltip hint to unconfigured filters that instructs users to "Use while crouching to configure". This appears in place of the "Configured" tooltip, helping new users discover the configuration mechanism.

Applies to all filter types.

Closes #1067 

# Breaking Changes

Added #isConfigured method to redstone filter capabilities.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redstone filters now show whether they are configured or not in item tooltips.
  * Unconfigured filters display a grey italic guidance hint when a configuration UI is available.
  * Configuration can be accessed by crouching while interacting with a filter item.

* **Chores**
  * Several redstone filter types now expose their configuration state for consistent tooltip behaviour.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->