### PR TITLE
Clean getCloneItemStack and add Jade tooltip for bound soulds

### DIFF
--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/client/EIOLanguageProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/client/EIOLanguageProvider.java
@@ -740,6 +740,8 @@ public class EIOLanguageProvider extends LanguageProvider {
 
         add(EIOCommonLang.DARK_STEEL_LADDER_FASTER, "Faster than regular ladders");
         add(EIOCommonLang.TOO_MANY_LEVELS, "You have more than 21862 levels, that's too much XP.");
+
+        add(EIOCommonLang.BOUND_SOUL, "Bound Soul: %s");
     }
 
     private void addKeybindsLang(){

--- a/enderio/src/generated/resources/assets/enderio/lang/en_us.json
+++ b/enderio/src/generated/resources/assets/enderio/lang/en_us.json
@@ -599,6 +599,7 @@
   "tooltip.enderio.machine.status.output_full": "There is not enough room for the output",
   "tooltip.enderio.no_soul_bound": "This item can have a soul bound to it.",
   "tooltip.enderio.show_advanced_tooltip": "<Hold Shift>",
+  "tooltip.enderio.soul_bound": "Bound Soul: %s",
   "tooltip.enderio.tool.soul_vial.health": "Health: %s/%s",
   "tooltip.enderio.tool.void_vial.hint": "Collects experience orbs on behalf of the player, can insert XP into tanks or be drunk by the player.",
   "tooltip.enderio.tool.void_vial.stored_experience": "Stored: %s levels + %s experience"

--- a/enderio/src/main/java/com/enderio/enderio/client/foundation/tooltip/TooltipHandler.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/foundation/tooltip/TooltipHandler.java
@@ -93,7 +93,7 @@ public class TooltipHandler {
             var soul = soulBindable.getBoundSoul();
 
             if (soul.hasEntity()) {
-                components.add(TooltipUtil.style(Component.translatable(soul.entityType().getDescriptionId())));
+                components.add(TooltipUtil.styledWithArgs(EIOCommonLang.BOUND_SOUL, soul.entityType().getDescription()));
             } else {
                 components.add(TooltipUtil.style(EIOCommonLang.TOOLTIP_NO_SOULBOUND));
             }

--- a/enderio/src/main/java/com/enderio/enderio/compat/jade/EIOJadePlugin.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jade/EIOJadePlugin.java
@@ -5,8 +5,10 @@ import com.enderio.enderio.api.conduits.bundle.ConduitBundle;
 import com.enderio.enderio.client.content.conduits.model.facades.FacadeUtil;
 import com.enderio.enderio.init.EIOBlocks;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
 import snownee.jade.api.WailaPlugin;
 
@@ -14,8 +16,6 @@ import snownee.jade.api.WailaPlugin;
 public class EIOJadePlugin implements IWailaPlugin {
 
     public static final ResourceLocation SOUL_BOUND_COMPONENT = EnderIO.rl("soul_bound");
-
-    // TODO: Could implement stuff like a waila tooltip for bound souls.
 
     @Override
     public void registerClient(IWailaClientRegistration registration) {
@@ -36,5 +36,12 @@ public class EIOJadePlugin implements IWailaPlugin {
             }
             return accessor;
         });
+
+        registration.registerBlockComponent(SoulBoundComponentProvider.INSTANCE, Block.class);
+    }
+
+    @Override
+    public void register(IWailaCommonRegistration registration) {
+        registration.registerBlockDataProvider(SoulBoundComponentProvider.INSTANCE, Block.class);
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/compat/jade/EIOJadePlugin.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jade/EIOJadePlugin.java
@@ -1,32 +1,37 @@
 package com.enderio.enderio.compat.jade;
 
+import com.enderio.enderio.EnderIO;
 import com.enderio.enderio.api.conduits.bundle.ConduitBundle;
 import com.enderio.enderio.client.content.conduits.model.facades.FacadeUtil;
 import com.enderio.enderio.init.EIOBlocks;
+import net.minecraft.resources.ResourceLocation;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaPlugin;
 import snownee.jade.api.WailaPlugin;
 
 @WailaPlugin
-public class EIOConduitsJadePlugin implements IWailaPlugin {
+public class EIOJadePlugin implements IWailaPlugin {
+
+    public static final ResourceLocation SOUL_BOUND_COMPONENT = EnderIO.rl("soul_bound");
 
     // TODO: Could implement stuff like a waila tooltip for bound souls.
 
     @Override
     public void registerClient(IWailaClientRegistration registration) {
-        // Show the correct conduit (or facade item)
+        // Use clone item stack to work out which item to show.
         registration.usePickedResult(EIOBlocks.CONDUIT_BUNDLE.get());
 
-        // Completely replace the block accessor with the facade block if it exists
+        // Completely replace the block accessor with the facade block if it exists.
+        // This prevents any special widgets (such as exposed capabilities like energy) from appearing when covered by a facade.
         registration.addRayTraceCallback((hitResult, accessor, originalAccessor) -> {
             if (accessor instanceof BlockAccessor blockAccessor) {
                 if (blockAccessor.getBlockEntity() instanceof ConduitBundle conduitBundle && conduitBundle.hasFacade()
-                        && FacadeUtil.areFacadesVisible(blockAccessor.getPlayer())) {
+                    && FacadeUtil.areFacadesVisible(blockAccessor.getPlayer())) {
                     return registration.blockAccessor()
-                            .from(blockAccessor)
-                            .fakeBlock(conduitBundle.getFacadeBlock().asItem().getDefaultInstance())
-                            .build();
+                        .from(blockAccessor)
+                        .fakeBlock(conduitBundle.getFacadeBlock().asItem().getDefaultInstance())
+                        .build();
                 }
             }
             return accessor;

--- a/enderio/src/main/java/com/enderio/enderio/compat/jade/SoulBoundComponentProvider.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/jade/SoulBoundComponentProvider.java
@@ -1,0 +1,55 @@
+package com.enderio.enderio.compat.jade;
+
+import com.enderio.core.common.util.TooltipUtil;
+import com.enderio.enderio.api.EnderIOCapabilities;
+import com.enderio.enderio.foundation.lang.EIOCommonLang;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.IServerDataProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+public enum SoulBoundComponentProvider implements IBlockComponentProvider, IServerDataProvider<BlockAccessor> {
+    INSTANCE;
+
+    @Override
+    public void appendTooltip(
+        ITooltip tooltip,
+        BlockAccessor accessor,
+        IPluginConfig config
+    ) {
+        var data = accessor.getServerData();
+        if (!data.contains("enderio_soulbound")) {
+            return;
+        }
+
+        ResourceLocation entityTypeId = ResourceLocation.tryParse(data.getString("enderio_soulbound"));
+        if (entityTypeId == null) {
+            return;
+        }
+
+        var entityType = BuiltInRegistries.ENTITY_TYPE.getOptional(entityTypeId);
+        if (entityType.isEmpty()) {
+            return;
+        }
+
+        tooltip.add(TooltipUtil.withArgs(EIOCommonLang.BOUND_SOUL, entityType.get().getDescription()));
+    }
+
+    @Override
+    public ResourceLocation getUid() {
+        return EIOJadePlugin.SOUL_BOUND_COMPONENT;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag compoundTag, BlockAccessor blockAccessor) {
+        var soulBindable = blockAccessor.getLevel().getCapability(EnderIOCapabilities.SOUL_BINDABLE_BLOCK, blockAccessor.getPosition());
+        if (soulBindable != null && soulBindable.hasSoul()) {
+            compoundTag.putString("enderio_soulbound", soulBindable.getBoundSoul().entityTypeId().toString());
+        }
+    }
+}

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlock.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlock.java
@@ -137,43 +137,39 @@ public class ConduitBundleBlock extends Block implements EntityBlock, SimpleWate
 
     // endregion
 
-    // TODO: Review, I'm sure this could be neater
     @Override
-    public ItemStack getCloneItemStack(BlockState state, HitResult target, LevelReader level, BlockPos pos,
-            Player player) {
-        if (level instanceof Level realLevel
-                && state.getOptionalValue(BlockStateProperties.WATERLOGGED).orElse(false)) {
-            var hitResult = Item.getPlayerPOVHitResult(realLevel, player, ClipContext.Fluid.NONE);
-            if (hitResult.getType() == HitResult.Type.MISS) {
-                return Items.AIR.getDefaultInstance();
-            }
+    public ItemStack getCloneItemStack(BlockState state, HitResult target, LevelReader level, BlockPos pos, Player player) {
+        if (!(level.getBlockEntity(pos) instanceof ConduitBundleBlockEntity blockEntity)) {
+            return super.getCloneItemStack(state, target, level, pos, player);
+        }
 
-            if (hitResult.getBlockPos().equals(pos)) {
-                target = hitResult;
+        if (blockEntity.hasFacade() && FacadeUtil.areFacadesVisible(player)) {
+            return blockEntity.getFacadeBlock().asItem().getDefaultInstance();
+        }
+
+        if (blockEntity.getConduits().isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        // If we're waterlogged, re-raycast without fluid hits to see which conduit we landed on (or if we are looking through at another block entirely)
+        if (state.getValue(BlockStateProperties.WATERLOGGED) && level instanceof Level realLevel) {
+            var newTarget = Item.getPlayerPOVHitResult(realLevel, player, ClipContext.Fluid.NONE);
+            if (newTarget.getBlockPos().equals(pos)) {
+                target = newTarget;
             } else {
-                return level.getBlockState(hitResult.getBlockPos())
-                        .getCloneItemStack(hitResult, level, hitResult.getBlockPos(), player);
+                // Pass through to the block that the player is actually looking at.
+                return level.getBlockState(newTarget.getBlockPos())
+                    .getCloneItemStack(newTarget, level, newTarget.getBlockPos(), player);
             }
         }
 
-        if (level.getBlockEntity(pos) instanceof ConduitBundleBlockEntity blockEntity) {
-            if (blockEntity.hasFacade() && FacadeUtil.areFacadesVisible(player)) {
-                return blockEntity.getFacadeBlock().asItem().getDefaultInstance();
-            }
-
-            Holder<Conduit<?, ?>> conduit = blockEntity.getShape().getConduit(pos, target);
-            if (conduit == null) {
-                if (blockEntity.getConduits().isEmpty()) {
-                    return ItemStack.EMPTY;
-                }
-
-                conduit = blockEntity.getConduits().getFirst();
-            }
-
-            return ConduitBlockItem.getStackFor(conduit, 1);
+        Holder<Conduit<?, ?>> conduit = blockEntity.getShape().getConduit(pos, target);
+        if (conduit == null) {
+            conduit = blockEntity.getConduits().getFirst();
         }
 
-        return super.getCloneItemStack(state, target, level, pos, player);
+        return ConduitBlockItem.getStackFor(conduit, 1);
+
     }
 
     @Override

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/solar_panel/SolarPanelBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/solar_panel/SolarPanelBlockEntity.java
@@ -1,11 +1,13 @@
 package com.enderio.enderio.content.machines.solar_panel;
 
 import com.enderio.enderio.api.soul.Soul;
+import com.enderio.enderio.api.soul.binding.SoulBindable;
 import com.enderio.enderio.foundation.MachineNBTKeys;
 import com.enderio.enderio.foundation.block.EIOBlockEntity;
 import com.enderio.enderio.foundation.souldata.SolarSoul;
 import com.enderio.enderio.foundation.tag.EIOTags;
 import com.enderio.enderio.init.EIODataComponents;
+import com.google.common.base.Preconditions;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -13,6 +15,7 @@ import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -30,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-public class SolarPanelBlockEntity extends EIOBlockEntity {
+public class SolarPanelBlockEntity extends EIOBlockEntity implements SoulBindable {
 
     public static final ICapabilityProvider<SolarPanelBlockEntity, Direction, IEnergyStorage> ENERGY_STORAGE_PROVIDER = (
         be, side) -> side != Direction.UP ? be.energyStorage : null;
@@ -124,6 +127,33 @@ public class SolarPanelBlockEntity extends EIOBlockEntity {
         }
 
         return validPushTargetCache;
+    }
+
+    // endregion
+
+    // region Soul Bindable
+
+    @Override
+    public Soul getBoundSoul() {
+        return boundSoul;
+    }
+
+    @Override
+    public boolean canBind() {
+        return true;
+    }
+
+    @Override
+    public boolean isSoulValid(Soul soul) {
+        return soul.entityType() == EntityType.PHANTOM;
+    }
+
+    @Override
+    public void bindSoul(Soul newSoul) {
+        Preconditions.checkArgument(isSoulValid(newSoul), "Soul is not valid for this block");
+        this.boundSoul = newSoul;
+        soulData = SolarSoul.SOLAR.matches(newSoul.entityTypeId()).get();
+        setChanged();
     }
 
     // endregion

--- a/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/MachineBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/block/entity/MachineBlockEntity.java
@@ -38,6 +38,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemContainerContents;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.fml.LogicalSide;
@@ -69,7 +70,7 @@ public abstract class MachineBlockEntity extends EIOBlockEntity
     public static final ICapabilityProvider<MachineBlockEntity, Direction, IItemHandler> ITEM_HANDLER_PROVIDER = (be,
             side) -> be.inventory != null ? be.inventory.getForSide(side) : null;
 
-    public static final ICapabilityProvider<MachineBlockEntity, Void, SoulBindable> SOUL_BINDABLE = (be, ctx)
+    public static final ICapabilityProvider<BlockEntity, Void, SoulBindable> SOUL_BINDABLE = (be, ctx)
         -> be instanceof SoulBindable bindable ? bindable : null;
 
     private static final ModelProperty<IOConfigurable> IO_CONFIG_PROPERTY = LegacyMachineBlockEntity.IO_CONFIG_PROPERTY;

--- a/enderio/src/main/java/com/enderio/enderio/foundation/lang/EIOCommonLang.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/lang/EIOCommonLang.java
@@ -72,6 +72,8 @@ public class EIOCommonLang {
 
     // endregion
 
+    public static final MutableComponent BOUND_SOUL = tooltip("soul_bound");
+
     private static MutableComponent gui(String path) {
         return create("gui", path);
     }

--- a/enderio/src/main/java/com/enderio/enderio/init/EIOBlockEntities.java
+++ b/enderio/src/main/java/com/enderio/enderio/init/EIOBlockEntities.java
@@ -49,6 +49,7 @@ import com.enderio.enderio.foundation.block.entity.legacy.LegacyMachineBlockEnti
 import com.enderio.enderio.foundation.block.entity.legacy.LegacyPoweredMachineBlockEntity;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.Util;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.capabilities.Capabilities;
@@ -232,6 +233,7 @@ public class EIOBlockEntities {
                     (worldPosition, blockState) -> new SolarPanelBlockEntity(EIOBlockEntities.SOLAR_PANELS.get(tier).get(),worldPosition, blockState, tier),
                     () -> EIOBlocks.SOLAR_PANELS.get(tier).get())
                 .capability(Capabilities.EnergyStorage.BLOCK, SolarPanelBlockEntity.ENERGY_STORAGE_PROVIDER)
+                .apply(EIOBlockEntities::soulBoundCapability)
                 .build())
             ;
         }
@@ -263,7 +265,7 @@ public class EIOBlockEntities {
         builder.capability(Capabilities.ItemHandler.BLOCK, LegacyMachineBlockEntity.ITEM_HANDLER_PROVIDER);
     }
 
-    private static void soulBoundCapability(BlockEntityTypeDeferredRegister.Builder<? extends MachineBlockEntity> blockEntity) {
+    private static void soulBoundCapability(BlockEntityTypeDeferredRegister.Builder<? extends BlockEntity> blockEntity) {
         blockEntity.capability(EnderIOCapabilities.SOUL_BINDABLE_BLOCK, MachineBlockEntity.SOUL_BINDABLE);
     }
 


### PR DESCRIPTION
# Description

Removes Jade/Viewer-specific logic out of getCloneItemStack because it was difficult to explain (and was a bit of a code smell if we're honest :P)

While it may degrade the experience for other viewers like TOP, I am happy to add support for those if we receive requests/reports that it does not work correctly.

# Breaking Changes

No breaking changes unless other mods were relying on getCloneItemStack and will break because they were using anything where  the ClipContext would consider fluids.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
