### PR TITLE
Fix soul filter not iterating

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/filters/soul/EnderSoulFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/soul/EnderSoulFilter.java
@@ -60,8 +60,6 @@ public record EnderSoulFilter(NonNullList<Soul> matches, boolean isDenyList, boo
             if (match.hasEntity()) {
                 if (shouldCompareTags ? Soul.isSameEntitySameTag(match, entity) : Soul.isSameEntity(match, entity)) {
                     return !isDenyList;
-                } else {
-                    return isDenyList;
                 }
             }
         }
@@ -80,8 +78,6 @@ public record EnderSoulFilter(NonNullList<Soul> matches, boolean isDenyList, boo
             if (!match.isEmpty()) {
                 if (shouldCompareTags ? Soul.isSameEntitySameTag(match, soul) : Soul.isSameEntity(match, soul)) {
                     return !isDenyList;
-                } else {
-                    return isDenyList;
                 }
             }
         }
@@ -93,7 +89,9 @@ public record EnderSoulFilter(NonNullList<Soul> matches, boolean isDenyList, boo
     public boolean test(EntityType<?> entityType) {
         for (var match : matches) {
             if (!match.isEmpty()) {
-                return !isDenyList && Soul.isSameEntity(match, entityType);
+                if (Soul.isSameEntity(match, entityType)) {
+                   return !isDenyList;
+                }
             }
         }
 

--- a/enderio/src/test/java/com/enderio/enderio/tests/filters/EnderSoulFilterTests.java
+++ b/enderio/src/test/java/com/enderio/enderio/tests/filters/EnderSoulFilterTests.java
@@ -11,18 +11,20 @@ import org.junit.jupiter.api.Test;
 public class EnderSoulFilterTests {
     @Test
     public void testBasicAllowFilter() {
-        var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, Soul.of(EntityType.ALLAY)), false, false);
+        var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, Soul.of(EntityType.ALLAY), Soul.of(EntityType.SKELETON)), false, false);
 
         Assertions.assertTrue(filter.test(Soul.of(EntityType.ALLAY)));
+        Assertions.assertTrue(filter.test(Soul.of(EntityType.SKELETON)));
         Assertions.assertFalse(filter.test(Soul.of(EntityType.COD)));
         Assertions.assertFalse(filter.test(Soul.of(EntityType.SHEEP)));
     }
 
     @Test
     public void testBasicDenyFilter() {
-        var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, Soul.of(EntityType.ALLAY)), true, false);
+        var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, Soul.of(EntityType.ALLAY), Soul.of(EntityType.SKELETON)), true, false);
 
         Assertions.assertFalse(filter.test(Soul.of(EntityType.ALLAY)));
+        Assertions.assertFalse(filter.test(Soul.of(EntityType.SKELETON)));
         Assertions.assertTrue(filter.test(Soul.of(EntityType.COD)));
         Assertions.assertTrue(filter.test(Soul.of(EntityType.SHEEP)));
     }
@@ -32,12 +34,32 @@ public class EnderSoulFilterTests {
         CompoundTag tag = new CompoundTag();
         tag.putInt("Health", 20);
         var soulWithHealth = new Soul(EntityType.ALLAY, tag);
+        var anotherSoulWithHealth = new Soul(EntityType.SKELETON, tag);
 
-        var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, soulWithHealth), false, true);
+        var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, soulWithHealth, anotherSoulWithHealth), false, true);
 
         Assertions.assertTrue(filter.test(soulWithHealth));
         Assertions.assertFalse(filter.test(Soul.of(EntityType.ALLAY)));
+        Assertions.assertTrue(filter.test(anotherSoulWithHealth));
+        Assertions.assertFalse(filter.test(Soul.of(EntityType.SKELETON)));
         Assertions.assertFalse(filter.test(Soul.of(EntityType.COD)));
         Assertions.assertFalse(filter.test(Soul.of(EntityType.SHEEP)));
+    }
+
+    @Test
+    public void testBasicDenyFilterWithComponentComparison() {
+        CompoundTag tag = new CompoundTag();
+        tag.putInt("Health", 20);
+        var soulWithHealth = new Soul(EntityType.ALLAY, tag);
+        var anotherSoulWithHealth = new Soul(EntityType.SKELETON, tag);
+
+        var filter = new EnderSoulFilter(NonNullList.of(Soul.EMPTY, soulWithHealth, anotherSoulWithHealth), true, true);
+
+        Assertions.assertFalse(filter.test(soulWithHealth));
+        Assertions.assertTrue(filter.test(Soul.of(EntityType.ALLAY)));
+        Assertions.assertFalse(filter.test(anotherSoulWithHealth));
+        Assertions.assertTrue(filter.test(Soul.of(EntityType.SKELETON)));
+        Assertions.assertTrue(filter.test(Soul.of(EntityType.COD)));
+        Assertions.assertTrue(filter.test(Soul.of(EntityType.SHEEP)));
     }
 }


### PR DESCRIPTION
The soul filter shouldn't exit the loop after the first element in it's list. Also updated the unit tests to include 2 elements so it will iterate.

closes #1245

# Description

Please write a summary of the changes you have implemented; explaining your design choices if necessary. Please also include a list of things to test if it isn't clear.

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->
# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soul filter logic to correctly handle entity matching and deny-list configurations.

* **Tests**
  * Expanded test coverage for soul filters to include additional entity types and component comparison scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->