### PR TITLE
feat(!): Support tags in tank recipes.

### DIFF
--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/common/recipes/TankRecipeProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/common/recipes/TankRecipeProvider.java
@@ -13,63 +13,63 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.material.Fluids;
-import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 public class TankRecipeProvider extends SubRecipeProvider {
 
     @Override
     public void buildRecipes(RecipeOutput recipeOutput, HolderLookup.Provider registries) {
         buildEmptying(Ingredient.of(Items.EXPERIENCE_BOTTLE), Items.GLASS_BOTTLE,
-                new FluidStack(EIOFluids.XP_JUICE.source().get(), 250), recipeOutput);
+                SizedFluidIngredient.of(EIOFluids.XP_JUICE.source().get(), 250), recipeOutput);
         buildFilling(Ingredient.of(Items.GLASS_BOTTLE), Items.EXPERIENCE_BOTTLE,
-                new FluidStack(EIOFluids.XP_JUICE.source().get(), 250), recipeOutput);
+                SizedFluidIngredient.of(EIOFluids.XP_JUICE.source().get(), 250), recipeOutput);
 
-        buildEmptying(Ingredient.of(Items.WET_SPONGE), Items.SPONGE, new FluidStack(Fluids.WATER, 1000), recipeOutput);
-        buildFilling(Ingredient.of(Items.SPONGE), Items.WET_SPONGE, new FluidStack(Fluids.WATER, 1000), recipeOutput);
+        buildEmptying(Ingredient.of(Items.WET_SPONGE), Items.SPONGE, SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
+        buildFilling(Ingredient.of(Items.SPONGE), Items.WET_SPONGE, SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
 
         buildFilling(Ingredient.of(Items.STICK), EIOItems.NUTRITIOUS_STICK,
-                new FluidStack(EIOFluids.NUTRIENT_DISTILLATION.source().get(), 1000), recipeOutput);
+                SizedFluidIngredient.of(EIOFluids.NUTRIENT_DISTILLATION.source().get(), 1000), recipeOutput);
 
         buildFilling(Ingredient.of(Items.WHITE_CONCRETE_POWDER), Items.WHITE_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
         buildFilling(Ingredient.of(Items.ORANGE_CONCRETE_POWDER), Items.ORANGE_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
         buildFilling(Ingredient.of(Items.MAGENTA_CONCRETE_POWDER), Items.MAGENTA_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
         buildFilling(Ingredient.of(Items.LIGHT_BLUE_CONCRETE_POWDER), Items.LIGHT_BLUE_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
         buildFilling(Ingredient.of(Items.YELLOW_CONCRETE_POWDER), Items.YELLOW_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
-        buildFilling(Ingredient.of(Items.LIME_CONCRETE_POWDER), Items.LIME_CONCRETE, new FluidStack(Fluids.WATER, 1000),
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
+        buildFilling(Ingredient.of(Items.LIME_CONCRETE_POWDER), Items.LIME_CONCRETE, SizedFluidIngredient.of(Fluids.WATER, 1000),
                 recipeOutput);
-        buildFilling(Ingredient.of(Items.PINK_CONCRETE_POWDER), Items.PINK_CONCRETE, new FluidStack(Fluids.WATER, 1000),
+        buildFilling(Ingredient.of(Items.PINK_CONCRETE_POWDER), Items.PINK_CONCRETE, SizedFluidIngredient.of(Fluids.WATER, 1000),
                 recipeOutput);
-        buildFilling(Ingredient.of(Items.GRAY_CONCRETE_POWDER), Items.GRAY_CONCRETE, new FluidStack(Fluids.WATER, 1000),
+        buildFilling(Ingredient.of(Items.GRAY_CONCRETE_POWDER), Items.GRAY_CONCRETE, SizedFluidIngredient.of(Fluids.WATER, 1000),
                 recipeOutput);
         buildFilling(Ingredient.of(Items.LIGHT_GRAY_CONCRETE_POWDER), Items.LIGHT_GRAY_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
-        buildFilling(Ingredient.of(Items.CYAN_CONCRETE_POWDER), Items.CYAN_CONCRETE, new FluidStack(Fluids.WATER, 1000),
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
+        buildFilling(Ingredient.of(Items.CYAN_CONCRETE_POWDER), Items.CYAN_CONCRETE, SizedFluidIngredient.of(Fluids.WATER, 1000),
                 recipeOutput);
         buildFilling(Ingredient.of(Items.PURPLE_CONCRETE_POWDER), Items.PURPLE_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
-        buildFilling(Ingredient.of(Items.BLUE_CONCRETE_POWDER), Items.BLUE_CONCRETE, new FluidStack(Fluids.WATER, 1000),
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
+        buildFilling(Ingredient.of(Items.BLUE_CONCRETE_POWDER), Items.BLUE_CONCRETE, SizedFluidIngredient.of(Fluids.WATER, 1000),
                 recipeOutput);
         buildFilling(Ingredient.of(Items.BROWN_CONCRETE_POWDER), Items.BROWN_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
         buildFilling(Ingredient.of(Items.GREEN_CONCRETE_POWDER), Items.GREEN_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
-        buildFilling(Ingredient.of(Items.RED_CONCRETE_POWDER), Items.RED_CONCRETE, new FluidStack(Fluids.WATER, 1000),
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
+        buildFilling(Ingredient.of(Items.RED_CONCRETE_POWDER), Items.RED_CONCRETE, SizedFluidIngredient.of(Fluids.WATER, 1000),
                 recipeOutput);
         buildFilling(Ingredient.of(Items.BLACK_CONCRETE_POWDER), Items.BLACK_CONCRETE,
-                new FluidStack(Fluids.WATER, 1000), recipeOutput);
+                SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
     }
 
-    protected void buildEmptying(Ingredient input, ItemLike output, FluidStack fluid, RecipeOutput recipeOutput) {
+    protected void buildEmptying(Ingredient input, ItemLike output, SizedFluidIngredient fluid, RecipeOutput recipeOutput) {
         recipeOutput.accept(EnderIO.rl("tank_empty/" + BuiltInRegistries.ITEM.getKey(output.asItem()).getPath()),
                 new TankRecipe(input, new ItemStack(output), fluid, TankRecipe.Mode.EMPTY), null);
     }
 
-    protected void buildFilling(Ingredient input, ItemLike output, FluidStack fluid, RecipeOutput recipeOutput) {
+    protected void buildFilling(Ingredient input, ItemLike output, SizedFluidIngredient fluid, RecipeOutput recipeOutput) {
         recipeOutput.accept(EnderIO.rl("tank_fill/" + BuiltInRegistries.ITEM.getKey(output.asItem()).getPath()),
                 new TankRecipe(input, new ItemStack(output), fluid, TankRecipe.Mode.FILL), null);
     }

--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/common/recipes/TankRecipeProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/common/recipes/TankRecipeProvider.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 public class TankRecipeProvider extends SubRecipeProvider {
@@ -20,9 +21,9 @@ public class TankRecipeProvider extends SubRecipeProvider {
     @Override
     public void buildRecipes(RecipeOutput recipeOutput, HolderLookup.Provider registries) {
         buildEmptying(Ingredient.of(Items.EXPERIENCE_BOTTLE), Items.GLASS_BOTTLE,
-                SizedFluidIngredient.of(EIOFluids.XP_JUICE.source().get(), 250), recipeOutput);
+                SizedFluidIngredient.of(Tags.Fluids.EXPERIENCE, 250), recipeOutput);
         buildFilling(Ingredient.of(Items.GLASS_BOTTLE), Items.EXPERIENCE_BOTTLE,
-                SizedFluidIngredient.of(EIOFluids.XP_JUICE.source().get(), 250), recipeOutput);
+                SizedFluidIngredient.of(Tags.Fluids.EXPERIENCE, 250), recipeOutput);
 
         buildEmptying(Ingredient.of(Items.WET_SPONGE), Items.SPONGE, SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);
         buildFilling(Ingredient.of(Items.SPONGE), Items.WET_SPONGE, SizedFluidIngredient.of(Fluids.WATER, 1000), recipeOutput);

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_empty/glass_bottle.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_empty/glass_bottle.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 250,
-    "fluid": "enderio:fluid_xp_juice_still"
+    "tag": "c:experience"
   },
   "input": {
     "item": "minecraft:experience_bottle"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_empty/glass_bottle.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_empty/glass_bottle.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 250,
-    "id": "enderio:fluid_xp_juice_still"
+    "fluid": "enderio:fluid_xp_juice_still"
   },
   "input": {
     "item": "minecraft:experience_bottle"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_empty/sponge.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_empty/sponge.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:wet_sponge"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/black_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/black_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:black_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/blue_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/blue_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:blue_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/brown_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/brown_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:brown_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/cyan_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/cyan_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:cyan_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/experience_bottle.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/experience_bottle.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 250,
-    "id": "enderio:fluid_xp_juice_still"
+    "fluid": "enderio:fluid_xp_juice_still"
   },
   "input": {
     "item": "minecraft:glass_bottle"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/experience_bottle.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/experience_bottle.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 250,
-    "fluid": "enderio:fluid_xp_juice_still"
+    "tag": "c:experience"
   },
   "input": {
     "item": "minecraft:glass_bottle"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/gray_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/gray_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:gray_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/green_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/green_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:green_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/light_blue_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/light_blue_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:light_blue_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/light_gray_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/light_gray_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:light_gray_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/lime_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/lime_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:lime_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/magenta_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/magenta_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:magenta_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/nutritious_stick.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/nutritious_stick.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "enderio:fluid_nutrient_distillation_still"
+    "fluid": "enderio:fluid_nutrient_distillation_still"
   },
   "input": {
     "item": "minecraft:stick"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/orange_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/orange_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:orange_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/pink_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/pink_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:pink_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/purple_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/purple_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:purple_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/red_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/red_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:red_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/wet_sponge.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/wet_sponge.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:sponge"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/white_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/white_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:white_concrete_powder"

--- a/enderio/src/generated/resources/data/enderio/recipe/tank_fill/yellow_concrete.json
+++ b/enderio/src/generated/resources/data/enderio/recipe/tank_fill/yellow_concrete.json
@@ -2,7 +2,7 @@
   "type": "enderio:tank",
   "fluid": {
     "amount": 1000,
-    "id": "minecraft:water"
+    "fluid": "minecraft:water"
   },
   "input": {
     "item": "minecraft:yellow_concrete_powder"

--- a/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/category/TankCategory.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/category/TankCategory.java
@@ -18,7 +18,9 @@ import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeHolder;
+import net.neoforged.neoforge.fluids.FluidStack;
 
+import java.util.Arrays;
 import java.util.List;
 
 // TODO: 1.20.1+ Add a custom TankRecipe for JEI to show mending and maybe fill/empty too.
@@ -62,16 +64,24 @@ public class TankCategory implements IRecipeCategory<RecipeHolder<TankRecipe>> {
 
             builder.addSlot(RecipeIngredientRole.OUTPUT, 3, 34).addItemStack(recipe.value().output().copy());
 
+            // Convert SizedFluidIngredient to FluidStack list for JEI display
+            List<FluidStack> fluidStacks = Arrays.asList(recipe.value().fluid().getFluids());
             builder.addSlot(RecipeIngredientRole.OUTPUT, 39, 3)
-                    .addIngredients(NeoForgeTypes.FLUID_STACK, List.of(recipe.value().fluid()))
+                    .addIngredients(NeoForgeTypes.FLUID_STACK, fluidStacks)
                     .setFluidRenderer(FluidTankBlockEntity.Standard.CAPACITY, false, 16, 47);
         } else if (recipe.value().mode() == TankRecipe.Mode.FILL) {
             builder.addSlot(RecipeIngredientRole.INPUT, 75, 3).addIngredients(recipe.value().input());
 
             builder.addSlot(RecipeIngredientRole.OUTPUT, 75, 34).addItemStack(recipe.value().output().copy());
 
+            // Convert SizedFluidIngredient to FluidStack list for JEI display
+            FluidStack[] fluidStacks = recipe.value().fluid().getFluids();
+            List<FluidStack> fluidList = new java.util.ArrayList<>();
+            for (FluidStack stack : fluidStacks) {
+                fluidList.add(stack.copyWithAmount((int) recipe.value().fluid().amount()));
+            }
             builder.addSlot(RecipeIngredientRole.INPUT, 39, 3)
-                    .addIngredients(NeoForgeTypes.FLUID_STACK, List.of(recipe.value().fluid()))
+                    .addIngredients(NeoForgeTypes.FLUID_STACK, fluidList)
                     .setFluidRenderer(FluidTankBlockEntity.Standard.CAPACITY, false, 16, 47);
         }
     }

--- a/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/category/TankCategory.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/category/TankCategory.java
@@ -6,6 +6,7 @@ import com.enderio.enderio.compat.jei.JEILang;
 import com.enderio.enderio.compat.jei.JEIUtils;
 import com.enderio.enderio.content.storage.fluid_tank.FluidTankBlockEntity;
 import com.enderio.enderio.content.storage.fluid_tank.TankRecipe;
+import com.enderio.enderio.foundation.util.SizedFluidIngredientHelper;
 import com.enderio.enderio.init.EIOBlocks;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -58,6 +59,7 @@ public class TankCategory implements IRecipeCategory<RecipeHolder<TankRecipe>> {
 
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<TankRecipe> recipe, IFocusGroup focuses) {
+        List<FluidStack> fluidStacks = SizedFluidIngredientHelper.getFluidStacksInPreferredOrder(recipe.value().fluid());
 
         if (recipe.value().mode() == TankRecipe.Mode.EMPTY) {
             builder.addSlot(RecipeIngredientRole.INPUT, 3, 3).addIngredients(recipe.value().input());
@@ -65,7 +67,6 @@ public class TankCategory implements IRecipeCategory<RecipeHolder<TankRecipe>> {
             builder.addSlot(RecipeIngredientRole.OUTPUT, 3, 34).addItemStack(recipe.value().output().copy());
 
             // Convert SizedFluidIngredient to FluidStack list for JEI display
-            List<FluidStack> fluidStacks = Arrays.asList(recipe.value().fluid().getFluids());
             builder.addSlot(RecipeIngredientRole.OUTPUT, 39, 3)
                     .addIngredients(NeoForgeTypes.FLUID_STACK, fluidStacks)
                     .setFluidRenderer(FluidTankBlockEntity.Standard.CAPACITY, false, 16, 47);
@@ -75,13 +76,8 @@ public class TankCategory implements IRecipeCategory<RecipeHolder<TankRecipe>> {
             builder.addSlot(RecipeIngredientRole.OUTPUT, 75, 34).addItemStack(recipe.value().output().copy());
 
             // Convert SizedFluidIngredient to FluidStack list for JEI display
-            FluidStack[] fluidStacks = recipe.value().fluid().getFluids();
-            List<FluidStack> fluidList = new java.util.ArrayList<>();
-            for (FluidStack stack : fluidStacks) {
-                fluidList.add(stack.copyWithAmount((int) recipe.value().fluid().amount()));
-            }
             builder.addSlot(RecipeIngredientRole.INPUT, 39, 3)
-                    .addIngredients(NeoForgeTypes.FLUID_STACK, fluidList)
+                    .addIngredients(NeoForgeTypes.FLUID_STACK, fluidStacks)
                     .setFluidRenderer(FluidTankBlockEntity.Standard.CAPACITY, false, 16, 47);
         }
     }

--- a/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/transfer/FluidTankTransferHelper.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jei_machines_to_merge/transfer/FluidTankTransferHelper.java
@@ -53,7 +53,8 @@ public class FluidTankTransferHelper implements IRecipeTransferHandler<FluidTank
 
         boolean hasFluid = true;
         if (recipe.value().mode() == TankRecipe.Mode.FILL) {
-            hasFluid = recipe.value().fluid().getFluid().isSame(container.getFluidTank().contents().getFluid()) && recipe.value().fluid().getAmount() <= container.getFluidTank().contents().getAmount();
+            // Check if the tank contains a fluid that matches the ingredient
+            hasFluid = recipe.value().fluid().test(container.getFluidTank().contents());
         }
 
         boolean hasItem = recipe.value().input().test(container.slots.get(0).getItem());

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
@@ -239,12 +239,21 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
                 if (outputStack.isEmpty() || (outputStack.is(recipeResultStack.getItem())
                         && outputStack.getCount() < outputStack.getMaxStackSize())) {
 
-                    int filled = TANK.fill(this, recipe.value().fluid(), IFluidHandler.FluidAction.SIMULATE);
-                    if (filled != recipe.value().fluid().getAmount()) {
+                    // Get the first matching fluid from the ingredient (for EMPTY mode, we're adding fluid to tank)
+                    FluidStack fluidToFill = FluidStack.EMPTY;
+                    for (FluidStack fluidToTry : recipe.value().fluid().getFluids()) {
+                        int filled = TANK.fill(this, fluidToTry, IFluidHandler.FluidAction.SIMULATE);
+                        if (filled == recipe.value().fluid().amount()) {
+                            fluidToFill = fluidToTry;
+                            break;
+                        }
+                    }
+
+                    if (fluidToFill.isEmpty()) {
                         return;
                     }
 
-                    TANK.fill(this, recipe.value().fluid(), IFluidHandler.FluidAction.EXECUTE);
+                    TANK.fill(this, fluidToFill, IFluidHandler.FluidAction.EXECUTE);
                     FLUID_FILL_INPUT.getItemStack(this).shrink(1);
 
                     if (outputStack.isEmpty()) {
@@ -260,12 +269,13 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
                 if (outputStack.isEmpty() || (outputStack.is(recipeResultStack.getItem())
                         && outputStack.getCount() < outputStack.getMaxStackSize())) {
 
-                    var drained = TANK.drain(this, recipe.value().fluid(), IFluidHandler.FluidAction.SIMULATE);
-                    if (drained.getAmount() != recipe.value().fluid().getAmount()) {
+                    // For FILL mode, we drain from tank - need to check what's actually in the tank
+                    var drained = TANK.drain(this, (int) recipe.value().fluid().amount(), IFluidHandler.FluidAction.SIMULATE);
+                    if (!recipe.value().fluid().test(drained) || drained.getAmount() != recipe.value().fluid().amount()) {
                         return;
                     }
 
-                    TANK.drain(this, recipe.value().fluid(), IFluidHandler.FluidAction.EXECUTE);
+                    TANK.drain(this, (int) recipe.value().fluid().amount(), IFluidHandler.FluidAction.EXECUTE);
                     FLUID_DRAIN_INPUT.getItemStack(this).shrink(1);
 
                     if (outputStack.isEmpty()) {

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
@@ -10,6 +10,7 @@ import com.enderio.enderio.foundation.io.fluid.MachineFluidTank;
 import com.enderio.enderio.foundation.io.fluid.MachineTankLayout;
 import com.enderio.enderio.foundation.io.fluid.TankAccess;
 import com.enderio.enderio.foundation.state.MachineState;
+import com.enderio.enderio.foundation.util.SizedFluidIngredientHelper;
 import com.enderio.enderio.init.EIOBlockEntities;
 import com.enderio.enderio.init.EIODataComponents;
 import com.enderio.enderio.init.EIORecipes;
@@ -240,8 +241,9 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
                         && outputStack.getCount() < outputStack.getMaxStackSize())) {
 
                     // Get the first matching fluid from the ingredient (for EMPTY mode, we're adding fluid to tank)
+                    List<FluidStack> possibleFluids = SizedFluidIngredientHelper.getFluidStacksInPreferredOrder(recipe.value().fluid());
                     FluidStack fluidToFill = FluidStack.EMPTY;
-                    for (FluidStack fluidToTry : recipe.value().fluid().getFluids()) {
+                    for (FluidStack fluidToTry : possibleFluids) {
                         int filled = TANK.fill(this, fluidToTry, IFluidHandler.FluidAction.SIMULATE);
                         if (filled == recipe.value().fluid().amount()) {
                             fluidToFill = fluidToTry;

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/TankRecipe.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/TankRecipe.java
@@ -1,8 +1,10 @@
 package com.enderio.enderio.content.storage.fluid_tank;
 
 import com.enderio.enderio.foundation.io.fluid.MachineFluidTank;
+import com.enderio.enderio.init.EIOConduitTypes;
 import com.enderio.enderio.init.EIORecipes;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.ByteBuf;
@@ -21,11 +23,12 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.function.IntFunction;
 
-public record TankRecipe(Ingredient input, ItemStack output, FluidStack fluid, Mode mode)
+public record TankRecipe(Ingredient input, ItemStack output, SizedFluidIngredient fluid, Mode mode)
         implements Recipe<TankRecipe.Input> {
 
     public enum Mode implements StringRepresentable {
@@ -52,20 +55,35 @@ public record TankRecipe(Ingredient input, ItemStack output, FluidStack fluid, M
 
     @Override
     public boolean matches(Input recipeInput, Level level) {
+        // If we have no input -or- output fluid, no matches allowed.
+        FluidStack[] possibleFluids = fluid.getFluids();
+        if (possibleFluids.length == 0) {
+            return false;
+        }
+
         switch (mode) {
         case FILL -> {
-            if (recipeInput.fluidTank().drain(fluid, IFluidHandler.FluidAction.SIMULATE).isEmpty()) {
+            FluidStack drainSimulation = recipeInput.fluidTank().drain(fluid.amount(), IFluidHandler.FluidAction.SIMULATE);
+            if (!fluid.test(drainSimulation) || drainSimulation.getAmount() < fluid.amount()) {
                 return false;
             }
 
             return input.test(recipeInput.fillItem);
         }
         case EMPTY -> {
-            if (recipeInput.fluidTank().fill(fluid, IFluidHandler.FluidAction.SIMULATE) <= 0) {
+            if (!input.test(recipeInput.emptyItem)) {
                 return false;
             }
 
-            return input.test(recipeInput.emptyItem);
+            for (FluidStack testFluid : possibleFluids) {
+                FluidStack testFill = testFluid.copyWithAmount(fluid.amount());
+                if (recipeInput.fluidTank().fill(testFill, IFluidHandler.FluidAction.SIMULATE) == fluid.amount()) {
+                    // We can fill this fluid type into the tank.
+                    return true;
+                }
+            }
+
+            return false;
         }
         default -> throw new NotImplementedException();
         }
@@ -121,16 +139,16 @@ public record TankRecipe(Ingredient input, ItemStack output, FluidStack fluid, M
     public static class Serializer implements RecipeSerializer<TankRecipe> {
 
         private static final MapCodec<TankRecipe> CODEC = RecordCodecBuilder
-                .mapCodec(instance -> instance
-                        .group(Ingredient.CODEC_NONEMPTY.fieldOf("input").forGetter(TankRecipe::input),
-                                ItemStack.CODEC.fieldOf("output").forGetter(TankRecipe::output),
-                                FluidStack.CODEC.fieldOf("fluid").forGetter(TankRecipe::fluid),
-                                Mode.CODEC.fieldOf("mode").forGetter(TankRecipe::mode))
-                        .apply(instance, TankRecipe::new));
+            .mapCodec(instance -> instance
+                    .group(Ingredient.CODEC_NONEMPTY.fieldOf("input").forGetter(TankRecipe::input),
+                            ItemStack.CODEC.fieldOf("output").forGetter(TankRecipe::output),
+                            SizedFluidIngredient.FLAT_CODEC.fieldOf("fluid").forGetter(TankRecipe::fluid),
+                            Mode.CODEC.fieldOf("mode").forGetter(TankRecipe::mode))
+                    .apply(instance, TankRecipe::new));
 
         public static final StreamCodec<RegistryFriendlyByteBuf, TankRecipe> STREAM_CODEC = StreamCodec.composite(
                 Ingredient.CONTENTS_STREAM_CODEC, TankRecipe::input, ItemStack.STREAM_CODEC, TankRecipe::output,
-                FluidStack.STREAM_CODEC, TankRecipe::fluid, Mode.STREAM_CODEC, TankRecipe::mode, TankRecipe::new);
+                SizedFluidIngredient.STREAM_CODEC, TankRecipe::fluid, Mode.STREAM_CODEC, TankRecipe::mode, TankRecipe::new);
 
         @Override
         public MapCodec<TankRecipe> codec() {

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/TankRecipe.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/TankRecipe.java
@@ -1,6 +1,7 @@
 package com.enderio.enderio.content.storage.fluid_tank;
 
 import com.enderio.enderio.foundation.io.fluid.MachineFluidTank;
+import com.enderio.enderio.foundation.util.SizedFluidIngredientHelper;
 import com.enderio.enderio.init.EIOConduitTypes;
 import com.enderio.enderio.init.EIORecipes;
 import com.mojang.serialization.Codec;
@@ -26,6 +27,7 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 import org.apache.commons.lang3.NotImplementedException;
 
+import java.util.List;
 import java.util.function.IntFunction;
 
 public record TankRecipe(Ingredient input, ItemStack output, SizedFluidIngredient fluid, Mode mode)
@@ -56,8 +58,8 @@ public record TankRecipe(Ingredient input, ItemStack output, SizedFluidIngredien
     @Override
     public boolean matches(Input recipeInput, Level level) {
         // If we have no input -or- output fluid, no matches allowed.
-        FluidStack[] possibleFluids = fluid.getFluids();
-        if (possibleFluids.length == 0) {
+        List<FluidStack> possibleFluids = SizedFluidIngredientHelper.getFluidStacksInPreferredOrder(fluid);
+        if (possibleFluids.isEmpty()) {
             return false;
         }
 

--- a/enderio/src/main/java/com/enderio/enderio/foundation/util/SizedFluidIngredientHelper.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/util/SizedFluidIngredientHelper.java
@@ -1,0 +1,40 @@
+package com.enderio.enderio.foundation.util;
+
+import com.enderio.enderio.EnderIO;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper utilities for working with SizedFluidIngredient.
+ * Provides ordering and conversion methods that prefer EnderIO fluids over others.
+ */
+public class SizedFluidIngredientHelper {
+    
+    /**
+     * Gets all possible fluid stacks from the ingredient in preferred order.
+     * EnderIO fluids are prioritized first, then other mod fluids.
+     * The returned stacks maintain their original amounts.
+     * 
+     * @param ingredient The sized fluid ingredient
+     * @return List of fluid stacks in preferred order
+     */
+    public static List<FluidStack> getFluidStacksInPreferredOrder(SizedFluidIngredient ingredient) {
+        FluidStack[] stacks = ingredient.getFluids();
+        List<FluidStack> preferred = new ArrayList<>(stacks.length);
+        List<FluidStack> others = new ArrayList<>(stacks.length);
+        
+        for (FluidStack stack : stacks) {
+            if (stack.getFluid().builtInRegistryHolder().getKey().location().getNamespace().equals(EnderIO.MOD_ID)) {
+                preferred.add(stack);
+            } else {
+                others.add(stack);
+            }
+        }
+
+        preferred.addAll(others);
+        return preferred;
+    }
+}


### PR DESCRIPTION
# Description

Use SizedFluidIngredient for tank recipes to allow using tags for recipes.

Closes: GH-902

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [x] Update any of our recipes to use tags.

# Breaking Changes

BREAKING CHANGE: Will break compatibility with existing recipes

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked tank recipes and fluid ingredient handling for more consistent fill/empty behaviour.

* **Bug Fixes**
  * Improved fluid matching and transfer logic to avoid incorrect consumes or failed transfers when multiple fluids are possible.

* **New Features**
  * Recipe viewer now shows fluid variants in preferred order for clearer display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->