### PR TITLE
fix: Item conduit stack size bug

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/conduit/type/item/ItemConduitTicker.java
+++ b/src/conduits/java/com/enderio/conduits/common/conduit/type/item/ItemConduitTicker.java
@@ -49,6 +49,12 @@ public class ItemConduitTicker extends CapabilityAwareConduitTicker<ItemConduitD
                     continue;
                 }
 
+                // Ensure we cap the stack to its max size, even if the parent handler doesn't respect it.
+                int extractedItemMaxStack = extractedItem.getMaxStackSize();
+                if (extractedItem.getCount() > extractedItemMaxStack) {
+                    extractedItem.setCount(extractedItemMaxStack);
+                }
+
                 if (extract.extractFilter instanceof ItemStackFilter itemFilter) {
                     if (!itemFilter.test(extractedItem)) {
                         continue;
@@ -80,7 +86,8 @@ public class ItemConduitTicker extends CapabilityAwareConduitTicker<ItemConduitD
                         }
                     }
 
-                    ItemStack notInserted = ItemHandlerHelper.insertItem(insert.capability, extractedItem, false);
+                    // Copy the stack to ensure extractedItem isn't modified by item handler implementations (Create Chute for example)
+                    ItemStack notInserted = ItemHandlerHelper.insertItem(insert.capability, extractedItem.copy(), false);
                     int successfullyInserted = extractedItem.getCount() - notInserted.getCount();
 
                     if (successfullyInserted > 0) {


### PR DESCRIPTION
# Description

Fixes a bug when item conduits deal with items that have unusual max stack sizes.
Also fixes mods like Create modifying the stack we pass into insertItem and breaking calculations sometimes

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
