### PR TITLE
fix: BlockDetector not properly updating strong-powered neighbor

### DIFF
--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1171.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1171.java
@@ -1,0 +1,87 @@
+package com.enderio.enderio.gametests.regressions.issues;
+
+import com.enderio.enderio.gametests.util.EnderGameTestHelper;
+import com.enderio.enderio.init.EIOBlocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestAssertException;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RedstoneLampBlock;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
+
+/**
+ * Regression test for issue #1171 - BlockDetector doesn't update neighbors.
+ * https://github.com/Team-EnderIO/EnderIO/issues/1171
+ * 
+ * Test scenario:
+ * - BlockDetector faces a block to detect
+ * - A stone block is placed in front of the detector
+ * - A lamp is on the other side of the stone block and should turn off when the detector is active.
+ * - Bug: The lamp stays lit because the detector doesn't notify neighbors
+ */
+@ForEachTest(groups = "regression.issue1171")
+public class Issue1171 {
+    
+    @GameTest
+    @TestHolder(description = "Tests that BlockDetector properly updates neighbors when detected block changes")
+    public static void testBlockDetectorUpdatesNeighbors(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(4, 2, 1)
+            // Block to detect
+            .set(0, 0, 0, Blocks.STONE.defaultBlockState())
+            // BlockDetector facing west (toward the stone)
+            .set(1, 0, 0, EIOBlocks.BLOCK_DETECTOR.get().defaultBlockState()
+                .setValue(BlockStateProperties.FACING, Direction.WEST))
+            .set(2, 0, 0, Blocks.STONE.defaultBlockState())
+            // Redstone lamp connected to detector
+            .set(3, 0, 0, Blocks.REDSTONE_LAMP.defaultBlockState()));
+
+        test.onGameTest(EnderGameTestHelper.class, helper -> {
+            helper.startSequence()
+                // Ensure the detector and lamp are in the correct state
+                .thenExecute(() -> {
+                    // Verify detector is powered
+                    var detectorState = helper.getBlockState(new BlockPos(1, 1, 0));
+                    if (!detectorState.getValue(BlockStateProperties.POWERED)) {
+                        throw new GameTestAssertException(
+                            "BlockDetector should be powered when detecting a block");
+                    }
+                    
+                    // Verify lamp is lit
+                    var lampState = helper.getBlockState(new BlockPos(3, 1, 0));
+                    if (!lampState.getValue(RedstoneLampBlock.LIT)) {
+                        throw new GameTestAssertException(
+                            "Redstone lamp should be lit when BlockDetector is powered");
+                    }
+                })
+                // Remove the detected block
+                .thenExecute(() -> helper.setBlock(new BlockPos(0, 1, 0), Blocks.AIR))
+                // Ensure the detector stops detecting immediately
+                .thenExecute(() -> {
+                    // Verify detector is no longer powered
+                    var detectorState = helper.getBlockState(new BlockPos(1, 1, 0));
+                    if (detectorState.getValue(BlockStateProperties.POWERED)) {
+                        throw new GameTestAssertException(
+                            "BlockDetector should not be powered when block is removed");
+                    }
+                })
+                // Wait for the lamp to change (4 ticks delay in the redstone lamp block code)
+                .thenExecuteAfter(4, () -> {
+                    // This is the crux of the test - verify the lamp is now off
+                    var lampState = helper.getBlockState(new BlockPos(3, 1, 0));
+                    if (lampState.getValue(RedstoneLampBlock.LIT)) {
+                        throw new GameTestAssertException(
+                            "Redstone lamp should turn off when BlockDetector stops outputting power. " +
+                            "This indicates the BlockDetector is not properly notifying neighbors of state changes.");
+                    }
+                })
+                .thenSucceed();
+        });
+    }
+}

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1171.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1171.java
@@ -6,8 +6,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestAssertException;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RedstoneLampBlock;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/block_detector/BlockDetectorBlock.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/block_detector/BlockDetectorBlock.java
@@ -15,6 +15,8 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import org.jetbrains.annotations.Nullable;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 
 public class BlockDetectorBlock extends DirectionalBlock {
     public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
@@ -89,5 +91,22 @@ public class BlockDetectorBlock extends DirectionalBlock {
             level.blockUpdated(pos, state.getBlock());
         }
         return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
+    }
+
+    @Override
+    protected void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
+        super.neighborChanged(state, level, pos, neighborBlock, neighborPos, movedByPiston);
+
+        if (level.isClientSide) {
+            return;
+        }
+
+        if (state.getValue(POWERED) != level.hasNeighborSignal(pos)) {
+            level.setBlock(pos, state.cycle(POWERED), Block.UPDATE_CLIENTS);
+
+            for (Direction direction : Direction.values()) {
+                level.updateNeighborsAt(pos.relative(direction), this);
+            }
+        }
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/block_detector/BlockDetectorBlock.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/block_detector/BlockDetectorBlock.java
@@ -101,7 +101,9 @@ public class BlockDetectorBlock extends DirectionalBlock {
             return;
         }
 
-        if (state.getValue(POWERED) != level.hasNeighborSignal(pos)) {
+        BlockPos targetPos = pos.relative(state.getValue(FACING));
+        boolean shouldBePowered = !level.getBlockState(targetPos).isAir();
+        if (state.getValue(POWERED) != shouldBePowered) {
             level.setBlock(pos, state.cycle(POWERED), Block.UPDATE_CLIENTS);
 
             for (Direction direction : Direction.values()) {


### PR DESCRIPTION
# Description

Fixed behaviour of the block detector and added a regression test for this bug.

Closes #1171 

# Breaking Changes

None

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BlockDetector now correctly synchronises its powered state with neighbouring changes so connected devices and lamps receive accurate power updates.

* **Tests**
  * Added a regression test that verifies detector behaviour, lamp lighting/unlighting, and neighbour-notification timing after a detected block is removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->