### PR TITLE
fix: travel anchor rendering

### DIFF
--- a/endercore/src/main/java/com/enderio/core/client/TravelRendererUtil.java
+++ b/endercore/src/main/java/com/enderio/core/client/TravelRendererUtil.java
@@ -1,0 +1,151 @@
+package com.enderio.core.client;
+
+import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import it.unimi.dsi.fastutil.objects.Object2ObjectSortedMaps;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.OutlineBufferSource;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.renderer.SubmitNodeStorage;
+import net.minecraft.client.renderer.block.BlockModelRenderState;
+import net.minecraft.client.renderer.block.model.BlockDisplayContext;
+import net.minecraft.client.renderer.block.model.BlockModel;
+import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.util.ARGB;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.common.util.Lazy;
+
+public class TravelRendererUtil {
+
+    private TravelRendererUtil() {
+
+    }
+
+    public static final BackdropTintingBufferSource FEATURE_BUFFER = new BackdropTintingBufferSource();
+    public static final OutlineBufferSource FEATURE_OUTLINE_BUFFER = new OutlineBufferSource();
+    public static final MultiBufferSource.BufferSource TEXT_BUFFER = MultiBufferSource.immediate(new ByteBufferBuilder(RenderType.SMALL_BUFFER_SIZE));
+
+    public static final FeatureRenderDispatcher FEATURE = new FeatureRenderDispatcher(
+        new SubmitNodeStorage(),
+        Minecraft.getInstance().getModelManager(),
+        FEATURE_BUFFER,
+        Minecraft.getInstance().getAtlasManager(),
+        FEATURE_OUTLINE_BUFFER,
+        Minecraft.getInstance().renderBuffers().crumblingBufferSource(),
+        Minecraft.getInstance().font,
+        Minecraft.getInstance().gameRenderer.getGameRenderState()
+    );
+
+    public static final SubmitNodeStorage NODE = FEATURE.getSubmitNodeStorage();
+
+    public static void renderFeatures() {
+        FEATURE.renderAllFeatures();
+        FEATURE_BUFFER.endBatch();
+        FEATURE_OUTLINE_BUFFER.endOutlineBatch();
+    }
+
+    public static void renderBackdrop(PoseStack poseStack, int packedLight, int color, Lazy<BlockModel> model) {
+        BlockModelRenderState renderState = new BlockModelRenderState();
+        model.get().update(renderState, Blocks.AIR.defaultBlockState(), BlockDisplayContext.create(), 42);
+
+        FEATURE_BUFFER.setTintColor(color);
+        try {
+            renderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
+            renderFeatures();
+        } finally {
+            FEATURE_BUFFER.clearTintColor();
+        }
+    }
+
+    public static void renderBlockModel(PoseStack poseStack, BlockState blockState, int packedLight) {
+        BlockModelRenderState modelRenderState = new BlockModelRenderState();
+        Minecraft.getInstance().getBlockModelResolver().update(modelRenderState, blockState, BlockDisplayContext.create());
+
+        modelRenderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
+        renderFeatures();
+    }
+
+    public static class BackdropTintingBufferSource extends MultiBufferSource.BufferSource {
+
+        private int tintColor = -1;
+
+        private BackdropTintingBufferSource() {
+            super(new ByteBufferBuilder(RenderType.SMALL_BUFFER_SIZE), Object2ObjectSortedMaps.emptyMap());
+        }
+
+        public void setTintColor(int tintColor) {
+            this.tintColor = tintColor;
+        }
+
+        public void clearTintColor() {
+            this.tintColor = -1;
+        }
+
+        @Override
+        public VertexConsumer getBuffer(RenderType renderType) {
+            if (this.tintColor != -1) {
+                // Tinting is only used for the standalone backdrop model, which must stay translucent.
+                renderType = Sheets.translucentBlockItemSheet();
+            }
+
+            VertexConsumer buffer = super.getBuffer(renderType);
+            return this.tintColor == -1 ? buffer : new TintingVertexConsumer(buffer, this.tintColor);
+        }
+    }
+
+    public record TintingVertexConsumer(VertexConsumer delegate, int tintColor) implements VertexConsumer {
+
+        @Override
+        public VertexConsumer addVertex(float x, float y, float z) {
+            this.delegate.addVertex(x, y, z);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int r, int g, int b, int a) {
+            this.delegate.setColor(ARGB.multiply(ARGB.color(a, r, g, b), this.tintColor));
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int color) {
+            this.delegate.setColor(ARGB.multiply(color, this.tintColor));
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv(float u, float v) {
+            this.delegate.setUv(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv1(int u, int v) {
+            this.delegate.setUv1(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv2(int u, int v) {
+            this.delegate.setUv2(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setNormal(float x, float y, float z) {
+            this.delegate.setNormal(x, y, z);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setLineWidth(float width) {
+            this.delegate.setLineWidth(width);
+            return this;
+        }
+    }
+}

--- a/enderio/src/main/java/com/enderio/enderio/client/EIOPipelineModifiers.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/EIOPipelineModifiers.java
@@ -3,8 +3,6 @@ package com.enderio.enderio.client;
 import com.enderio.enderio.EnderIO;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
-import com.mojang.blaze3d.pipeline.DepthStencilState;
-import com.mojang.blaze3d.platform.CompareOp;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.ResourceKey;
 import net.neoforged.api.distmarker.Dist;
@@ -20,11 +18,6 @@ public class EIOPipelineModifiers {
      */
     public static final ResourceKey<PipelineModifier> FORCE_TRANSLUCENT = ResourceKey.create(PipelineModifier.MODIFIERS_KEY, EnderIO.id("force_translucent"));
 
-    /**
-     * Kept available for addon/client renderers that need to draw through existing depth.
-     */
-    public static final ResourceKey<PipelineModifier> FORCE_NO_DEPTH = ResourceKey.create(PipelineModifier.MODIFIERS_KEY, EnderIO.id("force_no_depth"));
-
     @SubscribeEvent
     public static void onRegisterModifiers(RegisterPipelineModifiersEvent event)
     {
@@ -38,20 +31,6 @@ public class EIOPipelineModifiers {
                     .build();
             }
             return pipeline;
-        });
-
-        event.register(FORCE_NO_DEPTH, (pipeline, name) ->
-        {
-            DepthStencilState depthStencilState = pipeline.getDepthStencilState();
-            if (depthStencilState == null) {
-                return pipeline;
-            }
-
-            return pipeline.toBuilder()
-                .withLocation(name)
-                .withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, false, depthStencilState.depthBiasScaleFactor(),
-                    depthStencilState.depthBiasConstant()))
-                .build();
         });
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/client/EIOPipelineModifiers.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/EIOPipelineModifiers.java
@@ -19,6 +19,10 @@ public class EIOPipelineModifiers {
      * Force ENTITY_CUTOUT, ENTITY_CUTOUT_CULLED and ENTITY_SOLID to blend.
      */
     public static final ResourceKey<PipelineModifier> FORCE_TRANSLUCENT = ResourceKey.create(PipelineModifier.MODIFIERS_KEY, EnderIO.id("force_translucent"));
+
+    /**
+     * Kept available for addon/client renderers that need to draw through existing depth.
+     */
     public static final ResourceKey<PipelineModifier> FORCE_NO_DEPTH = ResourceKey.create(PipelineModifier.MODIFIERS_KEY, EnderIO.id("force_no_depth"));
 
     @SubscribeEvent
@@ -36,10 +40,18 @@ public class EIOPipelineModifiers {
             return pipeline;
         });
 
-        event.register(FORCE_NO_DEPTH, (pipeline, name) -> pipeline.toBuilder()
-                    .withLocation(name)
-                    .withDepthStencilState(new DepthStencilState(CompareOp.GREATER_THAN, true, pipeline.getDepthStencilState().depthBiasScaleFactor(),
-                        pipeline.getDepthStencilState().depthBiasConstant()))
-                    .build());
+        event.register(FORCE_NO_DEPTH, (pipeline, name) ->
+        {
+            DepthStencilState depthStencilState = pipeline.getDepthStencilState();
+            if (depthStencilState == null) {
+                return pipeline;
+            }
+
+            return pipeline.toBuilder()
+                .withLocation(name)
+                .withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, false, depthStencilState.depthBiasScaleFactor(),
+                    depthStencilState.depthBiasConstant()))
+                .build();
+        });
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
@@ -1,29 +1,34 @@
 package com.enderio.enderio.client.content.travel;
 
 import com.enderio.enderio.api.travel.TravelRenderer;
-import com.enderio.enderio.client.EIOPipelineModifiers;
 import com.enderio.enderio.client.EnderIOClient;
-import com.enderio.enderio.client.foundation.renderer.OutlineBuffer;
-import com.enderio.enderio.compat.ModCompatHelper;
 import com.enderio.enderio.content.travel.travel_anchor.AnchorTravelTarget;
 import com.enderio.enderio.content.travel.travel_anchor.PaintedTravelAnchorBlockEntity;
-import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
+import it.unimi.dsi.fastutil.objects.Object2ObjectSortedMaps;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.OutlineBufferSource;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
 import net.minecraft.client.renderer.block.model.BlockDisplayContext;
 import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
+import net.minecraft.client.renderer.item.ItemStackRenderState;
+import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.LightCoordsUtil;
+import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
@@ -48,12 +53,16 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
         return minecraft.getModelManager().getStandaloneModel(EnderIOClient.TRAVEL_ANCHOR_BACKDROP);
     });
 
+    private static final BackdropTintingBufferSource FEATURE_BUFFER = new BackdropTintingBufferSource();
+    private static final OutlineBufferSource FEATURE_OUTLINE_BUFFER = new OutlineBufferSource();
+    private static final MultiBufferSource.BufferSource TEXT_BUFFER = MultiBufferSource.immediate(new ByteBufferBuilder(RenderType.SMALL_BUFFER_SIZE));
+
     public static FeatureRenderDispatcher FEATURE = new FeatureRenderDispatcher(
         new SubmitNodeStorage(),
         Minecraft.getInstance().getModelManager(),
-        Minecraft.getInstance().renderBuffers().bufferSource(),
+        FEATURE_BUFFER,
         Minecraft.getInstance().getAtlasManager(),
-        Minecraft.getInstance().renderBuffers().outlineBufferSource(),
+        FEATURE_OUTLINE_BUFFER,
         Minecraft.getInstance().renderBuffers().crumblingBufferSource(),
         Minecraft.getInstance().font,
         Minecraft.getInstance().gameRenderer.getGameRenderState()
@@ -61,6 +70,32 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
 
     public static SubmitNodeStorage NODE = FEATURE.getSubmitNodeStorage();
 
+    private static void renderFeatures() {
+        FEATURE.renderAllFeatures();
+        FEATURE_BUFFER.endBatch();
+        FEATURE_OUTLINE_BUFFER.endOutlineBatch();
+    }
+
+    private static void renderBackdrop(PoseStack poseStack, int packedLight, int color) {
+        BlockModelRenderState renderState = new BlockModelRenderState();
+        BACKDROP.get().update(renderState, Blocks.AIR.defaultBlockState(), BlockDisplayContext.create(), 42);
+
+        FEATURE_BUFFER.setTintColor(color);
+        try {
+            renderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
+            renderFeatures();
+        } finally {
+            FEATURE_BUFFER.clearTintColor();
+        }
+    }
+
+    private static void renderBlockModel(PoseStack poseStack, BlockState blockState, int packedLight) {
+        BlockModelRenderState modelRenderState = new BlockModelRenderState();
+        Minecraft.getInstance().getBlockModelResolver().update(modelRenderState, blockState, BlockDisplayContext.create());
+
+        modelRenderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
+        renderFeatures();
+    }
 
     @Override
     public void render(AnchorTravelTarget travelData, LevelRenderer levelRenderer, PoseStack poseStack,
@@ -78,25 +113,24 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
         Vec3 towardsCamera = offsetToCamera.normalize();
         double distanceToCamera = offsetToCamera.length();
 
-        {
-            double anchorScale = (float) Math.sqrt(distanceToCamera);
-            if (active) {
-                anchorScale = anchorScale * 1.3;
-            }
-            anchorScale = anchorScale * (Math.sin(Math.toRadians(minecraft.options.fov().get() / 4d)));
-            anchorScale = Math.max(anchorScale, 1.0F);
+        double anchorScale = (float) Math.sqrt(distanceToCamera);
+        if (active) {
+            anchorScale = anchorScale * 1.3;
+        }
+        anchorScale = anchorScale * (Math.sin(Math.toRadians(minecraft.options.fov().get() / 4d)));
+        anchorScale = Math.max(anchorScale, 1.0F);
 
+        {
             poseStack.translate(0.5, 0.5, 0.5);
             float s = (float) anchorScale;
             poseStack.scale(s, s, s);
             poseStack.translate(-0.5, -0.5, -0.5);
         }
 
-        OutlineBuffer buffer = OutlineBuffer.INSTANCE;
         int outlineColor = 0xFF0B4D42;
         int textColor = 0xFFFFFFFF;
         if (active) {
-            textColor = ChatFormatting.AQUA.getColor() == null ? 0xFFFFFF : ChatFormatting.AQUA.getColor();
+            textColor = ChatFormatting.AQUA.getColor() == null ? 0xFFFFFFFF : ARGB.opaque(ChatFormatting.AQUA.getColor());
             outlineColor = textColor;
         }
         float outlineR = ((outlineColor & (0xFF << 16)) >> 16) / 255F;
@@ -108,25 +142,13 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
         boolean hasIcon = travelData.icon() != Items.AIR;
 
         if (!hasIcon) {
-            // Render Model
-            {
-                BlockState blockState = minecraft.level.getBlockState(travelData.pos());
-                if (minecraft.level.getBlockEntity(travelData.pos()) instanceof PaintedTravelAnchorBlockEntity paintedTravelAnchorBlock) {
-                    Optional<Block> paint = paintedTravelAnchorBlock.getPrimaryPaint();
+            BlockState blockState = minecraft.level.getBlockState(travelData.pos());
+            if (minecraft.level.getBlockEntity(travelData.pos()) instanceof PaintedTravelAnchorBlockEntity paintedTravelAnchorBlock) {
+                Optional<Block> paint = paintedTravelAnchorBlock.getPrimaryPaint();
 
-                    if (paint.isPresent()) {
-                        blockState = paint.get().defaultBlockState();
-                    }
+                if (paint.isPresent()) {
+                    blockState = paint.get().defaultBlockState();
                 }
-
-                BlockModelRenderState modelRenderState = new BlockModelRenderState();
-
-                BlockDisplayContext context = BlockDisplayContext.create();
-                Minecraft.getInstance().getBlockModelResolver().update(modelRenderState, blockState, context);
-
-                modelRenderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
-                FEATURE.renderAllFeatures();
-                Minecraft.getInstance().renderBuffers().bufferSource().endBatch();
             }
 
             // Render outline block
@@ -140,37 +162,13 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
                 poseStack.translate(offset.x, offset.y, offset.z);
                 poseStack.scale(scale, scale, scale);
 
-                BlockModelRenderState renderState = new BlockModelRenderState();
-                BACKDROP.get().update(renderState, Blocks.AIR.defaultBlockState(), BlockDisplayContext.create(), 42);
-                renderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB));
-
-                RenderSystem.pushPipelineModifier(EIOPipelineModifiers.FORCE_NO_DEPTH);
-                FEATURE.renderAllFeatures();
-                Minecraft.getInstance().renderBuffers().bufferSource().endBatch();
-                RenderSystem.popPipelineModifier();
+                renderBackdrop(poseStack, packedLight, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB));
 
                 poseStack.popPose();
             }
 
-            {
-                BlockState blockState = minecraft.level.getBlockState(travelData.pos());
-                if (minecraft.level.getBlockEntity(travelData.pos()) instanceof PaintedTravelAnchorBlockEntity paintedTravelAnchorBlock) {
-                    Optional<Block> paint = paintedTravelAnchorBlock.getPrimaryPaint();
-
-                    if (paint.isPresent()) {
-                        blockState = paint.get().defaultBlockState();
-                    }
-                }
-
-                BlockModelRenderState modelRenderState = new BlockModelRenderState();
-
-                BlockDisplayContext context = BlockDisplayContext.create();
-                Minecraft.getInstance().getBlockModelResolver().update(modelRenderState, blockState, context);
-
-                modelRenderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
-                FEATURE.renderAllFeatures();
-                Minecraft.getInstance().renderBuffers().bufferSource().endBatch();
-            }
+            // Render Model
+            renderBlockModel(poseStack, blockState, packedLight);
 
         } else {
             // Render Icon
@@ -193,19 +191,22 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
             }
 
             ItemStack stack = new ItemStack(travelData.icon());
-//            BakedModel bakedmodel = minecraft.getItemRenderer().getModel(stack, minecraft.level, null, 0);
-//            minecraft
-//                .getItemRenderer()
-//                .render(stack, ItemDisplayContext.GUI, false, poseStack, OutlineBuffer.INSTANCE, packedLight, OverlayTexture.NO_OVERLAY, bakedmodel);
+            ItemStackRenderState itemRenderState = new ItemStackRenderState();
+            minecraft.getItemModelResolver().updateForTopItem(itemRenderState, stack, ItemDisplayContext.GUI, minecraft.level, null, 0);
 
-            float s = 1.5F;
-            poseStack.scale(s, s, s);
-            poseStack.translate(-0.5, -0.5, -2);
-            poseStack.rotateAround(Axis.ZN.rotationDegrees(45), 0.5F, 0.5F, 0.5F);
+            poseStack.pushPose();
+            {
+                float s = 1.5F;
+                poseStack.scale(s, s, s);
+                poseStack.translate(-0.5, -0.5, -2);
+                poseStack.rotateAround(Axis.ZN.rotationDegrees(45), 0.5F, 0.5F, 0.5F);
 
-            BlockModelRenderState renderState = new BlockModelRenderState();
-            BACKDROP.get().update(renderState, Blocks.AIR.defaultBlockState(), BlockDisplayContext.create(), 42);
-            renderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB));
+                renderBackdrop(poseStack, packedLight, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB));
+            }
+            poseStack.popPose();
+
+            itemRenderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
+            renderFeatures();
 
             poseStack.popPose();
         }
@@ -241,27 +242,94 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
             int textBg1 = textBg;
             int textBg2 = 0;
 
-            if (ModCompatHelper.hasIris()) {
-                // required for text to render correctly, possibly an Iris bug
-                // is there a better way to draw text?
-                var _m = mode1;
-                mode1 = mode2;
-                mode2 = _m;
-
-                int _t = textBg1;
-                textBg1 = textBg2;
-                textBg2 = _t;
-            }
             Matrix4f matrix4f = poseStack.last().pose();
 
-            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, buffer, mode1, textBg1, packedLight);
-            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, buffer, mode2, textBg2, packedLight);
+            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, TEXT_BUFFER, mode1, textBg1, packedLight);
+            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, TEXT_BUFFER, mode2, textBg2, packedLight);
+            TEXT_BUFFER.endBatch();
 
             poseStack.popPose();
         }
 
         poseStack.popPose();
-        // Seems to work fine without this line, but leaving it here in case there are future buffer problems
-        // minecraft.renderBuffers().bufferSource().endBatch();
+    }
+
+    private static class BackdropTintingBufferSource extends MultiBufferSource.BufferSource {
+
+        private int tintColor = -1;
+
+        private BackdropTintingBufferSource() {
+            super(new ByteBufferBuilder(RenderType.SMALL_BUFFER_SIZE), Object2ObjectSortedMaps.emptyMap());
+        }
+
+        private void setTintColor(int tintColor) {
+            this.tintColor = tintColor;
+        }
+
+        private void clearTintColor() {
+            this.tintColor = -1;
+        }
+
+        @Override
+        public VertexConsumer getBuffer(RenderType renderType) {
+            if (this.tintColor != -1) {
+                // Tinting is only used for the standalone backdrop model, which must stay translucent.
+                renderType = Sheets.translucentBlockItemSheet();
+            }
+
+            VertexConsumer buffer = super.getBuffer(renderType);
+            return this.tintColor == -1 ? buffer : new TintingVertexConsumer(buffer, this.tintColor);
+        }
+    }
+
+    private record TintingVertexConsumer(VertexConsumer delegate, int tintColor) implements VertexConsumer {
+
+        @Override
+        public VertexConsumer addVertex(float x, float y, float z) {
+            this.delegate.addVertex(x, y, z);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int r, int g, int b, int a) {
+            this.delegate.setColor(ARGB.multiply(ARGB.color(a, r, g, b), this.tintColor));
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int color) {
+            this.delegate.setColor(ARGB.multiply(color, this.tintColor));
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv(float u, float v) {
+            this.delegate.setUv(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv1(int u, int v) {
+            this.delegate.setUv1(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv2(int u, int v) {
+            this.delegate.setUv2(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setNormal(float x, float y, float z) {
+            this.delegate.setNormal(x, y, z);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setLineWidth(float width) {
+            this.delegate.setLineWidth(width);
+            return this;
+        }
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
@@ -237,15 +237,9 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
             int textBg = (int) (textOpacitySetting * 255) << 24;
             float halfWidth = (float) (-minecraft.font.width(textComponent) / 2);
 
-            var mode1 = Font.DisplayMode.SEE_THROUGH;
-            var mode2 = Font.DisplayMode.NORMAL;
-            int textBg1 = textBg;
-            int textBg2 = 0;
-
             Matrix4f matrix4f = poseStack.last().pose();
 
-            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, TEXT_BUFFER, mode1, textBg1, packedLight);
-            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, TEXT_BUFFER, mode2, textBg2, packedLight);
+            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, TEXT_BUFFER, Font.DisplayMode.SEE_THROUGH, textBg, packedLight);
             TEXT_BUFFER.endBatch();
 
             poseStack.popPose();

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelAnchorRenderer.java
@@ -1,29 +1,19 @@
 package com.enderio.enderio.client.content.travel;
 
+import com.enderio.core.client.TravelRendererUtil;
 import com.enderio.enderio.api.travel.TravelRenderer;
 import com.enderio.enderio.client.EnderIOClient;
 import com.enderio.enderio.content.travel.travel_anchor.AnchorTravelTarget;
 import com.enderio.enderio.content.travel.travel_anchor.PaintedTravelAnchorBlockEntity;
-import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
-import it.unimi.dsi.fastutil.objects.Object2ObjectSortedMaps;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.OutlineBufferSource;
-import net.minecraft.client.renderer.Sheets;
-import net.minecraft.client.renderer.SubmitNodeStorage;
-import net.minecraft.client.renderer.block.BlockModelRenderState;
-import net.minecraft.client.renderer.block.model.BlockDisplayContext;
 import net.minecraft.client.renderer.block.model.BlockModel;
-import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
-import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.ARGB;
@@ -32,7 +22,6 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.util.Lazy;
@@ -52,50 +41,6 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
 
         return minecraft.getModelManager().getStandaloneModel(EnderIOClient.TRAVEL_ANCHOR_BACKDROP);
     });
-
-    private static final BackdropTintingBufferSource FEATURE_BUFFER = new BackdropTintingBufferSource();
-    private static final OutlineBufferSource FEATURE_OUTLINE_BUFFER = new OutlineBufferSource();
-    private static final MultiBufferSource.BufferSource TEXT_BUFFER = MultiBufferSource.immediate(new ByteBufferBuilder(RenderType.SMALL_BUFFER_SIZE));
-
-    public static FeatureRenderDispatcher FEATURE = new FeatureRenderDispatcher(
-        new SubmitNodeStorage(),
-        Minecraft.getInstance().getModelManager(),
-        FEATURE_BUFFER,
-        Minecraft.getInstance().getAtlasManager(),
-        FEATURE_OUTLINE_BUFFER,
-        Minecraft.getInstance().renderBuffers().crumblingBufferSource(),
-        Minecraft.getInstance().font,
-        Minecraft.getInstance().gameRenderer.getGameRenderState()
-    );
-
-    public static SubmitNodeStorage NODE = FEATURE.getSubmitNodeStorage();
-
-    private static void renderFeatures() {
-        FEATURE.renderAllFeatures();
-        FEATURE_BUFFER.endBatch();
-        FEATURE_OUTLINE_BUFFER.endOutlineBatch();
-    }
-
-    private static void renderBackdrop(PoseStack poseStack, int packedLight, int color) {
-        BlockModelRenderState renderState = new BlockModelRenderState();
-        BACKDROP.get().update(renderState, Blocks.AIR.defaultBlockState(), BlockDisplayContext.create(), 42);
-
-        FEATURE_BUFFER.setTintColor(color);
-        try {
-            renderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
-            renderFeatures();
-        } finally {
-            FEATURE_BUFFER.clearTintColor();
-        }
-    }
-
-    private static void renderBlockModel(PoseStack poseStack, BlockState blockState, int packedLight) {
-        BlockModelRenderState modelRenderState = new BlockModelRenderState();
-        Minecraft.getInstance().getBlockModelResolver().update(modelRenderState, blockState, BlockDisplayContext.create());
-
-        modelRenderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
-        renderFeatures();
-    }
 
     @Override
     public void render(AnchorTravelTarget travelData, LevelRenderer levelRenderer, PoseStack poseStack,
@@ -162,13 +107,13 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
                 poseStack.translate(offset.x, offset.y, offset.z);
                 poseStack.scale(scale, scale, scale);
 
-                renderBackdrop(poseStack, packedLight, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB));
+                TravelRendererUtil.renderBackdrop(poseStack, packedLight, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB), BACKDROP);
 
                 poseStack.popPose();
             }
 
             // Render Model
-            renderBlockModel(poseStack, blockState, packedLight);
+            TravelRendererUtil.renderBlockModel(poseStack, blockState, packedLight);
 
         } else {
             // Render Icon
@@ -201,12 +146,12 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
                 poseStack.translate(-0.5, -0.5, -2);
                 poseStack.rotateAround(Axis.ZN.rotationDegrees(45), 0.5F, 0.5F, 0.5F);
 
-                renderBackdrop(poseStack, packedLight, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB));
+                TravelRendererUtil.renderBackdrop(poseStack, packedLight, ARGB.colorFromFloat(1, outlineR, outlineG, outlineB), BACKDROP);
             }
             poseStack.popPose();
 
-            itemRenderState.submit(poseStack, NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
-            renderFeatures();
+            itemRenderState.submit(poseStack, TravelRendererUtil.NODE, packedLight, OverlayTexture.NO_OVERLAY, 0);
+            TravelRendererUtil.renderFeatures();
 
             poseStack.popPose();
         }
@@ -239,91 +184,12 @@ public class TravelAnchorRenderer implements TravelRenderer<AnchorTravelTarget> 
 
             Matrix4f matrix4f = poseStack.last().pose();
 
-            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, TEXT_BUFFER, Font.DisplayMode.SEE_THROUGH, textBg, packedLight);
-            TEXT_BUFFER.endBatch();
+            minecraft.font.drawInBatch(textComponent, halfWidth, 0, textColor, false, matrix4f, TravelRendererUtil.TEXT_BUFFER, Font.DisplayMode.SEE_THROUGH, textBg, packedLight);
+            TravelRendererUtil.TEXT_BUFFER.endBatch();
 
             poseStack.popPose();
         }
 
         poseStack.popPose();
-    }
-
-    private static class BackdropTintingBufferSource extends MultiBufferSource.BufferSource {
-
-        private int tintColor = -1;
-
-        private BackdropTintingBufferSource() {
-            super(new ByteBufferBuilder(RenderType.SMALL_BUFFER_SIZE), Object2ObjectSortedMaps.emptyMap());
-        }
-
-        private void setTintColor(int tintColor) {
-            this.tintColor = tintColor;
-        }
-
-        private void clearTintColor() {
-            this.tintColor = -1;
-        }
-
-        @Override
-        public VertexConsumer getBuffer(RenderType renderType) {
-            if (this.tintColor != -1) {
-                // Tinting is only used for the standalone backdrop model, which must stay translucent.
-                renderType = Sheets.translucentBlockItemSheet();
-            }
-
-            VertexConsumer buffer = super.getBuffer(renderType);
-            return this.tintColor == -1 ? buffer : new TintingVertexConsumer(buffer, this.tintColor);
-        }
-    }
-
-    private record TintingVertexConsumer(VertexConsumer delegate, int tintColor) implements VertexConsumer {
-
-        @Override
-        public VertexConsumer addVertex(float x, float y, float z) {
-            this.delegate.addVertex(x, y, z);
-            return this;
-        }
-
-        @Override
-        public VertexConsumer setColor(int r, int g, int b, int a) {
-            this.delegate.setColor(ARGB.multiply(ARGB.color(a, r, g, b), this.tintColor));
-            return this;
-        }
-
-        @Override
-        public VertexConsumer setColor(int color) {
-            this.delegate.setColor(ARGB.multiply(color, this.tintColor));
-            return this;
-        }
-
-        @Override
-        public VertexConsumer setUv(float u, float v) {
-            this.delegate.setUv(u, v);
-            return this;
-        }
-
-        @Override
-        public VertexConsumer setUv1(int u, int v) {
-            this.delegate.setUv1(u, v);
-            return this;
-        }
-
-        @Override
-        public VertexConsumer setUv2(int u, int v) {
-            this.delegate.setUv2(u, v);
-            return this;
-        }
-
-        @Override
-        public VertexConsumer setNormal(float x, float y, float z) {
-            this.delegate.setNormal(x, y, z);
-            return this;
-        }
-
-        @Override
-        public VertexConsumer setLineWidth(float width) {
-            this.delegate.setLineWidth(width);
-            return this;
-        }
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelTargetRendering.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelTargetRendering.java
@@ -87,44 +87,4 @@ public class TravelTargetRendering {
             event.getRenderState().setRenderData(DATA_KEY, renderStates);
         }
     }
-
-//    @SubscribeEvent
-//    public static void renderLevel(RenderLevelStageEvent.AfterWeather event) {
-//        List<ExtractTravelTarget> renderStates = event.getLevelRenderState().getRenderData(DATA_KEY);
-//        if (renderStates == null) {
-//            return;
-//        }
-//
-//        RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
-//        if (mainTarget.getDepthTexture() != null) {
-//            RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mainTarget.getDepthTexture(), 1.0);
-//        }
-//
-//        renderStates.sort(Comparator.comparingDouble(ExtractTravelTarget::distanceSquared).reversed());
-//        var previousColorTextureOverride = RenderSystem.outputColorTextureOverride;
-//        var previousDepthTextureOverride = RenderSystem.outputDepthTextureOverride;
-//        try {
-//            RenderSystem.outputColorTextureOverride = mainTarget.getColorTextureView();
-//            RenderSystem.outputDepthTextureOverride = mainTarget.getDepthTextureView();
-//
-//            for (ExtractTravelTarget state : renderStates) {
-//                PoseStack poseStack = event.getPoseStack();
-//                poseStack.pushPose();
-//                Vec3 projectedView = event.getLevelRenderState().cameraRenderState.pos;
-//                poseStack.translate(
-//                    state.target.pos().getX() - projectedView.x,
-//                    state.target.pos().getY() - projectedView.y,
-//                    state.target.pos().getZ() - projectedView.z);
-//
-//                // needed for smooth rendering
-//                // the boolean value controls whether it's still smooth while the game world is
-//                // paused (e.g. /tick freeze)
-//                render(state.target, event.getLevelRenderer(), poseStack, state.distanceSquared, state.active, state.partialTick);
-//                poseStack.popPose();
-//            }
-//        } finally {
-//            RenderSystem.outputColorTextureOverride = previousColorTextureOverride;
-//            RenderSystem.outputDepthTextureOverride = previousDepthTextureOverride;
-//        }
-//    }
 }

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelTargetRendering.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelTargetRendering.java
@@ -8,6 +8,8 @@ import com.enderio.enderio.api.travel.TravelTargetApi;
 import com.enderio.enderio.api.travel.TravelTargetType;
 import com.enderio.enderio.client.content.keymaps.KeymapHandler;
 import com.enderio.enderio.content.travel.TravelHandler;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -24,6 +26,7 @@ import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,27 +93,43 @@ public class TravelTargetRendering {
         }
     }
 
-    // TODO: 26.1: Check this render stage is right.
     @SubscribeEvent
-    public static void renderLevel(RenderLevelStageEvent.AfterTranslucentBlocks event) {
+    public static void renderLevel(RenderLevelStageEvent.AfterWeather event) {
         List<ExtractTravelTarget> renderStates = event.getLevelRenderState().getRenderData(DATA_KEY);
         if (renderStates == null) {
             return;
         }
-        for (ExtractTravelTarget state : renderStates) {
-            PoseStack poseStack = event.getPoseStack();
-            poseStack.pushPose();
-            Vec3 projectedView = event.getLevelRenderState().cameraRenderState.pos;
-            poseStack.translate(
-                state.target.pos().getX() - projectedView.x,
-                state.target.pos().getY() - projectedView.y,
-                state.target.pos().getZ() - projectedView.z);
 
-            // needed for smooth rendering
-            // the boolean value controls whether it's still smooth while the game world is
-            // paused (e.g. /tick freeze)
-            render(state.target, event.getLevelRenderer(), poseStack, state.distanceSquared, state.active, state.partialTick);
-            poseStack.popPose();
+        RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
+        if (mainTarget.getDepthTexture() != null) {
+            RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mainTarget.getDepthTexture(), 1.0);
+        }
+
+        renderStates.sort(Comparator.comparingDouble(ExtractTravelTarget::distanceSquared).reversed());
+        var previousColorTextureOverride = RenderSystem.outputColorTextureOverride;
+        var previousDepthTextureOverride = RenderSystem.outputDepthTextureOverride;
+        try {
+            RenderSystem.outputColorTextureOverride = mainTarget.getColorTextureView();
+            RenderSystem.outputDepthTextureOverride = mainTarget.getDepthTextureView();
+
+            for (ExtractTravelTarget state : renderStates) {
+                PoseStack poseStack = event.getPoseStack();
+                poseStack.pushPose();
+                Vec3 projectedView = event.getLevelRenderState().cameraRenderState.pos;
+                poseStack.translate(
+                    state.target.pos().getX() - projectedView.x,
+                    state.target.pos().getY() - projectedView.y,
+                    state.target.pos().getZ() - projectedView.z);
+
+                // needed for smooth rendering
+                // the boolean value controls whether it's still smooth while the game world is
+                // paused (e.g. /tick freeze)
+                render(state.target, event.getLevelRenderer(), poseStack, state.distanceSquared, state.active, state.partialTick);
+                poseStack.popPose();
+            }
+        } finally {
+            RenderSystem.outputColorTextureOverride = previousColorTextureOverride;
+            RenderSystem.outputDepthTextureOverride = previousDepthTextureOverride;
         }
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelTargetRendering.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/travel/TravelTargetRendering.java
@@ -8,25 +8,20 @@ import com.enderio.enderio.api.travel.TravelTargetApi;
 import com.enderio.enderio.api.travel.TravelTargetType;
 import com.enderio.enderio.client.content.keymaps.KeymapHandler;
 import com.enderio.enderio.content.travel.TravelHandler;
-import com.mojang.blaze3d.pipeline.RenderTarget;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.util.context.ContextKey;
-import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ExtractLevelRenderStateEvent;
-import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +29,7 @@ import java.util.Map;
 @EventBusSubscriber(value = Dist.CLIENT)
 public class TravelTargetRendering {
 
-    private static final ContextKey<List<ExtractTravelTarget>> DATA_KEY = new ContextKey<>(EnderIO.id("traveltargets"));
+    public static final ContextKey<List<ExtractTravelTarget>> DATA_KEY = new ContextKey<>(EnderIO.id("traveltargets"));
     private static Map<TravelTargetType<?>, TravelRenderer<?>> RENDERERS;
 
     public static void init() {
@@ -51,7 +46,7 @@ public class TravelTargetRendering {
         return (TravelRenderer<T>) RENDERERS.get(type);
     }
 
-    private static <T extends TravelTarget> void render(T target, LevelRenderer levelRender, PoseStack poseStack,
+    public static <T extends TravelTarget> void render(T target, LevelRenderer levelRender, PoseStack poseStack,
             double distanceSquared, boolean isActive, float partialTick) {
         // noinspection unchecked
         getRenderer((TravelTargetType<T>) target.type()).render(target, levelRender, poseStack, distanceSquared,
@@ -59,7 +54,7 @@ public class TravelTargetRendering {
     }
 
     //TODO make TravelTarget properly immutable
-    private record ExtractTravelTarget(float partialTick, TravelTarget target, double distanceSquared, boolean active) {}
+    public record ExtractTravelTarget(float partialTick, TravelTarget target, double distanceSquared, boolean active) {}
 
     @SubscribeEvent
     public static void extractLevel(ExtractLevelRenderStateEvent event) {
@@ -93,43 +88,43 @@ public class TravelTargetRendering {
         }
     }
 
-    @SubscribeEvent
-    public static void renderLevel(RenderLevelStageEvent.AfterWeather event) {
-        List<ExtractTravelTarget> renderStates = event.getLevelRenderState().getRenderData(DATA_KEY);
-        if (renderStates == null) {
-            return;
-        }
-
-        RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
-        if (mainTarget.getDepthTexture() != null) {
-            RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mainTarget.getDepthTexture(), 1.0);
-        }
-
-        renderStates.sort(Comparator.comparingDouble(ExtractTravelTarget::distanceSquared).reversed());
-        var previousColorTextureOverride = RenderSystem.outputColorTextureOverride;
-        var previousDepthTextureOverride = RenderSystem.outputDepthTextureOverride;
-        try {
-            RenderSystem.outputColorTextureOverride = mainTarget.getColorTextureView();
-            RenderSystem.outputDepthTextureOverride = mainTarget.getDepthTextureView();
-
-            for (ExtractTravelTarget state : renderStates) {
-                PoseStack poseStack = event.getPoseStack();
-                poseStack.pushPose();
-                Vec3 projectedView = event.getLevelRenderState().cameraRenderState.pos;
-                poseStack.translate(
-                    state.target.pos().getX() - projectedView.x,
-                    state.target.pos().getY() - projectedView.y,
-                    state.target.pos().getZ() - projectedView.z);
-
-                // needed for smooth rendering
-                // the boolean value controls whether it's still smooth while the game world is
-                // paused (e.g. /tick freeze)
-                render(state.target, event.getLevelRenderer(), poseStack, state.distanceSquared, state.active, state.partialTick);
-                poseStack.popPose();
-            }
-        } finally {
-            RenderSystem.outputColorTextureOverride = previousColorTextureOverride;
-            RenderSystem.outputDepthTextureOverride = previousDepthTextureOverride;
-        }
-    }
+//    @SubscribeEvent
+//    public static void renderLevel(RenderLevelStageEvent.AfterWeather event) {
+//        List<ExtractTravelTarget> renderStates = event.getLevelRenderState().getRenderData(DATA_KEY);
+//        if (renderStates == null) {
+//            return;
+//        }
+//
+//        RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
+//        if (mainTarget.getDepthTexture() != null) {
+//            RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mainTarget.getDepthTexture(), 1.0);
+//        }
+//
+//        renderStates.sort(Comparator.comparingDouble(ExtractTravelTarget::distanceSquared).reversed());
+//        var previousColorTextureOverride = RenderSystem.outputColorTextureOverride;
+//        var previousDepthTextureOverride = RenderSystem.outputDepthTextureOverride;
+//        try {
+//            RenderSystem.outputColorTextureOverride = mainTarget.getColorTextureView();
+//            RenderSystem.outputDepthTextureOverride = mainTarget.getDepthTextureView();
+//
+//            for (ExtractTravelTarget state : renderStates) {
+//                PoseStack poseStack = event.getPoseStack();
+//                poseStack.pushPose();
+//                Vec3 projectedView = event.getLevelRenderState().cameraRenderState.pos;
+//                poseStack.translate(
+//                    state.target.pos().getX() - projectedView.x,
+//                    state.target.pos().getY() - projectedView.y,
+//                    state.target.pos().getZ() - projectedView.z);
+//
+//                // needed for smooth rendering
+//                // the boolean value controls whether it's still smooth while the game world is
+//                // paused (e.g. /tick freeze)
+//                render(state.target, event.getLevelRenderer(), poseStack, state.distanceSquared, state.active, state.partialTick);
+//                poseStack.popPose();
+//            }
+//        } finally {
+//            RenderSystem.outputColorTextureOverride = previousColorTextureOverride;
+//            RenderSystem.outputDepthTextureOverride = previousDepthTextureOverride;
+//        }
+//    }
 }

--- a/enderio/src/main/java/com/enderio/enderio/mixin/LevelRendererMixin.java
+++ b/enderio/src/main/java/com/enderio/enderio/mixin/LevelRendererMixin.java
@@ -1,0 +1,61 @@
+package com.enderio.enderio.mixin;
+
+import com.enderio.enderio.client.content.travel.TravelTargetRendering;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.resource.ResourceHandle;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.state.level.LevelRenderState;
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4fc;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Mixin(LevelRenderer.class)
+public abstract class LevelRendererMixin implements ResourceManagerReloadListener, AutoCloseable{
+
+    @Final
+    @Shadow
+    LevelRenderState levelRenderState;
+
+    @Inject(method = "lambda$addLateDebugPass$0", at = @At(value = "FIELD", target = "Lcom/mojang/blaze3d/systems/RenderSystem;outputDepthTextureOverride:Lcom/mojang/blaze3d/textures/GpuTextureView;", opcode = Opcodes.PUTSTATIC, ordinal = 0, shift = At.Shift.AFTER))
+    private void renderTravel(GpuBufferSlice fog, ResourceHandle<RenderTarget> mainTarget, CameraRenderState camera, Matrix4fc modelViewMatrix, CallbackInfo ci) {
+        List<TravelTargetRendering.ExtractTravelTarget> renderStates = this.levelRenderState.getRenderData(TravelTargetRendering.DATA_KEY);
+        if (renderStates == null) {
+            return;
+        }
+
+        if (mainTarget.get().getDepthTexture() != null) {
+            RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mainTarget.get().getDepthTexture(), 1.0);
+        }
+
+        renderStates.sort(Comparator.comparingDouble(TravelTargetRendering.ExtractTravelTarget::distanceSquared).reversed());
+        for (TravelTargetRendering.ExtractTravelTarget state : renderStates) {
+            PoseStack poseStack = new PoseStack();
+            poseStack.pushPose();
+            Vec3 projectedView = camera.pos;
+            poseStack.translate(
+                state.target().pos().getX() - projectedView.x,
+                state.target().pos().getY() - projectedView.y,
+                state.target().pos().getZ() - projectedView.z);
+
+            // needed for smooth rendering
+            // the boolean value controls whether it's still smooth while the game world is
+            // paused (e.g. /tick freeze)
+            TravelTargetRendering.render(state.target(), (LevelRenderer) (Object) this, poseStack, state.distanceSquared(), state.active(), state.partialTick());
+            poseStack.popPose();
+        }
+    }
+}

--- a/enderio/src/main/resources/enderio.mixins.json
+++ b/enderio/src/main/resources/enderio.mixins.json
@@ -8,6 +8,7 @@
     ],
     "client" : [
 //        "GliderRotationMixin",
+        "LevelRendererMixin"
     ],
     "minVersion" : "0.8"
 }


### PR DESCRIPTION
# Description

  1. Use dedicated render buffers for travel anchor overlays
     - Current code reused shared level buffers for mixed model/text output, which result incorrect buffers to be rendered
     - With Iris rendering, an incompatible buffer/vertex format crash the client. (#1368)
     - Also fixes the travel anchor text rendering issue reported in AllTheMods/ATM-11#59.

  2. Fix travel anchor overlay ordering and 26.1 rendering
     - Re-order travel anchor backdrop/model in the intended order.
     - Pin overlay output to the main render target using `RenderSystem#output*TextureOverride`.
       ([1.21.6 primer: List of Additions](https://docs.neoforged.net/primer/docs/1.21.6/#list-of-additions))
     - Use `ItemStackRenderState` for item icons.
       ([1.21.4 primer: Rendering an Item](https://docs.neoforged.net/primer/docs/1.21.4/#rendering-an-item), [26.1 primer: Removing the Old Block and Item Renderers](https://docs.neoforged.net/primer/docs/26.1/#removing-the-old-block-and-item-renderers))
       
 | Before | After |
 |--------| ------|
 | <img width="966" height="620" alt="image" src="https://github.com/user-attachments/assets/5637fb54-6670-433e-bbd9-e5ba45e3707a" /> | <img width="966" height="620" alt="image" src="https://github.com/user-attachments/assets/b480df34-4d3a-42a6-aa47-2989e0282354" /> |

# Breaking Changes

List any breaking changes in this section, such as: changed/removed APIs, changed or removed items/blocks or modifications to recipes and gameplay mechanics.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
