### PR TITLE
Fix VAT input order

### DIFF
--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/common/recipes/FermentingRecipeProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/common/recipes/FermentingRecipeProvider.java
@@ -43,9 +43,9 @@ public class FermentingRecipeProvider extends SubRecipeProvider {
             EIOTags.Items.LIGHTNING_ROD, EIOTags.Items.WIND_CHARGES, 600, recipeOutput);
     }
 
-    protected void build(FluidStack output, SizedFluidIngredient input, TagKey<Item> leftReagent,
-            TagKey<Item> rightReagent, int ticks, RecipeOutput recipeOutput) {
+    protected void build(FluidStack output, SizedFluidIngredient input, TagKey<Item> firstReagent,
+            TagKey<Item> secondReagent, int ticks, RecipeOutput recipeOutput) {
         recipeOutput.accept(EnderIO.rl("fermenting/" + BuiltInRegistries.FLUID.getKey(output.getFluid()).getPath()),
-                new FermentingRecipe(input, leftReagent, rightReagent, output, ticks), null);
+                new FermentingRecipe(input, firstReagent, secondReagent, output, ticks), null);
     }
 }

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1211.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1211.java
@@ -1,0 +1,68 @@
+package com.enderio.enderio.gametests.regressions.issues;
+
+import com.enderio.enderio.content.machines.vat.VatBlockEntity;
+import com.enderio.enderio.gametests.util.EnderGameTestHelper;
+import com.enderio.enderio.init.EIOBlocks;
+import com.enderio.enderio.init.EIOFluids;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.fluids.FluidType;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
+
+/**
+ * Test for Issue #1211 - VAT should be input order independent
+ * https://github.com/Team-EnderIO/EnderIO/issues/1211
+ */
+@ForEachTest(groups = "regression.issue1211")
+public class Issue1211 {
+    @GameTest
+    @TestHolder(description = "Ensures that the VAT accepts reagents in any order.")
+    public static void testIssue1211NormalOrder(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(1, 1, 1)
+            .set(0, 0, 0, EIOBlocks.VAT.get().defaultBlockState()));
+
+        test.onGameTest(EnderGameTestHelper.class, helper -> {
+            helper.startSequence()
+                // Insert recipe for Cloud Seed (using test recipe) in the normal order.
+                .thenExecute(() -> {
+                    helper.fillContainer(0, 1, 0, Fluids.WATER, VatBlockEntity.TANK_CAPACITY);
+                    helper.insertIntoContainer(0, 1, 0, Items.DIRT, 1);
+                    helper.insertIntoContainer(0, 1, 0, Items.COBBLESTONE, 1);
+                })
+                // Wait for recipe to complete
+                .thenExecuteAfter(20, () -> {
+                    // Verify that cloud seed was produced
+                    long stored = helper.getAmountInHandler(0, 1, 0, EIOFluids.CLOUD_SEED.source().get());
+                    helper.assertValueEqual(stored, 1000L, "output fluid amount");
+                })
+                .thenSucceed();
+        });
+    }
+
+    @GameTest
+    @TestHolder(description = "Ensures that the VAT accepts reagents in reverse order.")
+    public static void testIssue1211ReversedOrder(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(1, 1, 1)
+            .set(0, 0, 0, EIOBlocks.VAT.get().defaultBlockState()));
+
+        test.onGameTest(EnderGameTestHelper.class, helper -> {
+            helper.startSequence()
+                // Insert recipe for Cloud Seed (using test recipe) in the opposite order.
+                .thenExecute(() -> {
+                    helper.fillContainer(0, 1, 0, Fluids.WATER, VatBlockEntity.TANK_CAPACITY);
+                    helper.insertIntoContainer(0, 1, 0, Items.COBBLESTONE, 1);
+                    helper.insertIntoContainer(0, 1, 0, Items.DIRT, 1);
+                })
+                .thenExecuteAfter(20, () -> {
+                    // Verify that cloud seed was produced
+                    long stored = helper.getAmountInHandler(0, 1, 0, EIOFluids.CLOUD_SEED.source().get());
+                    helper.assertValueEqual(stored, 1000L, "output fluid amount");
+                })
+                .thenSucceed();
+        });
+    }
+}

--- a/enderio/src/main/java/com/enderio/enderio/client/content/machines/gui/screen/VatScreen.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/machines/gui/screen/VatScreen.java
@@ -136,14 +136,14 @@ public class VatScreen extends MachineScreen<VatMenu> {
 
         // left modifier
         ItemStack item = getMenu().getSlot(0).getItem();
-        double modifier = FermentingRecipe.getModifier(item, recipe.value().leftReagent());
+        double modifier = FermentingRecipe.getModifier(item, recipe.value().firstReagent());
         String text = "x" + modifier;
         int x = getGuiLeft() + 63 - minecraft.font.width(text) / 2;
         guiGraphics.drawString(minecraft.font, text, x, getGuiTop() + 32, 4210752, false);
 
         // right modifier
         item = getMenu().getSlot(1).getItem();
-        modifier = FermentingRecipe.getModifier(item, recipe.value().rightReagent());
+        modifier = FermentingRecipe.getModifier(item, recipe.value().secondReagent());
         text = "x" + modifier;
         x = getGuiLeft() + 113 - minecraft.font.width(text) / 2;
         guiGraphics.drawString(minecraft.font, text, x, getGuiTop() + 32, 4210752, false);

--- a/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/category/VATCategory.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/category/VATCategory.java
@@ -63,14 +63,14 @@ public class VATCategory extends MachineRecipeCategory<RecipeHolder<FermentingRe
     public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<FermentingRecipe> recipe, IFocusGroup focuses) {
 
         builder.addSlot(RecipeIngredientRole.INPUT, 28, 2)
-                .addIngredients(Ingredient.of(recipe.value().leftReagent()))
+                .addIngredients(Ingredient.of(recipe.value().firstReagent()))
                 .addTooltipCallback((recipeSlotView, tooltip) -> tooltip.add(Component.literal("x"
-                        + getModifier(recipeSlotView.getDisplayedItemStack().get(), recipe.value().leftReagent()))));
+                        + getModifier(recipeSlotView.getDisplayedItemStack().get(), recipe.value().firstReagent()))));
 
         builder.addSlot(RecipeIngredientRole.INPUT, 77, 2)
-                .addIngredients(Ingredient.of(recipe.value().rightReagent()))
+                .addIngredients(Ingredient.of(recipe.value().secondReagent()))
                 .addTooltipCallback((recipeSlotView, tooltip) -> tooltip.add(Component.literal("x"
-                        + getModifier(recipeSlotView.getDisplayedItemStack().get(), recipe.value().rightReagent()))));
+                        + getModifier(recipeSlotView.getDisplayedItemStack().get(), recipe.value().secondReagent()))));
 
         for (var fluid : recipe.value().input().getFluids()) {
             builder.addSlot(RecipeIngredientRole.INPUT, 2, 2)
@@ -96,7 +96,7 @@ public class VATCategory extends MachineRecipeCategory<RecipeHolder<FermentingRe
             double mouseX, double mouseY) {
         // left modifier
         ItemStack item = recipeSlotsView.getSlotViews().get(0).getDisplayedItemStack().get();
-        double modifier = FermentingRecipe.getModifier(item, recipe.value().leftReagent());
+        double modifier = FermentingRecipe.getModifier(item, recipe.value().firstReagent());
         String text = "x" + modifier;
         Font font = Minecraft.getInstance().font;
         int x = 28 + 8 - font.width(text) / 2;
@@ -104,7 +104,7 @@ public class VATCategory extends MachineRecipeCategory<RecipeHolder<FermentingRe
 
         // right modifier
         item = recipeSlotsView.getSlotViews().get(1).getDisplayedItemStack().get();
-        modifier = FermentingRecipe.getModifier(item, recipe.value().rightReagent());
+        modifier = FermentingRecipe.getModifier(item, recipe.value().secondReagent());
         text = "x" + modifier;
         x = 77 + 8 - font.width(text) / 2;
         guiGraphics.drawString(font, text, x, 22, 4210752, false);

--- a/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/transfer/VATTransferHelper.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/transfer/VATTransferHelper.java
@@ -53,10 +53,10 @@ public class VATTransferHelper implements IRecipeTransferHandler<VatMenu, Recipe
         boolean maxTransfer, boolean doTransfer) {
 
         boolean hasFluid = recipe.value().input().ingredient().test(new FluidStack(container.getInputTank().contents().getFluid(), container.getInputTank().contents().getAmount()));
-        boolean hasLeft = container.slots.get(VatMenu.INPUTS_INDEX).getItem().is(recipe.value().leftReagent());
-        boolean hasRight = container.slots.get(VatMenu.INPUTS_INDEX + 1).getItem().is(recipe.value().rightReagent());
-        Ingredient left = getIngredientItem(player, Ingredient.of(recipe.value().leftReagent()));
-        Ingredient right = getIngredientItem(player, Ingredient.of(recipe.value().rightReagent()));
+        boolean hasLeft = container.slots.get(VatMenu.INPUTS_INDEX).getItem().is(recipe.value().firstReagent());
+        boolean hasRight = container.slots.get(VatMenu.INPUTS_INDEX + 1).getItem().is(recipe.value().secondReagent());
+        Ingredient left = getIngredientItem(player, Ingredient.of(recipe.value().firstReagent()));
+        Ingredient right = getIngredientItem(player, Ingredient.of(recipe.value().secondReagent()));
 
         if (!hasLeft || !hasRight || !hasFluid) {
             Component message = Component.translatable("jei.tooltip.error.recipe.transfer.missing");

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/vat/FermentingRecipe.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/vat/FermentingRecipe.java
@@ -28,7 +28,7 @@ import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import java.util.List;
 
-public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReagent, TagKey<Item> rightReagent,
+public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> firstReagent, TagKey<Item> secondReagent,
         FluidStack output, int ticks) implements MachineRecipe<FermentingRecipe.Input> {
 
     @Override
@@ -43,12 +43,12 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
 
         // Build modifier, ensure we use the correct item for each reagent
         double modifier;
-        if (firstInput.is(leftReagent) && secondInput.is(rightReagent)) {
-            modifier = getModifier(firstInput, leftReagent);
-            modifier *= getModifier(secondInput, rightReagent);
+        if (firstInput.is(firstReagent) && secondInput.is(secondReagent)) {
+            modifier = getModifier(firstInput, firstReagent);
+            modifier *= getModifier(secondInput, secondReagent);
         } else {
-            modifier = getModifier(secondInput, leftReagent);
-            modifier *= getModifier(firstInput, rightReagent);
+            modifier = getModifier(secondInput, firstReagent);
+            modifier *= getModifier(firstInput, secondReagent);
         }
 
         return List.of(OutputStack.of(new FluidStack(output.getFluid(), (int) (output.getAmount() * modifier))));
@@ -70,15 +70,15 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
         ItemStack secondInput = input.getItem(1);
 
         // Order independent check
-        return (firstInput.is(leftReagent) && secondInput.is(rightReagent)) ||
-            (firstInput.is(rightReagent) && secondInput.is(leftReagent));
+        return (firstInput.is(firstReagent) && secondInput.is(secondReagent)) ||
+            (firstInput.is(secondReagent) && secondInput.is(firstReagent));
     }
 
     @Override
     public NonNullList<Ingredient> getIngredients() {
         return NonNullList.of(Ingredient.EMPTY,
-            Ingredient.of(leftReagent),
-            Ingredient.of(rightReagent));
+            Ingredient.of(firstReagent),
+            Ingredient.of(secondReagent));
     }
 
     public static double getModifier(ItemStack stack, TagKey<Item> reagent) {
@@ -99,14 +99,14 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
         return EIORecipes.VAT_FERMENTING.type().get();
     }
 
-    public record Input(ItemStack leftReagent, ItemStack rightStack, FluidStack inputFluid)
+    public record Input(ItemStack firstReagent, ItemStack secondReagent, FluidStack inputFluid)
             implements RecipeInput {
 
         @Override
         public ItemStack getItem(int slotIndex) {
             return switch (slotIndex) {
-            case 0 -> leftReagent;
-            case 1 -> rightStack;
+            case 0 -> firstReagent;
+            case 1 -> secondReagent;
             default -> throw new IllegalArgumentException("No item for index " + slotIndex);
             };
         }
@@ -121,16 +121,17 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
         private static final StreamCodec<ByteBuf, TagKey<Item>> ITEM_TAG_STREAM_CODEC = ResourceLocation.STREAM_CODEC
                 .map(loc -> TagKey.create(Registries.ITEM, loc), TagKey::location);
 
+        // TODO: 1.21.11: Rename left and right to first and second
         public static final MapCodec<FermentingRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
                 SizedFluidIngredient.FLAT_CODEC.fieldOf("input").forGetter(FermentingRecipe::input),
-                TagKey.codec(Registries.ITEM).fieldOf("left_reagent").forGetter(FermentingRecipe::leftReagent),
-                TagKey.codec(Registries.ITEM).fieldOf("right_reagent").forGetter(FermentingRecipe::rightReagent),
+                TagKey.codec(Registries.ITEM).fieldOf("left_reagent").forGetter(FermentingRecipe::firstReagent),
+                TagKey.codec(Registries.ITEM).fieldOf("right_reagent").forGetter(FermentingRecipe::secondReagent),
                 FluidStack.CODEC.fieldOf("output").forGetter(FermentingRecipe::output),
                 Codec.INT.fieldOf("ticks").forGetter(FermentingRecipe::ticks)).apply(instance, FermentingRecipe::new));
 
         public static final StreamCodec<RegistryFriendlyByteBuf, FermentingRecipe> STREAM_CODEC = StreamCodec.composite(
                 SizedFluidIngredient.STREAM_CODEC, FermentingRecipe::input, ITEM_TAG_STREAM_CODEC,
-                FermentingRecipe::leftReagent, ITEM_TAG_STREAM_CODEC, FermentingRecipe::rightReagent,
+                FermentingRecipe::firstReagent, ITEM_TAG_STREAM_CODEC, FermentingRecipe::secondReagent,
                 FluidStack.STREAM_CODEC, FermentingRecipe::output, ByteBufCodecs.INT, FermentingRecipe::ticks,
                 FermentingRecipe::new);
 

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/vat/FermentingRecipe.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/vat/FermentingRecipe.java
@@ -8,6 +8,7 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.core.NonNullList;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -17,6 +18,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeInput;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -36,9 +38,18 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
 
     @Override
     public List<OutputStack> craft(Input input, RegistryAccess registryAccess) {
+        ItemStack firstInput = input.getItem(0);
+        ItemStack secondInput = input.getItem(1);
 
-        double modifier = getModifier(input.getItem(0), leftReagent);
-        modifier *= getModifier(input.getItem(1), rightReagent);
+        // Build modifier, ensure we use the correct item for each reagent
+        double modifier;
+        if (firstInput.is(leftReagent) && secondInput.is(rightReagent)) {
+            modifier = getModifier(firstInput, leftReagent);
+            modifier *= getModifier(secondInput, rightReagent);
+        } else {
+            modifier = getModifier(secondInput, leftReagent);
+            modifier *= getModifier(firstInput, rightReagent);
+        }
 
         return List.of(OutputStack.of(new FluidStack(output.getFluid(), (int) (output.getAmount() * modifier))));
     }
@@ -55,7 +66,19 @@ public record FermentingRecipe(SizedFluidIngredient input, TagKey<Item> leftReag
             return false;
         }
 
-        return input.getItem(0).is(leftReagent) && input.getItem(1).is(rightReagent);
+        ItemStack firstInput = input.getItem(0);
+        ItemStack secondInput = input.getItem(1);
+
+        // Order independent check
+        return (firstInput.is(leftReagent) && secondInput.is(rightReagent)) ||
+            (firstInput.is(rightReagent) && secondInput.is(leftReagent));
+    }
+
+    @Override
+    public NonNullList<Ingredient> getIngredients() {
+        return NonNullList.of(Ingredient.EMPTY,
+            Ingredient.of(leftReagent),
+            Ingredient.of(rightReagent));
     }
 
     public static double getModifier(ItemStack stack, TagKey<Item> reagent) {

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/vat/VatBlockEntity.java
@@ -9,6 +9,7 @@ import com.enderio.enderio.foundation.block.entity.MachineBlockEntity;
 import com.enderio.enderio.foundation.inventory.MachineInventory;
 import com.enderio.enderio.foundation.inventory.MachineInventoryLayout;
 import com.enderio.enderio.foundation.inventory.MultiSlotAccess;
+import com.enderio.enderio.foundation.recipe.MachineRecipeCaches;
 import com.enderio.enderio.foundation.io.fluid.FluidItemInteractive;
 import com.enderio.enderio.foundation.io.fluid.MachineFluidHandler;
 import com.enderio.enderio.foundation.io.fluid.MachineFluidTank;
@@ -95,7 +96,14 @@ public class VatBlockEntity extends MachineBlockEntity implements FluidTankUser,
 
     @Override
     public @Nullable MachineInventoryLayout createInventoryLayout() {
-        return MachineInventoryLayout.builder().inputSlot(2).slotAccess(REAGENTS).build();
+        return MachineInventoryLayout.builder()
+            .inputSlot(2, this::acceptSlotInput)
+            .slotAccess(REAGENTS)
+            .build();
+    }
+
+    protected boolean acceptSlotInput(int slot, ItemStack stack) {
+        return MachineRecipeCaches.FERMENTING.hasValidRecipeIf(getInventory(), REAGENTS, slot, stack);
     }
 
     @Override


### PR DESCRIPTION
# Description

The VAT is intended to allow inputs to be in any order.

Also implemented getIngredients() so that RecipeInputCache could be used by the VAT.

Closes #1211 

# TODO

- [x] Consider renaming left + right
- [x] Make VAT use RecipeInputCache for slot filtering

# Breaking Changes

Any recipes that depended on this broken behaviour may now have conflicts.

I am also tempted to change the names of left and right to be first and second.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - VAT fermenting recipe now accepts both reagents in any order, improving recipe flexibility and usability.

* **Bug Fixes**
  - Enhanced input validation for VAT fermenting input slots to ensure recipe validity.

* **Tests**
  - Added comprehensive regression tests to verify VAT reagent order independence functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->