### PR TITLE
fix: respect non-standard bucket fluid capabilities

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/InternalTankTasks.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/InternalTankTasks.java
@@ -4,6 +4,7 @@ import com.enderio.core.common.storage.ResourceStorage;
 import com.enderio.core.common.storage.slot.ResourceSlotId;
 import com.enderio.core.common.util.EnderResourceUtil;
 import com.enderio.enderio.foundation.block.entity.MachineBlockEntity;
+import com.enderio.enderio.foundation.inventory.MachineInventory;
 import com.enderio.enderio.foundation.inventory.SingleSlotAccess;
 import com.enderio.enderio.foundation.util.ExperienceUtil;
 import net.minecraft.core.registries.Registries;
@@ -20,8 +21,86 @@ import net.neoforged.neoforge.transfer.access.ItemAccess;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 public class InternalTankTasks {
+
+    private record SingleItemOutputAccess(MachineInventory inventory, SingleSlotAccess inputSlot, SingleSlotAccess outputSlot) implements ItemAccess {
+        @Override
+        public ItemResource getResource() {
+            return inputSlot.getResource(inventory);
+        }
+
+        @Override
+        public int getAmount() {
+            return Math.min(1, inventory.getAmountAsInt(inputSlot.getIndex()));
+        }
+
+        @Override
+        public int insert(ItemResource resource, int amount, TransactionContext transaction) {
+            // NeoForge currently requires a non-empty returned item, but may later allow null
+            // to mean "the source item was consumed without a remainder".
+            if (resource == null) {
+                return Math.min(amount, 1);
+            }
+
+            return outputSlot.insert(inventory, resource, Math.min(amount, 1), transaction);
+        }
+
+        @Override
+        public int extract(ItemResource resource, int amount, TransactionContext transaction) {
+            return inventory.extract(inputSlot.getIndex(), resource, Math.min(amount, 1), transaction);
+        }
+    }
+
+    private static int getSingleItemFluidAmount(ItemAccess itemAccess) {
+        var fluidHandlerItem = itemAccess.getCapability(Capabilities.Fluid.ITEM);
+        for (int i = 0; i < fluidHandlerItem.size(); i++) {
+            FluidResource resource = fluidHandlerItem.getResource(i);
+            int amount = fluidHandlerItem.getAmountAsInt(i);
+
+            if (!resource.isEmpty() && amount > 0) {
+                return amount;
+            }
+        }
+
+        return 0;
+    }
+
+    private static <T extends MachineBlockEntity> boolean tryFillNonStandardBucketItem(
+        T blockEntity,
+        ResourceStorage<FluidResource> fluidStorage,
+        ResourceSlotId<FluidResource> tankSlot,
+        SingleSlotAccess fluidFillInput,
+        SingleSlotAccess fluidFillOutput
+    ) {
+        ItemStack inputItem = fluidFillInput.getItemStack(blockEntity);
+        if (!(inputItem.getItem() instanceof BucketItem) || inputItem.getItem().getClass() == BucketItem.class) {
+            return false;
+        }
+
+        ItemAccess itemAccess = new SingleItemOutputAccess(blockEntity.getInventory(), fluidFillInput, fluidFillOutput);
+        var fluidHandlerItem = itemAccess.getCapability(Capabilities.Fluid.ITEM);
+        if (fluidHandlerItem == null) {
+            return false;
+        }
+
+        int containedAmount = getSingleItemFluidAmount(itemAccess);
+        if (containedAmount <= 0) {
+            return false;
+        }
+
+        // Non-standard BucketItem subclasses can advertise custom amounts or remainders through their capability.
+        // Use the capability exchange path so their returned item is preserved in the output slot.
+        try (Transaction transaction = Transaction.openRoot()) {
+            int moved = EnderResourceUtil.moveInto(fluidHandlerItem, fluidStorage, tankSlot, fr -> true, containedAmount, transaction);
+            if (moved == containedAmount) {
+                transaction.commit();
+            }
+        }
+
+        return true;
+    }
 
     // TODO: enable fluid tanks to receive stackable fluid containers
     public static <T extends MachineBlockEntity> void fillInternal(
@@ -35,6 +114,10 @@ public class InternalTankTasks {
         ItemStack outputItem = fluidFillOutput.getItemStack(blockEntity);
 
         if (!inputItem.isEmpty()) {
+            if (tryFillNonStandardBucketItem(blockEntity, fluidStorage, tankSlot, fluidFillInput, fluidFillOutput)) {
+                return;
+            }
+
             if (inputItem.getItem() instanceof BucketItem filledBucket && !filledBucket.content.isSame(Fluids.EMPTY)) {
                 if (outputItem.isEmpty() || (outputItem.getItem() == Items.BUCKET
                     && outputItem.getCount() < outputItem.getMaxStackSize())) {


### PR DESCRIPTION


# Description

Handle BucketItem subclasses that expose a non-bucket fluid amount via `Capabilities.Fluid.ITEM` before the vanilla bucket check. 

Some mods, such as [BBL Strainers' Fluid Drops](https://github.com/bbl-team/Strainers/blob/e2e0f52888608f7a5a496b2d41ec1f30e16ea177/src/main/java/com/benbenlaw/strainers/item/util/FluidDropResourceHandler.java), extend `BucketItem` while exposing a custom fluid amount and returned item through their fluid capability. In this case, one fluid drop is 250 mB and returns its own remainder item.

The current tank logic checks `instanceof BucketItem` first, so these items are processed as vanilla buckets. This makes a 250 mB item into 1000 mB of fluid and creates an empty bucket from the tank output.
  
<img width="393" height="204" alt="image" src="https://github.com/user-attachments/assets/47d7bed1-0963-4b42-9c3e-71643b9ae63e" />

by checking non-vanilla `BucketItem` subclasses for a fluid capability first. If the capability sees a non-bucket amount, the tank transfers that exact amount and preserves the capability-provided returned item.

<img width="726" height="348" alt="image" src="https://github.com/user-attachments/assets/a9d046a9-33b8-4de8-8ba1-11a5b6e13434" />

(Note that stick in output slot is intended. check BBL Strainer's code mentioned above.)


# TODO

- [ ] If this is a draft, populate this with remaining tasks. Otherwise, remove this section.

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [ ] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
