### PR TITLE
Make anchors render full-block icons as blocks instead of items

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
@@ -13,11 +13,11 @@ import com.mojang.math.Axis;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.block.ModelBlockRenderer;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.model.BakedModel;
@@ -31,7 +31,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.neoforged.neoforge.common.util.Lazy;
 import org.joml.Math;
 import org.joml.Matrix4f;
@@ -96,12 +95,11 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
             textColor = ChatFormatting.AQUA.getColor() == null ? 0xFFFFFF : ChatFormatting.AQUA.getColor();
             outlineColor = textColor;
         }
-        float outlineR = ((outlineColor & (0xFF << 16)) >> 16) / 255F;
-        float outlineG = ((outlineColor & (0xFF << 8)) >> 8) / 255F;
+        float outlineR = ((outlineColor >> 16) & 0xFF) / 255F;
+        float outlineG = ((outlineColor >> 8) & 0xFF) / 255F;
         float outlineB = (outlineColor & 0xFF) / 255F;
 
-        VertexConsumer solidRenderBuffer = buffer.getBuffer(RenderType.solid());
-        ModelBlockRenderer blockModelRenderer = minecraft.getBlockRenderer().getModelRenderer();
+        VertexConsumer renderBuffer = buffer.getBuffer(RenderType.tripwire());
 
         int packedLight = LightTexture.pack(15, 15);
 
@@ -112,7 +110,7 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
 
         if (iconBlock != Blocks.AIR && BaseConfig.CLIENT.ANCHORS_USE_ICON_AS_BLOCK.get()) {
             blockState = iconBlock.defaultBlockState();
-            iconIsFullBlock = blockState.getOcclusionShape(minecraft.level, travelData.pos()) == Shapes.block();
+            iconIsFullBlock = Block.isShapeFullBlock(blockState.getOcclusionShape(minecraft.level, travelData.pos()));;
         } else {
             blockState = minecraft.level.getBlockState(travelData.pos());
 
@@ -129,8 +127,31 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
 
         if (!hasIcon) {
             // Render Model
-            BakedModel blockModel = minecraft.getBlockRenderer().getBlockModel(blockState);
-            blockModelRenderer.renderModel(poseStack.last(), solidRenderBuffer, blockState, blockModel, 1, 1, 1, packedLight, OverlayTexture.NO_OVERLAY);
+            {
+                BakedModel blockModel = minecraft.getBlockRenderer().getBlockModel(blockState);
+                BlockColors blockColors = minecraft.getBlockColors();
+
+                var randomSource = RandomSource.create(42L);
+                ArrayList<BakedQuad> quads = new ArrayList<>(blockModel.getQuads(blockState, null, randomSource));
+                for (Direction direction : Direction.values()) {
+                    randomSource.setSeed(42L);
+                    quads.addAll(blockModel.getQuads(blockState, direction, randomSource));
+                }
+
+                for (BakedQuad quad : quads) {
+                    int tintIndex = quad.getTintIndex();
+                    float r = 1F, g = 1F, b = 1F;
+
+                    if (tintIndex != -1) {
+                        int color = blockColors.getColor(blockState, minecraft.level, travelData.pos(), tintIndex);
+                        r = ((color >> 16) & 0xFF) / 255F;
+                        g = ((color >> 8) & 0xFF) / 255F;
+                        b = (color & 0xFF) / 255F;
+                    }
+
+                    renderBuffer.putBulkData(poseStack.last(), quad, r, g, b, 1.0F, packedLight, OverlayTexture.NO_OVERLAY);
+                }
+            }
 
             // Render outline block
             {
@@ -144,7 +165,7 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
                 poseStack.scale(scale, scale, scale);
 
                 for (BakedQuad quad : BACKDROP_QUADS.get()) {
-                    solidRenderBuffer.putBulkData(poseStack.last(), quad, outlineR, outlineG, outlineB, 1, packedLight, OverlayTexture.NO_OVERLAY);
+                    renderBuffer.putBulkData(poseStack.last(), quad, outlineR, outlineG, outlineB, 1, packedLight, OverlayTexture.NO_OVERLAY);
                 }
 
                 poseStack.popPose();
@@ -181,7 +202,7 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
             poseStack.rotateAround(Axis.ZN.rotationDegrees(45), 0.5F, 0.5F, 0.5F);
 
             for (BakedQuad quad : BACKDROP_QUADS.get()) {
-                solidRenderBuffer.putBulkData(poseStack.last(), quad, outlineR, outlineG, outlineB, 1, packedLight, OverlayTexture.NO_OVERLAY);
+                renderBuffer.putBulkData(poseStack.last(), quad, outlineR, outlineG, outlineB, 1, packedLight, OverlayTexture.NO_OVERLAY);
             }
 
             poseStack.popPose();

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
@@ -4,6 +4,7 @@ import com.enderio.enderio.api.travel.TravelRenderer;
 import com.enderio.enderio.client.EnderIOClient;
 import com.enderio.enderio.client.foundation.renderer.OutlineBuffer;
 import com.enderio.enderio.compat.ModCompatHelper;
+import com.enderio.enderio.config.base.BaseConfig;
 import com.enderio.enderio.content.travel.travel_anchor.AnchorTravelTarget;
 import com.enderio.enderio.content.travel.travel_anchor.PaintedTravelAnchorBlockEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -27,8 +28,10 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.neoforged.neoforge.common.util.Lazy;
 import org.joml.Math;
 import org.joml.Matrix4f;
@@ -102,23 +105,32 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
 
         int packedLight = LightTexture.pack(15, 15);
 
-        boolean hasIcon = travelData.icon() != Items.AIR;
+        Block iconBlock = Block.byItem(travelData.icon());
+
+        BlockState blockState;
+        boolean iconIsFullBlock = false;
+
+        if (iconBlock != Blocks.AIR && BaseConfig.CLIENT.ANCHORS_USE_ICON_AS_BLOCK.get()) {
+            blockState = iconBlock.defaultBlockState();
+            iconIsFullBlock = blockState.getOcclusionShape(minecraft.level, travelData.pos()) == Shapes.block();
+        } else {
+            blockState = minecraft.level.getBlockState(travelData.pos());
+
+            if (minecraft.level.getBlockEntity(travelData.pos()) instanceof PaintedTravelAnchorBlockEntity paintedTravelAnchorBlock) {
+                Optional<Block> paint = paintedTravelAnchorBlock.getPrimaryPaint();
+
+                if (paint.isPresent()) {
+                    blockState = paint.get().defaultBlockState();
+                }
+            }
+        }
+
+        boolean hasIcon = !(travelData.icon() == Items.AIR || iconIsFullBlock);
 
         if (!hasIcon) {
             // Render Model
-            {
-                BlockState blockState = minecraft.level.getBlockState(travelData.pos());
-                if (minecraft.level.getBlockEntity(travelData.pos()) instanceof PaintedTravelAnchorBlockEntity paintedTravelAnchorBlock) {
-                    Optional<Block> paint = paintedTravelAnchorBlock.getPrimaryPaint();
-
-                    if (paint.isPresent()) {
-                        blockState = paint.get().defaultBlockState();
-                    }
-                }
-
-                BakedModel blockModel = minecraft.getBlockRenderer().getBlockModel(blockState);
-                blockModelRenderer.renderModel(poseStack.last(), solidRenderBuffer, blockState, blockModel, 1, 1, 1, packedLight, OverlayTexture.NO_OVERLAY);
-            }
+            BakedModel blockModel = minecraft.getBlockRenderer().getBlockModel(blockState);
+            blockModelRenderer.renderModel(poseStack.last(), solidRenderBuffer, blockState, blockModel, 1, 1, 1, packedLight, OverlayTexture.NO_OVERLAY);
 
             // Render outline block
             {
@@ -157,7 +169,7 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
                 poseStack.scale(-s, s, -s);
             }
 
-            ItemStack stack = new ItemStack(travelData.icon());
+            ItemStack stack = travelData.icon().getDefaultInstance();
             BakedModel bakedmodel = minecraft.getItemRenderer().getModel(stack, minecraft.level, null, 0);
             minecraft
                 .getItemRenderer()

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
@@ -110,7 +110,7 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
 
         if (iconBlock != Blocks.AIR && BaseConfig.CLIENT.ANCHORS_USE_ICON_AS_BLOCK.get()) {
             blockState = iconBlock.defaultBlockState();
-            iconIsFullBlock = Block.isShapeFullBlock(blockState.getOcclusionShape(minecraft.level, travelData.pos()));;
+            iconIsFullBlock = Block.isShapeFullBlock(blockState.getOcclusionShape(minecraft.level, travelData.pos()));
         } else {
             blockState = minecraft.level.getBlockState(travelData.pos());
 

--- a/enderio/src/main/java/com/enderio/enderio/config/base/client/BaseClientConfig.java
+++ b/enderio/src/main/java/com/enderio/enderio/config/base/client/BaseClientConfig.java
@@ -5,14 +5,16 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 public class BaseClientConfig {
     public final ModConfigSpec.BooleanValue MACHINE_PARTICLES;
     public final ModConfigSpec.IntValue TRAVEL_KEY_HOLD_DELAY;
+    public final ModConfigSpec.BooleanValue ANCHORS_USE_ICON_AS_BLOCK;
 
     public BaseClientConfig(ModConfigSpec.Builder builder) {
         builder.push("behavior");
-        TRAVEL_KEY_HOLD_DELAY = builder.comment("Ticks before Staff Of Traveling Keybind is considered 'held' for anchor teleports ").defineInRange("travelKeyHoldDelayTicks", 8, 0, Integer.MAX_VALUE);
+        TRAVEL_KEY_HOLD_DELAY = builder.comment("Ticks before Staff Of Traveling Keybind is considered 'held' for anchor teleports ")
+            .defineInRange("travelKeyHoldDelayTicks", 8, 0, Integer.MAX_VALUE);
         builder.pop();
         builder.push("visual");
         MACHINE_PARTICLES = builder.comment("Enable machine particles").define("machineParticles", true);
+        ANCHORS_USE_ICON_AS_BLOCK = builder.comment("Try to render items as blocks").define("anchorsUseIconAsBlock", true);
         builder.pop();
-
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/config/base/client/BaseClientConfig.java
+++ b/enderio/src/main/java/com/enderio/enderio/config/base/client/BaseClientConfig.java
@@ -14,7 +14,8 @@ public class BaseClientConfig {
         builder.pop();
         builder.push("visual");
         MACHINE_PARTICLES = builder.comment("Enable machine particles").define("machineParticles", true);
-        ANCHORS_USE_ICON_AS_BLOCK = builder.comment("Try to render items as blocks").define("anchorsUseIconAsBlock", true);
+        ANCHORS_USE_ICON_AS_BLOCK = builder.comment("Whether Travel Anchors try to render items as blocks")
+            .define("anchorsUseIconAsBlock", true);
         builder.pop();
     }
 }


### PR DESCRIPTION
# Description

Added a config option let full-block icons replace the anchor block model.

<details>
<summary>Click to see "before" image</summary>
 ______<br>

<img width="854" height="480" alt="2026-03-02_19 39 17" src="https://github.com/user-attachments/assets/ef7f50cb-ff80-4066-9860-df85698def89" />

</details>

<img width="854" height="480" alt="2026-03-02_19 39 20" src="https://github.com/user-attachments/assets/bbaa8db9-ed0d-4709-ab5d-109336e1bf64" />


# TODO

- [x] Fix grass/tinted block rendering? (broken prior to this PR, but more relevant with this change)
  - <details>
    <img width="273" height="246" alt="image" src="https://github.com/user-attachments/assets/2cc1c8e9-0888-4fa4-8c74-226a6142920f" /> 
    <img width="267" height="208" alt="image" src="https://github.com/user-attachments/assets/3afea189-7126-4a32-b58c-ac8699dda011" /><br>
    (Right image is before #1261 was merged)<br>
    -- Now fixed. --<br>
    <img width="310" height="268" alt="image" src="https://github.com/user-attachments/assets/153cdab1-5c68-434b-b851-aa95c530f4e4" />

    </details>
- [ ] Add configuration for travel anchor colors
  - Configuring the inactive color is simple enough, but what about the active color, should it no longer be derived from `ChatFormatting`?
  - Should text color be configurable separately from background/outline color?
- [ ] Fix rendering being slightly out of sync with Sodium installed
  - Since #1261, not particularly obvious unless you set the FPS limit to a low value (<30FPS).
  - It looks like the anchors are somehow rendered where they will be next frame.

