### PR TITLE
Make it possible to pump out the fluid of the weather obelisk

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/machines/obelisks/weather/WeatherObeliskBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/obelisks/weather/WeatherObeliskBlockEntity.java
@@ -177,7 +177,7 @@ public class WeatherObeliskBlockEntity extends MachineBlockEntity implements Flu
     @Override
     protected @Nullable MachineInventoryLayout createInventoryLayout() {
         return MachineInventoryLayout.builder()
-                .inputSlot((i, s) -> s.is(Items.FIREWORK_ROCKET))
+                .storageSlot((i, s) -> s.is(Items.FIREWORK_ROCKET))
                 .slotAccess(ROCKET)
                 .build();
     }
@@ -196,7 +196,7 @@ public class WeatherObeliskBlockEntity extends MachineBlockEntity implements Flu
 
     @Override
     public IOConfig getDefaultIOConfig() {
-        return IOConfig.of(IOMode.PULL);
+        return IOConfig.of(IOMode.BOTH);
     }
 
     @Override


### PR DESCRIPTION
# Description

Currently once a fluid is in the obelisk it can't be pulled out. This should make it so you can pull fluids out as well.

closes #1197

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Weather Obelisk firework rocket handling has been adjusted for improved storage configuration.
* Weather Obelisk can now perform bidirectional item transfers with adjacent machines instead of one-way pulls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->