### PR TITLE
fix: Add check for nearby players to powered spawner

### DIFF
--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/client/EIOLanguageProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/client/EIOLanguageProvider.java
@@ -390,6 +390,7 @@ public class EIOLanguageProvider extends LanguageProvider {
         add(MachinesLang.POWERED_SPAWNER_STATUS_OTHER_MOD, "Blocked by another mod");
         add(MachinesLang.POWERED_SPAWNER_STATUS_DISABLED, "Disabled by config");
         add(MachinesLang.POWERED_SPAWNER_STATUS_UNKNOWN_MOB, "Unknown mob");
+        add(MachinesLang.POWERED_SPAWNER_STATUS_NO_PLAYER, "No nearby player");
 
         add(MachinesLang.PHOTOVOLTAIC_CELL, "Solar Power!");
         add(MachinesLang.PHOTOVOLTAIC_CELL_ADVANCED, "Produces Power during daylight hours");

--- a/enderio/src/generated/resources/assets/enderio/lang/en_us.json
+++ b/enderio/src/generated/resources/assets/enderio/lang/en_us.json
@@ -332,6 +332,7 @@
   "gui.enderio.machine.obelisk.upkeep_cost": "Upkeep %sµI/t",
   "gui.enderio.machine.powered_spawner.mode": "Spawner Mode",
   "gui.enderio.machine.powered_spawner.status.disabled": "Disabled by config",
+  "gui.enderio.machine.powered_spawner.status.no_player": "No nearby player",
   "gui.enderio.machine.powered_spawner.status.other_mod": "Blocked by another mod",
   "gui.enderio.machine.powered_spawner.status.overcrowded.mobs": "Too many mobs",
   "gui.enderio.machine.powered_spawner.status.overcrowded.spawners": "Too many spawners",

--- a/enderio/src/main/java/com/enderio/enderio/config/machines/common/MachinesCommonConfig.java
+++ b/enderio/src/main/java/com/enderio/enderio/config/machines/common/MachinesCommonConfig.java
@@ -13,6 +13,7 @@ public class MachinesCommonConfig {
     public final ModConfigSpec.ConfigValue<Integer> DEFAULT_SPAWN_ENERGY_COST;
     public final ModConfigSpec.ConfigValue<MobSpawnMode> SPAWN_TYPE;
     public final ModConfigSpec.IntValue SPAWN_AMOUNT;
+    public final ModConfigSpec.ConfigValue<Integer> REQUIRED_PLAYER_RANGE;
     public final ModConfigSpec.ConfigValue<Integer> ATTRACTOR_RANGE;
     public final ModConfigSpec.ConfigValue<Boolean> ATTRACTOR_PULL_BOSSES;
     public final ModConfigSpec.ConfigValue<Integer> INHIBITOR_RANGE;
@@ -48,6 +49,10 @@ public class MachinesCommonConfig {
         DEFAULT_SPAWN_ENERGY_COST = builder
                 .comment("The amount of energy used to spawn mobs that do not have custom spawner soul data.")
                 .defineInRange("defaultSpawnEnergyCost", 50000, 0, Integer.MAX_VALUE);
+        // Defaults to standard spawner range. Intended as a fix for GH-1213.
+        REQUIRED_PLAYER_RANGE = builder
+                .comment("The range in blocks a player must be within for the spawner to be active.")
+                .defineInRange("requiredPlayerRange", 16, 16, 512);
         builder.pop();
 
         builder.push("enderface");

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/MachinesLang.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/MachinesLang.java
@@ -86,6 +86,7 @@ public class MachinesLang {
     public static final MutableComponent POWERED_SPAWNER_STATUS_OTHER_MOD = gui("powered_spawner/status/other_mod");
     public static final MutableComponent POWERED_SPAWNER_STATUS_DISABLED = gui("powered_spawner/status/disabled");
     public static final MutableComponent POWERED_SPAWNER_STATUS_UNKNOWN_MOB = gui("powered_spawner/status/unknown_mob");
+    public static final MutableComponent POWERED_SPAWNER_STATUS_NO_PLAYER = gui("powered_spawner/status/no_player");
 
     // endregion
 

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/powered_spawner/PoweredSpawnerBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/powered_spawner/PoweredSpawnerBlockEntity.java
@@ -189,7 +189,7 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity impleme
             worldPosition.getY() + 0.5,
             worldPosition.getZ() + 0.5,
             requiredRange,
-            false // Don't include spectators
+            true // allow creative mode players
         );
         
         return nearestPlayer != null;

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/powered_spawner/PoweredSpawnerBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/powered_spawner/PoweredSpawnerBlockEntity.java
@@ -125,8 +125,8 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity impleme
             return null;
         }
 
-        // Ensure output is free in capture mode
         if (mode == PoweredSpawnerMode.CAPTURE) {
+            // Ensure output is free in capture mode
             if (!INPUT.getItemStack(this).is(EIOItems.SOUL_VIAL)) {
                 setReason(SpawnerBlockedReason.INPUT_EMPTY);
                 return null;
@@ -139,6 +139,12 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity impleme
                     setReason(SpawnerBlockedReason.OUTPUT_FULL);
                     return null;
                 }
+            }
+        } else if (mode == PoweredSpawnerMode.SPAWN) {
+            // Ensure there are players nearby if we're in spawning mode.
+            if (!areAnyPlayersInRange()) {
+                setReason(SpawnerBlockedReason.NO_NEARBY_PLAYER);
+                return null;
             }
         }
 
@@ -167,6 +173,26 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity impleme
 
     public int getRange() {
         return ACTION_RANGE;
+    }
+
+    private boolean areAnyPlayersInRange() {
+        if (level == null) {
+            return false;
+        }
+
+        // Get the required player range from config
+        int requiredRange = MachinesConfig.COMMON.REQUIRED_PLAYER_RANGE.get();
+
+        // Check if any player is within the configured range
+        Player nearestPlayer = level.getNearestPlayer(
+            worldPosition.getX() + 0.5,
+            worldPosition.getY() + 0.5,
+            worldPosition.getZ() + 0.5,
+            requiredRange,
+            false // Don't include spectators
+        );
+        
+        return nearestPlayer != null;
     }
 
     public boolean isRangeVisible() {
@@ -425,7 +451,9 @@ public class PoweredSpawnerBlockEntity extends PoweredMachineBlockEntity impleme
         UNKNOWN_MOB(MachinesLang.POWERED_SPAWNER_STATUS_UNKNOWN_MOB),
         OTHER_MOD(MachinesLang.POWERED_SPAWNER_STATUS_OTHER_MOD),
         DISABLED(MachinesLang.POWERED_SPAWNER_STATUS_DISABLED),
-        INPUT_EMPTY(MachinesLang.STATUS_INPUT_EMPTY), OUTPUT_FULL(MachinesLang.STATUS_OUTPUT_FULL),
+        INPUT_EMPTY(MachinesLang.STATUS_INPUT_EMPTY),
+        OUTPUT_FULL(MachinesLang.STATUS_OUTPUT_FULL),
+        NO_NEARBY_PLAYER(MachinesLang.POWERED_SPAWNER_STATUS_NO_PLAYER),
         NONE(Component.literal("NONE"));
 
         private final MutableComponent component;


### PR DESCRIPTION
# Description

Adds a check to make sure players are nearby the powered spawner (if in spawner mode).

Defaults to 16 blocks (vanilla spawner default) - we could discuss this default and increase it out of the box (honestly, perhaps 24 blocks is good?)

Made it configurable to be sure that modpacks can tune it if needed.

# Breaking Changes

Spawners will no longer fire without a player nearby. I think that's reasonable given that the spawned mobs will not currently exist when a player isn't in range - however if we rule that the powered spawner *should* work without players nearby and there's a reasonable way to do so - I'm all ears.

CC @ferriarnus and @dphaldes to discuss the last point.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
