### PR TITLE
feat: Add config for ME conduit idle energy consumption rates

### DIFF
--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/ModdedConduits.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/ModdedConduits.java
@@ -6,15 +6,18 @@ import com.enderio.modded_conduits.common.modules.ConduitCommonModule;
 import com.enderio.modded_conduits.common.modules.appeng.AE2ConduitsModule;
 import com.enderio.modded_conduits.common.modules.mekanism.MekanismModule;
 import com.enderio.modded_conduits.common.modules.refinedstorage.RefinedStorageCommonModule;
+import com.enderio.modded_conduits.config.ModdedConduitsConfig;
 import com.enderio.modded_conduits.data.ModConduitRecipeProvider;
 import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceKey;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 
@@ -40,8 +43,12 @@ public class ModdedConduits {
 
     public static IEventBus modEventBus;
 
-    public ModdedConduits(IEventBus modEventBus) {
+    public ModdedConduits(IEventBus modEventBus, ModContainer modContainer) {
         ModdedConduits.modEventBus = modEventBus;
+        
+        // Register config files
+        modContainer.registerConfig(ModConfig.Type.COMMON, ModdedConduitsConfig.COMMON_SPEC, "enderio/modded-conduits-common.toml");
+        
         executeOnLoadedModules(module -> module.initialize(modEventBus));
     }
 

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/appeng/MEConduit.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/appeng/MEConduit.java
@@ -13,6 +13,7 @@ import com.enderio.enderio.api.conduits.network.node.ConduitNode;
 import com.enderio.enderio.api.conduits.ticker.ConduitTicker;
 import com.enderio.enderio.api.io.RedstoneControl;
 import com.enderio.enderio.content.conduits.ConduitBlockItem;
+import com.enderio.modded_conduits.config.ModdedConduitsConfig;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -127,7 +128,9 @@ public record MEConduit(ResourceLocation texture, Component description, AEColor
                 .setTagName("conduit")
                 .setGridColor(color);
 
-        mainNode.setIdlePowerUsage(isDense() ? 0.4d : 0.1d);
+        mainNode.setIdlePowerUsage(isDense() 
+            ? ModdedConduitsConfig.COMMON.AE2.DENSE_ME_POWER_USAGE_PER_TICK.get()
+            : ModdedConduitsConfig.COMMON.AE2.NORMAL_ME_POWER_USAGE_PER_TICK.get());
 
         if (isDense()) {
             mainNode.setFlags(GridFlags.DENSE_CAPACITY);

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/ModdedConduitsConfig.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/ModdedConduitsConfig.java
@@ -1,0 +1,16 @@
+package com.enderio.modded_conduits.config;
+
+import com.enderio.modded_conduits.config.common.ModdedConduitsCommonConfig;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class ModdedConduitsConfig {
+    public static final ModdedConduitsCommonConfig COMMON;
+    public static final ModConfigSpec COMMON_SPEC;
+
+    static {
+        Pair<ModdedConduitsCommonConfig, ModConfigSpec> commonSpecPair = new ModConfigSpec.Builder().configure(ModdedConduitsCommonConfig::new);
+        COMMON = commonSpecPair.getLeft();
+        COMMON_SPEC = commonSpecPair.getRight();
+    }
+}

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/common/AE2Config.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/common/AE2Config.java
@@ -1,0 +1,22 @@
+package com.enderio.modded_conduits.config.common;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public class AE2Config {
+    public final ModConfigSpec.DoubleValue NORMAL_ME_POWER_USAGE_PER_TICK;
+    public final ModConfigSpec.DoubleValue DENSE_ME_POWER_USAGE_PER_TICK;
+
+    public AE2Config(ModConfigSpec.Builder builder) {
+        builder.push("ae2");
+
+        NORMAL_ME_POWER_USAGE_PER_TICK = builder
+            .comment("Idle power usage per tick for normal (non dense) ME conduits (AE)")
+            .defineInRange("normalPowerUsagePerTick", 0.1d, 0.0d, Double.MAX_VALUE);
+
+        DENSE_ME_POWER_USAGE_PER_TICK = builder
+            .comment("Idle power usage per tick for dense ME conduits (AE)")
+            .defineInRange("densePowerUsagePerTick", 0.4d, 0.0d, Double.MAX_VALUE);
+
+        builder.pop();
+    }
+}

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/common/AE2Config.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/common/AE2Config.java
@@ -11,11 +11,11 @@ public class AE2Config {
 
         NORMAL_ME_POWER_USAGE_PER_TICK = builder
             .comment("Idle power usage per tick for normal (non dense) ME conduits (AE)")
-            .defineInRange("normalPowerUsagePerTick", 0.1d, 0.0d, Double.MAX_VALUE);
+            .defineInRange("normalPowerUsagePerTick", 0, 0, Double.MAX_VALUE);
 
         DENSE_ME_POWER_USAGE_PER_TICK = builder
             .comment("Idle power usage per tick for dense ME conduits (AE)")
-            .defineInRange("densePowerUsagePerTick", 0.4d, 0.0d, Double.MAX_VALUE);
+            .defineInRange("densePowerUsagePerTick", 0, 0, Double.MAX_VALUE);
 
         builder.pop();
     }

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/common/ModdedConduitsCommonConfig.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/config/common/ModdedConduitsCommonConfig.java
@@ -1,0 +1,11 @@
+package com.enderio.modded_conduits.config.common;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public class ModdedConduitsCommonConfig {
+    public final AE2Config AE2;
+
+    public ModdedConduitsCommonConfig(ModConfigSpec.Builder builder) {
+        AE2 = new AE2Config(builder);
+    }
+}


### PR DESCRIPTION
# Description

Adds configs for normal and dense ME conduit energy consumption so that they can be configured to be enabled or disabled.

Also removes the power draw by default to offset the negatives when using ME conduits (Lack of integration with AE's 'parts' system for example)

Closes #1194

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applied Energistics 2 ME Conduits now support configurable power consumption rates for both normal and dense variants, allowing customisation via configuration files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->