### PR TITLE
fix: EnderSoulFilter codec serialization

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/filters/soul/EnderSoulFilter.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/filters/soul/EnderSoulFilter.java
@@ -27,7 +27,13 @@ public record EnderSoulFilter(NonNullList<Soul> matches, boolean isDenyList, boo
             .group(
                 OrderedListCodec.create(256, Soul.CODEC, Soul.EMPTY)
                     .fieldOf("entities")
-                    .forGetter(EnderSoulFilter::matches),
+                    .forGetter(filter -> {
+                        NonNullList<Soul> sparse = NonNullList.create();
+                        for (Soul soul : filter.matches()) {
+                            if (!soul.isEmpty()) sparse.add(soul);
+                        }
+                        return sparse;
+                }),
                 Codec.BOOL.fieldOf("isInvert").forGetter(EnderSoulFilter::isDenyList),
                 Codec.BOOL.fieldOf("nbt").forGetter(EnderSoulFilter::shouldCompareTags))
             .apply(componentInstance, EnderSoulFilter::new));


### PR DESCRIPTION
Empty filter slots were being encoded as Soul[entityType=null] which produced unregistered holders and caused an IllegalStateException on save. Filter the matches list to exclude empty slots in the forGetter so null entity types are never passed to Soul.CODEC.

Fixes #1335

# Description

Empty soul filter slots were being serialized as Soul[entityType=null] by EnderSoulFilter's CODEC, producing unregistered holders that caused an IllegalStateException when the game attempted to save the player's inventory or the aversion obelisk's block entity state. This crash was reproducible 100% of the time on a clean install with no other mods by simply configuring a soul filter with fewer entities than the filter has slots.

The fix strips empty slots from the matches list in the CODEC's forGetter before encoding, so null entity types are never passed to Soul.CODEC. Decoding is unaffected since EnderSoulFilterMenu.getEntityInFilter already handles a matches list shorter than slotCount() by returning Soul.EMPTY for out-of-bounds indices.

Confirmed fix by testing a partially-filled soul filter (1 entity, 8 empty slots) — the game now saves cleanly and the aversion obelisk functions as intended. Also resolves the secondary obelisk block entity save failure described in #1335.

# Breaking Changes

None. No API changes, no recipe changes, no gameplay changes. Existing soul filters with partially-filled slots will have their empty slots silently dropped on next save, which is the correct behavior.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
