### PR TITLE
feat: Add support for properly handling capability invalidation

### DIFF
--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/appeng/MEConduit.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/appeng/MEConduit.java
@@ -3,10 +3,12 @@ package com.enderio.modded_conduits.common.modules.appeng;
 import appeng.api.AECapabilities;
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.GridHelper;
+import appeng.api.networking.IGridNode;
 import appeng.api.networking.IManagedGridNode;
 import appeng.api.util.AEColor;
 import com.enderio.enderio.api.EnderIORegistries;
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.connection.config.ConnectionConfigType;
 import com.enderio.enderio.api.conduits.network.node.ConduitNode;
@@ -24,6 +26,7 @@ import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import org.jetbrains.annotations.NotNull;
@@ -68,7 +71,7 @@ public record MEConduit(ResourceLocation texture, Component description, AEColor
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
         return GridHelper.getExposedNode(level, conduitPos.relative(direction), direction.getOpposite()) != null;
     }
 

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/mekanism/chemical/ChemicalConduit.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/mekanism/chemical/ChemicalConduit.java
@@ -2,6 +2,7 @@ package com.enderio.modded_conduits.common.modules.mekanism.chemical;
 
 import com.enderio.core.common.util.TooltipUtil;
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.bundle.SlotType;
 import com.enderio.enderio.api.conduits.connection.path.ConnectionPathProperty;
@@ -23,6 +24,7 @@ import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector2i;
@@ -67,9 +69,8 @@ public record ChemicalConduit(ResourceLocation texture, Component description, l
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
-        return level.getCapability(MekanismModule.Capabilities.CHEMICAL, conduitPos.relative(direction),
-                direction.getOpposite()) != null;
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        return capabilityAccessor.getSidedCapability(MekanismModule.Capabilities.CHEMICAL, direction) != null;
     }
 
     @Override

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/mekanism/heat/HeatConduit.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/mekanism/heat/HeatConduit.java
@@ -1,6 +1,7 @@
 package com.enderio.modded_conduits.common.modules.mekanism.heat;
 
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.connection.config.ConnectionConfigType;
 import com.enderio.modded_conduits.common.modules.mekanism.MekanismModule;
@@ -8,6 +9,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,9 +27,8 @@ public record HeatConduit(ResourceLocation texture, Component description)
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
-        return level.getCapability(MekanismModule.Capabilities.HEAT, conduitPos.relative(direction),
-                direction.getOpposite()) != null;
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        return capabilityAccessor.getSidedCapability(MekanismModule.Capabilities.HEAT, direction) != null;
     }
 
     @Override

--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/refinedstorage/RSConduit.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/refinedstorage/RSConduit.java
@@ -1,6 +1,7 @@
 package com.enderio.modded_conduits.common.modules.refinedstorage;
 
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.connection.config.ConnectionConfigType;
 import com.enderio.enderio.api.conduits.network.node.ConduitNode;
@@ -13,6 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import org.jetbrains.annotations.NotNull;
@@ -38,10 +40,9 @@ public record RSConduit(ResourceLocation texture, Component description)
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
-        var cap = level.getCapability(
-                RefinedStorageNeoForgeApiImpl.INSTANCE.getNetworkNodeContainerProviderCapability(),
-                conduitPos.relative(direction), direction.getOpposite());
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        var cap = capabilityAccessor.getSidedCapability(
+            RefinedStorageNeoForgeApiImpl.INSTANCE.getNetworkNodeContainerProviderCapability(), direction);
         if (cap != null) {
             for (var connection : cap.getContainers()) {
                 if (connection.canAcceptIncomingConnection(direction.getOpposite(), level.getBlockState(conduitPos))) {

--- a/enderio/src/main/java/com/enderio/enderio/api/conduits/Conduit.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/conduits/Conduit.java
@@ -28,6 +28,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipProvider;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import org.apache.commons.lang3.NotImplementedException;
@@ -141,8 +142,26 @@ public interface Conduit<TConduit extends Conduit<TConduit, TConnectionConfig>, 
         return false;
     }
 
-    boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction);
+    default boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        return canConnectToBlock(level, conduitPos, direction);
+    }
 
+    /**
+     * @deprecated Use {@link #canConnectToBlock(Level, ConduitCapabilityAccessor, BlockPos, Direction)} instead as it provides capability caching and invalidation handling.
+     */
+    @Deprecated(since = "8.2.6")
+    default boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
+        return false;
+    }
+
+    default boolean canForceConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        return canConnectToBlock(level, capabilityAccessor, conduitPos, direction);
+    }
+
+    /**
+     * @deprecated Use {@link #canConnectToBlock(Level, ConduitCapabilityAccessor, BlockPos, Direction)} instead as it provides capability caching and invalidation handling.
+     */
+    @Deprecated(since = "8.2.6")
     default boolean canForceConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
         return canConnectToBlock(level, conduitPos, direction);
     }

--- a/enderio/src/main/java/com/enderio/enderio/api/conduits/ConduitCapabilityAccessor.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/conduits/ConduitCapabilityAccessor.java
@@ -1,0 +1,30 @@
+package com.enderio.enderio.api.conduits;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.capabilities.BlockCapability;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Provides access to neighboring block capabilities.
+ */
+@ApiStatus.Experimental
+public interface ConduitCapabilityAccessor {
+    /**
+     * Get the desired capability from a neighboring block.
+     *
+     * @param capability the desired capability.
+     * @param neighborSide the side to query for a neighboring capability.
+     * @return the capability or null if it is not available.
+     */
+    @Nullable
+    <T, C> T getCapability(BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context);
+
+    @Nullable
+    @ApiStatus.NonExtendable
+    default <T> T getSidedCapability(BlockCapability<T, Direction> capability, Direction neighborSide) {
+        return getCapability(capability, neighborSide, neighborSide.getOpposite());
+    }
+}

--- a/enderio/src/main/java/com/enderio/enderio/api/conduits/connection/ConduitBlockConnection.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/conduits/connection/ConduitBlockConnection.java
@@ -34,8 +34,8 @@ public record ConduitBlockConnection(ConduitNode node, Direction connectionSide)
      * @return the capability or null if it is not available.
      */
     @Nullable
-    public <TCapability> TCapability getSidedCapability(BlockCapability<TCapability, Direction> capability) {
-        return node.getNeighborSidedCapability(capability, connectionSide);
+    public <T, C> T getCapability(BlockCapability<T, C> capability, @Nullable C context) {
+        return node.getCapability(capability, connectionSide, context);
     }
 
     /**
@@ -45,8 +45,8 @@ public record ConduitBlockConnection(ConduitNode node, Direction connectionSide)
      * @return the capability or null if it is not available.
      */
     @Nullable
-    public <TCapability> TCapability getVoidCapability(BlockCapability<TCapability, Void> capability) {
-        return node.getNeighborVoidCapability(capability, connectionSide);
+    public <T> T getSidedCapability(BlockCapability<T, Direction> capability) {
+        return getCapability(capability, connectionSide.getOpposite());
     }
 
     /**

--- a/enderio/src/main/java/com/enderio/enderio/api/conduits/network/node/ConduitNode.java
+++ b/enderio/src/main/java/com/enderio/enderio/api/conduits/network/node/ConduitNode.java
@@ -1,6 +1,7 @@
 package com.enderio.enderio.api.conduits.network.node;
 
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.connection.ConnectionStatus;
 import com.enderio.enderio.api.conduits.connection.config.ConnectionConfig;
@@ -21,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
  * Each node represents a single conduit within a bundle, and can have up to six connections in any {@link Direction}.
  */
 @ApiStatus.AvailableSince("8.0.0")
-public interface ConduitNode {
+public interface ConduitNode extends ConduitCapabilityAccessor {
     /**
      * @return the conduit the node represents.
      * @apiNote Currently the node must be valid (loaded, attached etc.) for this to not throw an exception.
@@ -104,27 +105,19 @@ public interface ConduitNode {
     <T extends NodeData> void setNodeData(@Nullable T data);
 
     /**
-     * Get the desired capability from a neighboring block.
-     *
-     * @param capability the desired capability.
-     * @param side the side to query for a neighboring capability.
-     * @return the capability or null if it is not available.
      * @throws IllegalStateException if this node is not loaded
      */
-    @Nullable
-    <TCapability> TCapability getNeighborSidedCapability(BlockCapability<TCapability, Direction> capability,
-            Direction side);
+    @Override
+    @Nullable <T, C> T getCapability(BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context);
 
     /**
-     * Get the desired capability from a neighboring block.
-     *
-     * @param capability the desired capability.
-     * @param side the side to query for a neighboring capability.
-     * @return the capability or null if it is not available.
      * @throws IllegalStateException if this node is not loaded
      */
+    @Override
     @Nullable
-    <TCapability> TCapability getNeighborVoidCapability(BlockCapability<TCapability, Void> capability, Direction side);
+    default <T> T getSidedCapability(BlockCapability<T, Direction> capability, Direction neighborSide) {
+        return ConduitCapabilityAccessor.super.getSidedCapability(capability, neighborSide);
+    }
 
     /**
      * @param signalColor the redstone conduit signal color to check for, or null for in-world signal only.

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
@@ -4,6 +4,7 @@ import com.enderio.core.common.blockentity.EnderBlockEntity;
 import com.enderio.enderio.api.EnderIOCapabilities;
 import com.enderio.enderio.api.UseOnly;
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.ConduitUtility;
 import com.enderio.enderio.api.conduits.bundle.AddConduitResult;
@@ -190,6 +191,12 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
             // Fire on-created events
             for (var conduit : conduits) {
                 conduit.value().onCreated(conduitNodes.get(conduit), level, getBlockPos(), null);
+
+                // For any side that has connected as loaded, query canConnectToBlock once. This will establish any relevant capability caches
+                // TODO: Maybe we *should* just tryConnectTo any blocks on load (in case of datapack change, mod update etc.)
+                for (Direction side : Direction.values()) {
+                    conduit.value().canConnectToBlock(level, getCacheFor(conduit), getBlockPos(), side);
+                }
             }
 
             // Attempt to make connections for recovered nodes.
@@ -298,7 +305,7 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
         }
 
         // TODO: This should be cached and updated whenever neighbors change...
-        return conduit.value().canForceConnectToBlock(level, getBlockPos(), side);
+        return conduit.value().canForceConnectToBlock(level, getCacheFor(conduit),getBlockPos(), side);
     }
 
     @Override
@@ -920,8 +927,8 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
 
             disconnect(conduit, side);
             return false;
-        } else if (conduit.value().canConnectToBlock(level, getBlockPos(), side)
-                || (isForcedConnection && conduit.value().canForceConnectToBlock(level, getBlockPos(), side))) {
+        } else if (conduit.value().canConnectToBlock(level, getCacheFor(conduit),getBlockPos(), side)
+                || (isForcedConnection && conduit.value().canForceConnectToBlock(level, getCacheFor(conduit),getBlockPos(), side))) {
             connectBlock(conduit, side);
             return true;
         }
@@ -982,7 +989,7 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
                 if (currentStatus.canConnect()) {
                     tryConnectTo(conduit, side, false);
                 } else if (currentStatus.isEndpoint()) {
-                    if (!conduit.value().canForceConnectToBlock(level, getBlockPos(), side)) {
+                    if (!conduit.value().canForceConnectToBlock(level, getCacheFor(conduit),getBlockPos(), side)) {
                         disconnect(conduit, side);
                         onConnectionsUpdated(conduit);
                     }
@@ -993,40 +1000,27 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
 
     // endregion
 
-    // region Node Interactions
+    // region World Interactions
 
     public void markNodesDirty() {
         hasDirtyNodes = true;
     }
 
-    @Nullable
-    public <TCapability> TCapability getNeighborSidedCapability(Holder<Conduit<?, ?>> conduit,
-            BlockCapability<TCapability, Direction> capability, Direction side) {
-        // Doesn't use EnderBlockEntity's capability cache so that we can bin capability
-        // caches that aren't needed when conduits are removed.
-        // Probably an "early optimization" but I don't think this really hurts.
-        if (level instanceof ServerLevel serverLevel) {
-            var capabilityCache = neighbouringCapabilityCaches.computeIfAbsent(conduit,
-                    c -> new NeighboringCapabilityCaches());
-            return capabilityCache.getSidedCapability(capability, serverLevel, getBlockPos(), side);
-        }
-
-        return null;
+    private void onCapabilityInvalidated() {
+        checkConnection = checkConnection.activate();
     }
 
-    @Nullable
-    public <TCapability> TCapability getNeighborVoidCapability(Holder<Conduit<?, ?>> conduit,
-            BlockCapability<TCapability, Void> capability, Direction side) {
-        // Doesn't use EnderBlockEntity's capability cache so that we can bin capability
-        // caches that aren't needed when conduits are removed.
-        // Probably an "early optimization" but I don't think this really hurts.
-        if (level instanceof ServerLevel serverLevel) {
-            var capabilityCache = neighbouringCapabilityCaches.computeIfAbsent(conduit,
-                    c -> new NeighboringCapabilityCaches());
-            return capabilityCache.getVoidCapability(capability, serverLevel, getBlockPos(), side);
-        }
+    private NeighboringCapabilityCaches getCacheFor(Holder<Conduit<?, ?>> conduit) {
+        return neighbouringCapabilityCaches.computeIfAbsent(conduit,
+            c -> new NeighboringCapabilityCaches(this::onCapabilityInvalidated));
+    }
 
-        return null;
+    // Doesn't use EnderBlockEntity's capability cache so that we can bin capability
+    // caches that aren't needed when conduits are removed.
+    // Probably an "early optimization" but I don't think this really hurts.
+    @Override
+    public @Nullable <T, C> T getCapability(Holder<Conduit<?, ?>> conduit, BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context) {
+        return getCacheFor(conduit).getCapability(capability, neighborSide, context);
     }
 
     // endregion
@@ -1685,38 +1679,28 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
         }
     }
 
-    private static class NeighboringCapabilityCaches {
-        private final Map<Direction, Map<BlockCapability<?, Direction>, BlockCapabilityCache<?, Direction>>> directionalCaches = new EnumMap<>(
-                Direction.class);
-        private final Map<Direction, Map<BlockCapability<?, Void>, BlockCapabilityCache<?, Void>>> voidCaches = new EnumMap<>(
-                Direction.class);
+    private class NeighboringCapabilityCaches implements ConduitCapabilityAccessor {
+        private final Runnable invalidationListener;
 
-        /**
-         * Get a capability for the given side of the node
-         */
-        @Nullable
-        public <TCapability> TCapability getSidedCapability(BlockCapability<TCapability, Direction> capability,
-                ServerLevel level, BlockPos conduitPos, Direction side) {
-            var cacheMap = directionalCaches.computeIfAbsent(side, s -> new HashMap<>());
-            var cache = cacheMap.computeIfAbsent(capability,
-                    c -> BlockCapabilityCache.create(c, level, conduitPos.relative(side), side.getOpposite()));
+        private final Map<Direction, Map<BlockCapability<?, ?>, Map<Object, BlockCapabilityCache<?, ?>>>> cachesByNeighbor = new EnumMap<>(Direction.class);
 
-            // noinspection unchecked
-            return (TCapability) cache.getCapability();
+        private NeighboringCapabilityCaches(Runnable invalidationListener) {
+            this.invalidationListener = invalidationListener;
         }
 
-        /**
-         * Get a capability for the given side of the node
-         */
-        @Nullable
-        public <TCapability> TCapability getVoidCapability(BlockCapability<TCapability, Void> capability,
-                ServerLevel level, BlockPos conduitPos, Direction side) {
-            var cacheMap = voidCaches.computeIfAbsent(side, s -> new HashMap<>());
-            var cache = cacheMap.computeIfAbsent(capability,
-                    c -> BlockCapabilityCache.create(c, level, conduitPos.relative(side), null));
+        @Override
+        public @Nullable <T, C> T getCapability(BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context) {
+            if (!(level instanceof ServerLevel serverLevel)) {
+                return level.getCapability(capability, getBlockPos().relative(neighborSide), context);
+            }
 
-            // noinspection unchecked
-            return (TCapability) cache.getCapability();
+            var cachesByCapability = cachesByNeighbor.computeIfAbsent(neighborSide, d -> new HashMap<>());
+            var cachesByContext = cachesByCapability.computeIfAbsent(capability, c -> new HashMap<>());
+            var cache = cachesByContext.computeIfAbsent(context, c ->
+                BlockCapabilityCache.create(capability, serverLevel, getBlockPos().relative(neighborSide), context, () -> !isRemoved(), invalidationListener));
+
+            //noinspection unchecked
+            return (T)cache.getCapability();
         }
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/network/ConduitNodeImpl.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/network/ConduitNodeImpl.java
@@ -225,19 +225,10 @@ public final class ConduitNodeImpl implements INetworkNode<ConduitNetworkImpl, C
     // region World Interaction
 
     @Override
-    public <TCapability> TCapability getNeighborSidedCapability(BlockCapability<TCapability, Direction> capability,
-            Direction side) {
+    public @Nullable <T, C> T getCapability(BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context) {
         ensureValid();
         // noinspection DataFlowIssue
-        return conduitBundle.getNeighborSidedCapability(conduit, capability, side);
-    }
-
-    @Override
-    public <TCapability> TCapability getNeighborVoidCapability(BlockCapability<TCapability, Void> capability,
-            Direction side) {
-        ensureValid();
-        // noinspection DataFlowIssue
-        return conduitBundle.getNeighborVoidCapability(conduit, capability, side);
+        return conduitBundle.getCapability(conduit, capability, neighborSide, context);
     }
 
     @Override

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/network/IConduitNodeAttachment.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/network/IConduitNodeAttachment.java
@@ -23,12 +23,7 @@ public interface IConduitNodeAttachment {
     void markNodesDirty();
 
     @Nullable
-    <TCapability> TCapability getNeighborSidedCapability(Holder<Conduit<?, ?>> conduit,
-        BlockCapability<TCapability, Direction> capability, Direction side);
-
-    @Nullable
-    <TCapability> TCapability getNeighborVoidCapability(Holder<Conduit<?, ?>> conduit,
-        BlockCapability<TCapability, Void> capability, Direction side);
+    <T, C> T getCapability(Holder<Conduit<?, ?>> conduit, BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context);
 
     boolean hasRedstoneSignal(@Nullable DyeColor signalColor);
 

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/type/energy/EnergyConduit.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/type/energy/EnergyConduit.java
@@ -2,6 +2,7 @@ package com.enderio.enderio.content.conduits.type.energy;
 
 import com.enderio.core.common.util.TooltipUtil;
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.connection.ConnectionStatus;
 import com.enderio.enderio.api.conduits.connection.path.ConnectionPathProperty;
@@ -22,6 +23,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.Capabilities;
@@ -62,9 +64,8 @@ public record EnergyConduit(ResourceLocation texture, Component description, int
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
-        IEnergyStorage capability = level.getCapability(Capabilities.EnergyStorage.BLOCK,
-                conduitPos.relative(direction), direction.getOpposite());
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        IEnergyStorage capability = capabilityAccessor.getSidedCapability(Capabilities.EnergyStorage.BLOCK, direction);
         return capability != null;
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/type/fluid/FluidConduit.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/type/fluid/FluidConduit.java
@@ -3,6 +3,7 @@ package com.enderio.enderio.content.conduits.type.fluid;
 import com.enderio.core.common.util.TooltipUtil;
 import com.enderio.enderio.api.EnderIOCapabilities;
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.bundle.ConduitBundle;
 import com.enderio.enderio.api.conduits.bundle.SlotType;
@@ -29,6 +30,7 @@ import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.capabilities.Capabilities;
@@ -81,9 +83,8 @@ public record FluidConduit(ResourceLocation texture, Component description, int 
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
-        IFluidHandler capability = level.getCapability(Capabilities.FluidHandler.BLOCK, conduitPos.relative(direction),
-                direction.getOpposite());
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        IFluidHandler capability = capabilityAccessor.getSidedCapability(Capabilities.FluidHandler.BLOCK, direction);
         return capability != null;
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/type/item/ItemConduit.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/type/item/ItemConduit.java
@@ -3,6 +3,7 @@ package com.enderio.enderio.content.conduits.type.item;
 import com.enderio.core.common.util.TooltipUtil;
 import com.enderio.enderio.api.EnderIOCapabilities;
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.bundle.ConduitBundle;
 import com.enderio.enderio.api.conduits.bundle.SlotType;
@@ -29,6 +30,7 @@ import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.items.IItemHandler;
@@ -105,9 +107,8 @@ public record ItemConduit(ResourceLocation texture, Component description, int t
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
-        IItemHandler capability = level.getCapability(Capabilities.ItemHandler.BLOCK, conduitPos.relative(direction),
-                direction.getOpposite());
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
+        IItemHandler capability = capabilityAccessor.getSidedCapability(Capabilities.ItemHandler.BLOCK, direction);
         return capability != null;
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/type/redstone/RedstoneConduit.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/type/redstone/RedstoneConduit.java
@@ -2,6 +2,7 @@ package com.enderio.enderio.content.conduits.type.redstone;
 
 import com.enderio.enderio.api.EnderIOCapabilities;
 import com.enderio.enderio.api.conduits.Conduit;
+import com.enderio.enderio.api.conduits.ConduitCapabilityAccessor;
 import com.enderio.enderio.api.conduits.ConduitType;
 import com.enderio.enderio.api.conduits.bundle.ConduitBundle;
 import com.enderio.enderio.api.conduits.bundle.SlotType;
@@ -20,6 +21,7 @@ import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +57,7 @@ public record RedstoneConduit(ResourceLocation texture, ResourceLocation activeT
     }
 
     @Override
-    public boolean canConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
+    public boolean canConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
         BlockPos neighbor = conduitPos.relative(direction);
         BlockState blockState = level.getBlockState(neighbor);
         return blockState.is(EIOTags.Blocks.REDSTONE_CONNECTABLE)
@@ -63,7 +65,7 @@ public record RedstoneConduit(ResourceLocation texture, ResourceLocation activeT
     }
 
     @Override
-    public boolean canForceConnectToBlock(Level level, BlockPos conduitPos, Direction direction) {
+    public boolean canForceConnectToBlock(Level level, ConduitCapabilityAccessor capabilityAccessor, BlockPos conduitPos, Direction direction) {
         BlockPos neighbor = conduitPos.relative(direction);
         BlockState blockState = level.getBlockState(neighbor);
         return !blockState.isAir();

--- a/enderio/src/test/java/com/enderio/enderio/conduits/tests/network/ConduitNodeTests.java
+++ b/enderio/src/test/java/com/enderio/enderio/conduits/tests/network/ConduitNodeTests.java
@@ -167,8 +167,8 @@ public class ConduitNodeTests {
 
         var conduitNode = new ConduitNodeImpl(itemConduit, BlockPos.ZERO);
 
-        Assertions.assertThrows(IllegalStateException.class, () -> conduitNode.getNeighborSidedCapability(Capabilities.EnergyStorage.BLOCK, Direction.UP));
-        Assertions.assertThrows(IllegalStateException.class, () -> conduitNode.getNeighborVoidCapability(EnderIOCapabilities.SOUL_BINDABLE_BLOCK, Direction.UP));
+        Assertions.assertThrows(IllegalStateException.class, () -> conduitNode.getSidedCapability(Capabilities.EnergyStorage.BLOCK, Direction.UP));
+        Assertions.assertThrows(IllegalStateException.class, () -> conduitNode.getCapability(EnderIOCapabilities.SOUL_BINDABLE_BLOCK, Direction.UP, null));
         Assertions.assertThrows(IllegalStateException.class, () -> conduitNode.hasRedstoneSignal(null));
         Assertions.assertThrows(IllegalStateException.class, () -> conduitNode.isConnectedToBlock(Direction.UP));
         Assertions.assertThrows(IllegalStateException.class, () -> conduitNode.isConnectedTo(Direction.UP));

--- a/enderio/src/test/java/com/enderio/enderio/conduits/tests/network/FakeConduitNodeAttachment.java
+++ b/enderio/src/test/java/com/enderio/enderio/conduits/tests/network/FakeConduitNodeAttachment.java
@@ -51,14 +51,7 @@ public class FakeConduitNodeAttachment implements IConduitNodeAttachment {
     }
 
     @Override
-    public <TCapability> @Nullable TCapability getNeighborSidedCapability(Holder<Conduit<?, ?>> conduit, BlockCapability<TCapability, Direction> capability,
-        Direction side) {
-        return null;
-    }
-
-    @Override
-    public <TCapability> @Nullable TCapability getNeighborVoidCapability(Holder<Conduit<?, ?>> conduit, BlockCapability<TCapability, Void> capability,
-        Direction side) {
+    public @Nullable <T, C> T getCapability(Holder<Conduit<?, ?>> conduit, BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context) {
         return null;
     }
 

--- a/enderio/src/test/java/com/enderio/enderio/conduits/tests/network/pathing/FakeConduitNode.java
+++ b/enderio/src/test/java/com/enderio/enderio/conduits/tests/network/pathing/FakeConduitNode.java
@@ -130,25 +130,12 @@ public class FakeConduitNode implements ConduitNode {
     public <T extends NodeData> void setNodeData(@Nullable T data) {
         throw new UnsupportedOperationException("Not needed for pathfinding tests");
     }
-    
+
     @Override
-    @Nullable
-    public <TCapability> TCapability getNeighborSidedCapability(
-        BlockCapability<TCapability, Direction> capability,
-        Direction side
-    ) {
+    public @Nullable <T, C> T getCapability(BlockCapability<T, C> capability, Direction neighborSide, @Nullable C context) {
         throw new UnsupportedOperationException("Not needed for pathfinding tests");
     }
-    
-    @Override
-    @Nullable
-    public <TCapability> TCapability getNeighborVoidCapability(
-        BlockCapability<TCapability, Void> capability,
-        Direction side
-    ) {
-        throw new UnsupportedOperationException("Not needed for pathfinding tests");
-    }
-    
+
     @Override
     public boolean hasRedstoneSignal(@Nullable DyeColor signalColor) {
         throw new UnsupportedOperationException("Not needed for pathfinding tests");


### PR DESCRIPTION
# Description

Provides access to cached capabilities in Conduit implementations - this enables conduits to react to invalidated capabilities better (by caching the cap in the first instance when checking a capability exists). Helps with support for blocks like the XyCraft Proxy.

# Breaking Changes

API changes *should* be backwards compatible.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
