### PR TITLE
Implement Loot Capacitor Modifier exclusions

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/api/capacitor/CapacitorModifier.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/capacitor/CapacitorModifier.java
@@ -51,6 +51,11 @@ public enum CapacitorModifier implements StringRepresentable {
     public static CapacitorModifier getRandomModifier(RandomSource randomSource, Collection<CapacitorModifier> exclude) {
         var selectables = new ArrayList<>(CapacitorModifier.SELECTABLE_MODIFIERS);
         selectables.removeAll(exclude);
+
+        if (selectables.isEmpty()) {
+            throw new IllegalArgumentException("No selectable modifiers left after excluding " + exclude);
+        }
+
         return selectables.get(randomSource.nextInt(selectables.size()));
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/api/capacitor/CapacitorModifier.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/capacitor/CapacitorModifier.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.function.IntFunction;
 
 /**
@@ -44,19 +45,19 @@ public enum CapacitorModifier implements StringRepresentable {
         BURNING_ENERGY_GENERATION
     );
 
-    public static CapacitorModifier getRandomModifier(RandomSource randomSource) {
+    public static Optional<CapacitorModifier> getRandomModifier(RandomSource randomSource) {
         return getRandomModifier(randomSource, List.of());
     }
 
-    public static CapacitorModifier getRandomModifier(RandomSource randomSource, Collection<CapacitorModifier> exclude) {
+    public static Optional<CapacitorModifier> getRandomModifier(RandomSource randomSource, Collection<CapacitorModifier> exclude) {
         var selectables = new ArrayList<>(CapacitorModifier.SELECTABLE_MODIFIERS);
         selectables.removeAll(exclude);
 
         if (selectables.isEmpty()) {
-            throw new IllegalArgumentException("No selectable modifiers left after excluding " + exclude);
+            return Optional.empty();
         }
 
-        return selectables.get(randomSource.nextInt(selectables.size()));
+        return Optional.of(selectables.get(randomSource.nextInt(selectables.size())));
     }
 
     CapacitorModifier(int id) {

--- a/enderio/src/main/java/com/enderio/enderio/api/capacitor/CapacitorModifier.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/capacitor/CapacitorModifier.java
@@ -9,6 +9,8 @@ import net.minecraft.util.ByIdMap;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.StringRepresentable;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.IntFunction;
@@ -43,7 +45,13 @@ public enum CapacitorModifier implements StringRepresentable {
     );
 
     public static CapacitorModifier getRandomModifier(RandomSource randomSource) {
-        return CapacitorModifier.SELECTABLE_MODIFIERS.get(randomSource.nextInt(CapacitorModifier.SELECTABLE_MODIFIERS.size()));
+        return getRandomModifier(randomSource, List.of());
+    }
+
+    public static CapacitorModifier getRandomModifier(RandomSource randomSource, Collection<CapacitorModifier> exclude) {
+        var selectables = new ArrayList<>(CapacitorModifier.SELECTABLE_MODIFIERS);
+        selectables.removeAll(exclude);
+        return selectables.get(randomSource.nextInt(selectables.size()));
     }
 
     CapacitorModifier(int id) {

--- a/enderio/src/main/java/com/enderio/enderio/content/capacitors/SetLootCapacitorFunction.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/capacitors/SetLootCapacitorFunction.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.storage.loot.providers.number.NumberProviders;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class SetLootCapacitorFunction extends LootItemConditionalFunction {
 
@@ -42,16 +43,19 @@ public class SetLootCapacitorFunction extends LootItemConditionalFunction {
         float base = range.getFloat(context);
         Map<CapacitorModifier, Float> modifiers = new EnumMap<>(CapacitorModifier.class);
 
-        modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom()), range.getFloat(context));
+        var modifier = CapacitorModifier.getRandomModifier(context.getRandom());
+        modifier.ifPresent(m -> modifiers.put(m, range.getFloat(context)));
 
         // 15% chance of a secondary modifier
         if (context.getRandom().nextFloat() < 0.15f) {
-            modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom(), modifiers.keySet()), range.getFloat(context));
+            modifier = CapacitorModifier.getRandomModifier(context.getRandom(), modifiers.keySet());
+            modifier.ifPresent(m -> modifiers.put(m, range.getFloat(context)));
         }
 
         // 2% change of a third
         if (context.getRandom().nextFloat() < 0.02f) {
-            modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom(), modifiers.keySet()), range.getFloat(context));
+            modifier = CapacitorModifier.getRandomModifier(context.getRandom(), modifiers.keySet());
+            modifier.ifPresent(m -> modifiers.put(m, range.getFloat(context)));
         }
 
         stack.set(EIODataComponents.CAPACITOR_DATA, new CapacitorData(base, modifiers));

--- a/enderio/src/main/java/com/enderio/enderio/content/capacitors/SetLootCapacitorFunction.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/capacitors/SetLootCapacitorFunction.java
@@ -14,7 +14,7 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
 import net.minecraft.world.level.storage.loot.providers.number.NumberProviders;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,18 +40,18 @@ public class SetLootCapacitorFunction extends LootItemConditionalFunction {
     @Override
     protected ItemStack run(ItemStack stack, LootContext context) {
         float base = range.getFloat(context);
-        Map<CapacitorModifier, Float> modifiers = new HashMap<>();
+        Map<CapacitorModifier, Float> modifiers = new EnumMap<>(CapacitorModifier.class);
 
         modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom()), range.getFloat(context));
 
         // 15% chance of a secondary modifier
         if (context.getRandom().nextFloat() < 0.15f) {
-            modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom()), range.getFloat(context));
+            modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom(), modifiers.keySet()), range.getFloat(context));
         }
 
         // 2% change of a third
         if (context.getRandom().nextFloat() < 0.02f) {
-            modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom()), range.getFloat(context));
+            modifiers.put(CapacitorModifier.getRandomModifier(context.getRandom(), modifiers.keySet()), range.getFloat(context));
         }
 
         stack.set(EIODataComponents.CAPACITOR_DATA, new CapacitorData(base, modifiers));


### PR DESCRIPTION
# Description

This pull request adds an overloaded method to the `CapacitorModifier` enum that accepts a collection of modifiers to exclude when selecting a new random modifier.

This change addresses an issue in `SetLootCapacitorFunction`, where multiple modifiers are only assigned when a new modifier is successfully rolled. Since the modifiers are stored in a map, rolling a modifier that has already been applied overrides the existing entry. As a result, the capacitor may end up with only a single modifier, even if the probability check for additional modifiers succeeds, making secondary and tertiary modifiers significantly rarer than intended.

Additionally, I changed the `HashMap` to an `EnumMap`. The performance impact is negligible, but enum maps are a lot better when working with enum keys.

# Breaking Changes

There are no breaking changes. The new functionality is provided via an overload, so existing add-ons that rely on the original method without the exclusion collection will continue to work as before.

# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.
