### PR TITLE
Restrict facade visibility updates to the local player

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/client/content/conduits/model/facades/ClientFacadeVisibility.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/conduits/model/facades/ClientFacadeVisibility.java
@@ -24,6 +24,15 @@ public class ClientFacadeVisibility {
     @SubscribeEvent
     public static void onTick(PlayerTickEvent.Pre event) {
         // Update every tick on the client.
+
+        if (Minecraft.getInstance() == null || Minecraft.getInstance().level == null) {
+            return;
+        }
+
+        if (event.getEntity() != Minecraft.getInstance().player) {
+            return;
+        }
+
         setFacadesVisible(FacadeUtil.areFacadesVisible(event.getEntity()));
     }
 


### PR DESCRIPTION
This change adds a check to ensure only the local player's held items affect the facade visibility state.

closes #1251

# Description

Fixes an issue where conduit facades would fail to hide correctly for the local player in multiplayer environments.

The `ClientFacadeVisibility.onTick` method subscribes to `PlayerTickEvent`, which fires for every player entity.

Added a guard clause to ensure `setFacadesVisible` is only called when `event.getEntity()` matches `Minecraft.getInstance().player`.


<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of facade visibility handling by implementing protective validation checks. These ensure proper game state verification before applying visibility updates, preventing potential crashes and ensuring consistent, reliable behaviour during gameplay.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->