### PR TITLE
fix: filter null network + decode err in ConduitNetworkSavedData

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/network/ConduitNetworkSavedData.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/network/ConduitNetworkSavedData.java
@@ -43,8 +43,13 @@ import java.util.Optional;
 @EventBusSubscriber
 public class ConduitNetworkSavedData extends SavedData {
 
-    public static final Codec<ConduitNetworkSavedData> CODEC = ConduitNetworkImpl.CODEC.listOf()
-            .xmap(ConduitNetworkSavedData::new, ConduitNetworkSavedData::getNetworks);
+	public static final Codec<ConduitNetworkSavedData> CODEC = ConduitNetworkImpl.CODEC.listOf()
+	        .xmap(
+	            list -> new ConduitNetworkSavedData(
+	                list.stream().filter(Objects::nonNull).toList()
+	            ),
+	            ConduitNetworkSavedData::getNetworks
+	        );
 
     private final Multimap<ConduitType<?, ?>, ConduitNetworkImpl> networks = HashMultimap.create();
 
@@ -83,9 +88,9 @@ public class ConduitNetworkSavedData extends SavedData {
             return loadLegacy(nbt, lookupProvider);
         }
 
-        // TODO: Are we handling partials fine here?
-        return CODEC.parse(lookupProvider.createSerializationContext(NbtOps.INSTANCE), nbt.get(KEY_NEW_DATA))
-                .getPartialOrThrow();
+        var result = CODEC.parse(lookupProvider.createSerializationContext(NbtOps.INSTANCE), nbt.get(KEY_NEW_DATA));
+        result.error().ifPresent(e -> LOGGER.error("Errors loading conduit network data, some networks may be missing: {}", e.message()));
+        return result.getPartialOrThrow();
     }
 
     private List<ConduitNetworkImpl> getNetworks() {


### PR DESCRIPTION
Null ConduitNetworkImpl entries decoded by the listOf() codec were propagating into the ConduitNetworkSavedData constructor and causing a NullPointerException at Optional.of() on every level tick. Added a null filter in the CODEC xmap to drop invalid entries before they reach the constructor, and added error logging before getPartialOrThrow() in load() to surface decode failures rather than swallowing them silently.

Addresses the TODO comment questioning partial handling in load().

# Description

When loading enderio_conduit_network saved data, ConduitNetworkImpl.CODEC.listOf() could decode entries containing null values and return them as a partial success. These nulls would then propagate into ConduitNetworkSavedData(List<ConduitNetworkImpl>) and cause a NullPointerException at Optional.of() on every level tick, spamming the log continuously until the server was restarted.
Two changes made:

Added a null filter in the CODEC xmap so null network entries are silently dropped before being passed to the constructor, preventing the NPE.
Replaced the silent getPartialOrThrow() in load() with an error-logging step first, so any future decode failures are visible in the log rather than swallowed. This also addresses the existing TODO comment questioning whether partials were being handled correctly.

The root cause of why ConduitNetworkImpl.CODEC produces nulls is likely a missing or unresolvable registry entry within a network's data — this fix is a defensive measure at the saved data level regardless of what produces the null downstream.
Confirmed fix on a dedicated server where the error was previously repeating every 5 seconds on every level tick.

# Breaking Changes

None. Networks that fail to decode are dropped and logged rather than crashing the server. Existing valid network data is unaffected.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
