### PR TITLE
fix: Discard networks corrupted by the update from 8.0.7 to 8.2.9

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/network/ConduitNetworkSavedData.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/network/ConduitNetworkSavedData.java
@@ -68,6 +68,17 @@ public class ConduitNetworkSavedData extends SavedData {
 
     private ConduitNetworkSavedData(List<ConduitNetworkImpl> networks) {
         for (ConduitNetworkImpl network : networks) {
+            // If a world has been loaded from 8.0.7 into 8.2.9 and then updated further, the conduit data has become corrupted.
+            // In this instance, we'll have to discard the network and have it get repaired.
+            // ConstantValue issues are because conduit() is supposed to be non null.
+            //noinspection ConstantValue
+            boolean anyNodesMissingConduit = network.nodes().stream().anyMatch(n -> n.conduit() == null);
+            //noinspection ConstantValue
+            if (anyNodesMissingConduit) {
+                LOGGER.warn("Skipping network with damaged conduit data.");
+                continue;
+            }
+
             network.setOnChunkCoverageChanged(this::onNetworkChunksChanged);
             this.networks.put(network.conduitType(), network);
 


### PR DESCRIPTION
# Description

These networks are irreparable, so we should prevent the game from crashing and let the networks regenerate.

# Breaking Changes

Should not discard undamaged networks, or non-migrated networks.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
