### PR TITLE
Fix crash when destroying conduit bundle block

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
@@ -954,7 +954,7 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
     private void disconnect(Holder<Conduit<?, ?>> conduit, Direction side) {
         for (var c : conduits) {
             if (ConduitUtility.canConnectConduits(conduit, c)) {
-                setConnectionStatus(conduit, side, ConnectionStatus.DISCONNECTED);
+                setConnectionStatus(c, side, ConnectionStatus.DISCONNECTED);
             }
         }
     }


### PR DESCRIPTION
Fixes #1274

disconnect() was passing the neighbor's conduit holder to setConnectionStatus() instead of the local compatible one. Changed conduit to c to match how connectConduit() already does it.