### PR TITLE
feat: Remove energy throttling and evenly distribute energy

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/api/io/energy/EnergyIOMode.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/io/energy/EnergyIOMode.java
@@ -1,6 +1,7 @@
 package com.enderio.enderio.api.io.energy;
 
 import com.enderio.enderio.api.io.IOConfigurable;
+import com.enderio.enderio.api.io.IOMode;
 
 /**
  * Energy IO Mode declares how Energy IO is determined using IO configs.
@@ -47,5 +48,29 @@ public enum EnergyIOMode {
     // TODO: Clarify - IOConfig canConnect has precedence over this.
     public boolean respectIOConfig() {
         return respectIOConfig;
+    }
+
+    public boolean canPush(IOMode ioMode) {
+        if (!canOutput()) {
+            return false;
+        }
+
+        if (respectIOConfig) {
+            return ioMode.canPush();
+        }
+
+        return true;
+    }
+
+    public boolean canPull(IOMode ioMode) {
+        if (!canInput()) {
+            return false;
+        }
+
+        if (respectIOConfig) {
+            return ioMode.canPull();
+        }
+
+        return true;
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/api/io/energy/EnergyIOMode.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/io/energy/EnergyIOMode.java
@@ -55,6 +55,10 @@ public enum EnergyIOMode {
             return false;
         }
 
+        if (!ioMode.canConnect()) {
+            return false;
+        }
+
         if (respectIOConfig) {
             return ioMode.canPush();
         }
@@ -64,6 +68,10 @@ public enum EnergyIOMode {
 
     public boolean canPull(IOMode ioMode) {
         if (!canInput()) {
+            return false;
+        }
+
+        if (!ioMode.canConnect()) {
             return false;
         }
 

--- a/enderio/src/main/java/com/enderio/enderio/config/machines/common/EnergyConfig.java
+++ b/enderio/src/main/java/com/enderio/enderio/config/machines/common/EnergyConfig.java
@@ -3,8 +3,6 @@ package com.enderio.enderio.config.machines.common;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 public class EnergyConfig {
-    public final ModConfigSpec.BooleanValue THROTTLE_ENERGY_INPUT;
-
     public final ModConfigSpec.ConfigValue<Integer> ALLOY_SMELTER_CAPACITY;
     public final ModConfigSpec.ConfigValue<Integer> ALLOY_SMELTER_USAGE;
     public final ModConfigSpec.ConfigValue<Integer> ALLOY_SMELTER_VANILLA_ITEM_ENERGY;
@@ -60,10 +58,6 @@ public class EnergyConfig {
 
     public EnergyConfig(ModConfigSpec.Builder builder) {
         builder.push("energy");
-
-        THROTTLE_ENERGY_INPUT = builder
-                .comment("Whether or not the machine should throttle energy input to 2x it's consumption rate")
-                .define("throttleEnergyUsage", true);
 
         builder.push("alloySmelter");
         ALLOY_SMELTER_CAPACITY = builder.comment("The base energy capacity in uI.")

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/type/energy/EnergyConduitTicker.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/type/energy/EnergyConduitTicker.java
@@ -3,6 +3,7 @@ package com.enderio.enderio.content.conduits.type.energy;
 import com.enderio.enderio.api.conduits.network.ConduitNetwork;
 import com.enderio.enderio.api.conduits.ticker.ConduitTicker;
 import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
 import it.unimi.dsi.fastutil.Pair;
 import net.minecraft.server.level.ServerLevel;
 import net.neoforged.neoforge.capabilities.Capabilities;
@@ -77,14 +78,14 @@ public class EnergyConduitTicker implements ConduitTicker<EnergyConduit> {
         int toShareWith = insertHandlers.size();
         for (var handler : insertHandlers) {
             // If we have too little energy left, just give it to the first handler that will accept it all
-            int energyInserted;
+            int shareAmount;
             if (energyRemaining < toShareWith) {
-                // If we're smaller than an int, we can just cast.
-                energyInserted = handler.left().receiveEnergy((int)energyRemaining, false);
+                shareAmount = Ints.saturatedCast(energyRemaining);
             } else {
-                // Don't insert more than INT_MAX :)
-                energyInserted = handler.left().receiveEnergy((int)Math.min(energyRemaining / toShareWith, Integer.MAX_VALUE), false);
+                shareAmount = Ints.saturatedCast(energyRemaining / toShareWith);
             }
+
+            int energyInserted = handler.left().receiveEnergy(shareAmount, false);
 
             // One less to share with now.
             toShareWith--;

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/type/energy/EnergyConduitTicker.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/type/energy/EnergyConduitTicker.java
@@ -9,6 +9,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 
+import java.util.Comparator;
 import java.util.List;
 
 public class EnergyConduitTicker implements ConduitTicker<EnergyConduit> {
@@ -72,7 +73,7 @@ public class EnergyConduitTicker implements ConduitTicker<EnergyConduit> {
 
     private long distributeTo(List<Pair<IEnergyStorage, Integer>> insertHandlers, long availableEnergy) {
         // Try to fill smaller buffers first.
-        insertHandlers.sort((a, b) -> Integer.compare(b.right(), a.right()));
+        insertHandlers.sort(Comparator.comparingInt(Pair::right));
 
         long energyRemaining = availableEnergy;
         int toShareWith = insertHandlers.size();

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/MachineBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/MachineBlockEntity.java
@@ -341,7 +341,7 @@ public abstract class MachineBlockEntity extends EIOBlockEntity
     }
 
     @UseOnly(LogicalSide.SERVER)
-    protected final void distributeResources() {
+    protected void distributeResources() {
         // TODO: Quick way to see if any sides are set to force.
 
         for (Direction side : Direction.values()) {

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/PoweredMachineBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/PoweredMachineBlockEntity.java
@@ -4,12 +4,14 @@ import com.enderio.enderio.api.EnderIOCapabilities;
 import com.enderio.enderio.api.UseOnly;
 import com.enderio.enderio.api.capacitor.CapacitorData;
 import com.enderio.enderio.api.capacitor.CapacitorScalable;
+import com.enderio.enderio.api.io.IOMode;
 import com.enderio.enderio.api.io.energy.EnergyIOMode;
 import com.enderio.enderio.content.capacitors.CapacitorItem;
 import com.enderio.enderio.foundation.MachineNBTKeys;
 import com.enderio.enderio.foundation.block.entity.flags.CapacitorSupport;
 import com.enderio.enderio.foundation.energy.PoweredMachineEnergyStorage;
 import com.enderio.enderio.foundation.inventory.MachineInventory;
+import com.enderio.enderio.foundation.io.TransferUtil;
 import com.enderio.enderio.foundation.state.MachineState;
 import com.enderio.enderio.init.EIODataComponents;
 import net.minecraft.core.BlockPos;
@@ -136,26 +138,11 @@ public abstract class PoweredMachineBlockEntity extends MachineBlockEntity imple
     }
 
     @Override
-    protected void distributeResources(Direction side) {
-        super.distributeResources(side);
+    protected void distributeResources() {
+        super.distributeResources();
 
-        if (energyIOMode.canOutput() && getIOMode(side).canPush()) {
-            distributeEnergy(side);
-        }
-    }
-
-    private void distributeEnergy(Direction side) {
-        // Get the other energy handler
-        IEnergyStorage otherHandler = getNeighbouringCapability(Capabilities.EnergyStorage.BLOCK, side);
-        if (otherHandler == null) {
-            return;
-        }
-
-        // If the other handler can receive power transmit ours
-        if (otherHandler.canReceive()) {
-            int energyToReceive = energyStorage.extractEnergy(Integer.MAX_VALUE, true);
-            int received = otherHandler.receiveEnergy(energyToReceive, false);
-            energyStorage.extractEnergy(received, false);
+        if (energyIOMode.canOutput()) {
+            TransferUtil.distributeEnergyEvenly(level, worldPosition, dir -> energyIOMode.canPush(getIOMode(dir)));
         }
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/legacy/LegacyPoweredMachineBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/legacy/LegacyPoweredMachineBlockEntity.java
@@ -12,6 +12,7 @@ import com.enderio.enderio.foundation.block.entity.legacy.sync.EnergySyncData;
 import com.enderio.enderio.foundation.block.legacy.LegacyProgressMachineBlock;
 import com.enderio.enderio.foundation.inventory.MachineInventory;
 import com.enderio.enderio.foundation.inventory.MachineInventoryLayout;
+import com.enderio.enderio.foundation.io.TransferUtil;
 import com.enderio.enderio.foundation.io.energy.IMachineEnergyStorage;
 import com.enderio.enderio.foundation.io.energy.ImmutableMachineEnergyStorage;
 import com.enderio.enderio.foundation.io.energy.MachineEnergyStorage;
@@ -185,28 +186,8 @@ public abstract class LegacyPoweredMachineBlockEntity extends LegacyMachineBlock
             return;
         }
 
-        // Transmit power out all sides.
-        for (Direction side : Direction.values()) {
-            if (!shouldPushEnergyTo(side)) {
-                continue;
-            }
-
-            var selfHandler = getSelfCapability(Capabilities.EnergyStorage.BLOCK, side);
-            if (selfHandler == null) {
-                continue;
-            }
-
-            // Get the other energy handler
-            IEnergyStorage otherHandler = getNeighbouringCapability(Capabilities.EnergyStorage.BLOCK, side);
-            if (otherHandler != null) {
-                // If the other handler can receive power transmit ours
-                if (otherHandler.canReceive()) {
-                    int energyToReceive = selfHandler.extractEnergy(selfHandler.getEnergyStored(), true);
-                    int received = otherHandler.receiveEnergy(energyToReceive, false);
-                    selfHandler.extractEnergy(received, false);
-                }
-            }
-        }
+        EnergyIOMode energyIOMode = getExposedEnergyStorage().getIOMode();
+        TransferUtil.distributeEnergyEvenly(level, worldPosition, dir -> energyIOMode.canPush(getIOMode(dir)));
     }
 
     /**

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/legacy/LegacyPoweredMachineBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/legacy/LegacyPoweredMachineBlockEntity.java
@@ -187,7 +187,7 @@ public abstract class LegacyPoweredMachineBlockEntity extends LegacyMachineBlock
         }
 
         EnergyIOMode energyIOMode = getExposedEnergyStorage().getIOMode();
-        TransferUtil.distributeEnergyEvenly(level, worldPosition, dir -> energyIOMode.canPush(getIOMode(dir)));
+        TransferUtil.distributeEnergyEvenly(level, worldPosition, dir -> energyIOMode.canPush(getIOMode(dir)) && shouldPushEnergyTo(dir));
     }
 
     /**

--- a/enderio/src/main/java/com/enderio/enderio/foundation/energy/PoweredMachineEnergyStorage.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/energy/PoweredMachineEnergyStorage.java
@@ -115,10 +115,6 @@ public class PoweredMachineEnergyStorage implements IEnergyStorage, INBTSerializ
             return 0;
         }
 
-        if (MachinesConfig.COMMON.ENERGY.THROTTLE_ENERGY_INPUT.get()) {
-            maxReceive = Math.min(machine.getMaxEnergyUse() * 2, maxReceive);
-        }
-
         int energyReceived = Mth.clamp(getMaxEnergyStored() - energyStored, 0, maxReceive);
         if (!simulate) {
             setEnergyStored(energyStored + energyReceived);

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
@@ -1,11 +1,20 @@
 package com.enderio.enderio.foundation.io;
 
 import com.enderio.enderio.api.io.IOMode;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.energy.IEnergyStorage;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidUtil;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.items.IItemHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 public class TransferUtil {
 
@@ -85,6 +94,75 @@ public class TransferUtil {
                 } else {
                     FluidUtil.tryFluidTransfer(selfItemHandler, otherItemHandler, new FluidStack(selfItemHandler.getFluidInTank(i).getFluid(), maxDrain), true);
                 }
+            }
+        }
+    }
+
+    // endregion
+
+    // region Even Distribution
+
+    // Helper record for energy distribution
+    private record EnergyStoragePair(IEnergyStorage self, IEnergyStorage receiver) {}
+
+    /**
+     * Distributes energy evenly to all neighboring blocks that can receive it.
+     * Queries capabilities per-side for both source and receivers.
+     *
+     * @apiNote Assumes that the source block has a single energy buffer shared across all sides. If this is not the case, do not use this.
+     * @param level The level
+     * @param pos The position of the source block
+     * @param canPushTo Function to check if energy can be pushed to a given direction
+     */
+    public static void distributeEnergyEvenly(Level level, BlockPos pos, Function<Direction, Boolean> canPushTo) {
+        // Collect all valid receivers and senders per side
+        List<EnergyStoragePair> transfers = new ArrayList<>();
+        
+        for (Direction direction : Direction.values()) {
+            if (!canPushTo.apply(direction)) {
+                continue;
+            }
+
+            // Get self capability for this side
+            IEnergyStorage selfHandler = level.getCapability(Capabilities.EnergyStorage.BLOCK, pos, direction);
+            if (selfHandler == null || !selfHandler.canExtract()) {
+                continue;
+            }
+
+            // Get neighbor capability
+            IEnergyStorage otherHandler = level.getCapability(Capabilities.EnergyStorage.BLOCK, pos.relative(direction), direction.getOpposite());
+            if (otherHandler != null && otherHandler.canReceive()) {
+                transfers.add(new EnergyStoragePair(selfHandler, otherHandler));
+            }
+        }
+
+        // Abort if we have no valid pairs
+        if (transfers.isEmpty()) {
+            return;
+        }
+
+        // Use first available self handler to check total available energy
+        // all of the 'self' handlers should be the same buffer.
+        int availableEnergy = transfers.getFirst().self.extractEnergy(Integer.MAX_VALUE, true);
+        if (availableEnergy <= 0) {
+            return;
+        }
+
+        // Distribute evenly using the same algorithm as energy conduits
+        int energyRemaining = availableEnergy;
+        int toShareWith = transfers.size();
+        
+        for (EnergyStoragePair transfer : transfers) {
+            int shareAmount = energyRemaining / toShareWith;
+            int inserted = transfer.receiver.receiveEnergy(shareAmount, false);
+            if (inserted > 0) {
+                transfer.self.extractEnergy(inserted, false);
+                energyRemaining -= inserted;
+            }
+            
+            toShareWith--;
+            if (energyRemaining <= 0) {
+                break;
             }
         }
     }

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
@@ -153,7 +153,14 @@ public class TransferUtil {
         int toShareWith = transfers.size();
         
         for (EnergyStoragePair transfer : transfers) {
-            int shareAmount = energyRemaining / toShareWith;
+            // If we have too little energy left, just give it to the first handler that will accept it all
+            int shareAmount;
+            if (energyRemaining <= toShareWith) {
+                shareAmount = energyRemaining;
+            } else {
+                shareAmount = energyRemaining / toShareWith;
+            }
+
             int inserted = transfer.receiver.receiveEnergy(shareAmount, false);
             if (inserted > 0) {
                 transfer.self.extractEnergy(inserted, false);

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
@@ -131,7 +131,7 @@ public class TransferUtil {
 
             // Get neighbor capability
             IEnergyStorage otherHandler = level.getCapability(Capabilities.EnergyStorage.BLOCK, pos.relative(direction), direction.getOpposite());
-            if (otherHandler != null && otherHandler.canReceive()) {
+            if (otherHandler != null && otherHandler != selfHandler && otherHandler.canReceive()) {
                 transfers.add(new EnergyStoragePair(selfHandler, otherHandler));
             }
         }

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/energy/MachineEnergyStorage.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/energy/MachineEnergyStorage.java
@@ -122,14 +122,7 @@ public class MachineEnergyStorage implements IMachineEnergyStorage, INBTSerializ
             return 0;
         }
 
-        int maximumEnergyToReceive;
-        if (MachinesConfig.COMMON.ENERGY.THROTTLE_ENERGY_INPUT.get()) {
-            maximumEnergyToReceive = Math.min(getMaxEnergyUse() * 2, maxReceive);
-        } else {
-            maximumEnergyToReceive = maxReceive;
-        }
-
-        int energyReceived = Math.min(getMaxEnergyStored() - getEnergyStored(), maximumEnergyToReceive);
+        int energyReceived = Math.min(getMaxEnergyStored() - getEnergyStored(), maxReceive);
         if (!simulate) {
             addEnergy(energyReceived);
         }


### PR DESCRIPTION
# Description

Removes energy throttling for energy inputs and makes machines that output energy do so evenly.

Closes #1225 

# Breaking Changes

Generator blocks will now always output energy by default, something that used to be the case but broke when we started to rewrite machines. This is now the desired behaviour.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Removed the energy input throttling option, simplifying machine energy behaviour.

* **New Features**
  * Added a reusable utility to distribute energy evenly across multiple sides.
  * Exposed per-side push/pull checks for energy I/O modes.

* **Improvements**
  * Centralised and standardised side-agnostic energy distribution across machines.
  * Made resource distribution overridable to allow customised machine behaviour.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->