### PR TITLE
Fix Soulbound restore with Sync respawns

### DIFF
--- a/src/main/java/com/enderio/base/common/enchantment/SoulBoundHandler.java
+++ b/src/main/java/com/enderio/base/common/enchantment/SoulBoundHandler.java
@@ -1,23 +1,48 @@
 package com.enderio.base.common.enchantment;
 
 import com.enderio.base.common.init.EIOEnchantments;
+import com.mojang.logging.LogUtils;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameRules;
 import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import org.slf4j.Logger;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
-//TODO testing against graves and other mods
 @EventBusSubscriber
 public class SoulBoundHandler {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final long RESTORE_CHECK_INTERVAL_MS = 1000;
+    private static final int SYNC_STOP_RESTORE_DELAY_TICKS = 120;
+    private static final String SYNC_START_EVENT_CLASS = "net.pawjwp.sync.api.event.PlayerSyncEvents$StartSyncing";
+    private static final String SYNC_STOP_EVENT_CLASS = "net.pawjwp.sync.api.event.PlayerSyncEvents$StopSyncing";
+    private static final Map<UUID, Integer> syncRestoreReadyTicks = new HashMap<>();
+    private static final Set<UUID> syncingPlayers = new HashSet<>();
+    private static long lastRestoreCheck = 0;
+    private static boolean syncHandlersRegistered = false;
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void deathHandler(LivingDropsEvent event) {
@@ -27,42 +52,303 @@ public class SoulBoundHandler {
         if (event.getEntity().level().getGameRules().getBoolean(GameRules.RULE_KEEPINVENTORY)) {
             return;
         }
-        ArrayList<ItemStack> soulItems = new ArrayList<>();
-        if (event.getEntity() instanceof Player player) {
-            Iterator<ItemEntity> iter = event.getDrops().iterator();
-            while (iter.hasNext()) {
-                ItemEntity ei = iter.next();
-                ItemStack item = ei.getItem();
-                if (isSoulBound(item)) {
-                    if (player.addItem(item)) {
-                        iter.remove();
-                    }//TODO More detailed and better item storage.
-                    soulItems.add(item);
-                }
-            }
-            if (soulItems.isEmpty()) {
-                return;
-            }
-            soulItems.forEach(player::addItem);
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
         }
+
+        tryRegisterSyncHandlers();
+
+        List<ItemStack> soulItems = new ArrayList<>();
+        Iterator<ItemEntity> iter = event.getDrops().iterator();
+        while (iter.hasNext()) {
+            ItemEntity ei = iter.next();
+            ItemStack item = ei.getItem();
+            if (isSoulBound(item)) {
+                soulItems.add(item.copy());
+                iter.remove();
+            }
+        }
+
+        if (soulItems.isEmpty()) {
+            return;
+        }
+
+        LOGGER.info("SoulBound: captured {} items for player {}", soulItems.size(), player.getGameProfile().getName());
+        SoulBoundSavedData.get(player.level()).storeItems(player, soulItems);
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void reviveHandler(PlayerEvent.Clone event) {
+        if (!event.isWasDeath()) {
+            return;
+        }
+
+        Player newPlayer = event.getEntity();
+        if (newPlayer.level().getGameRules().getBoolean(GameRules.RULE_KEEPINVENTORY)) {
+            return;
+        }
+
+        if (restorePendingItems(newPlayer, "Clone")) {
+            return;
+        }
+
+        LOGGER.info("SoulBound: Clone fallback - scanning original inventory");
+        copySoulBoundItems(event.getOriginal().getInventory(), newPlayer);
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void respawnHandler(PlayerEvent.PlayerRespawnEvent event) {
+        if (isSyncing(event.getEntity())) {
+            return;
+        }
+        restorePendingItems(event.getEntity(), "Respawn");
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void loginHandler(PlayerEvent.PlayerLoggedInEvent event) {
+        restorePendingItems(event.getEntity(), "Login");
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void changedDimensionHandler(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (isSyncing(event.getEntity())) {
+            return;
+        }
+        restorePendingItems(event.getEntity(), "ChangedDimension");
     }
 
     @SubscribeEvent
-    public static void reviveHandler(PlayerEvent.Clone event) {
-        if (!event.getOriginal().isDeadOrDying()) {
+    public static void serverTick(TickEvent.ServerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
             return;
         }
-        if (event.getEntity().level().getGameRules().getBoolean(GameRules.RULE_KEEPINVENTORY)) {
+
+        long now = System.currentTimeMillis();
+        if (now - lastRestoreCheck < RESTORE_CHECK_INTERVAL_MS) {
             return;
         }
-        //TODO More detailed and better item recovery.
-        event.getOriginal().getInventory().items.forEach(item -> event.getEntity().addItem(item));
-        event.getOriginal().getInventory().armor.forEach(armor -> event.getEntity().addItem(armor));
-        event.getOriginal().getInventory().offhand.forEach(offhand -> event.getEntity().addItem(offhand));
+        lastRestoreCheck = now;
+
+        MinecraftServer server = event.getServer();
+        if (server == null) {
+            return;
+        }
+
+        for (var serverPlayer : server.getPlayerList().getPlayers()) {
+            if (isSyncLoaded()) {
+                Integer readyTick = syncRestoreReadyTicks.get(serverPlayer.getUUID());
+                if (readyTick == null || serverPlayer.tickCount < readyTick) {
+                    continue;
+                }
+                if (!isReadyForRestore(serverPlayer)) {
+                    continue;
+                }
+                restorePendingItems(serverPlayer, "SyncStopDelayed");
+                syncRestoreReadyTicks.remove(serverPlayer.getUUID());
+                continue;
+            }
+
+            restorePendingItems(serverPlayer, "ServerTick");
+        }
+    }
+
+    private static void syncStartHandler(Event event) {
+        if (!SYNC_START_EVENT_CLASS.equals(event.getClass().getName()) || !(event instanceof PlayerEvent playerEvent)) {
+            return;
+        }
+
+        Player player = playerEvent.getEntity();
+        if (player.level().isClientSide) {
+            return;
+        }
+
+        syncingPlayers.add(player.getUUID());
+
+        List<ItemStack> pending = SoulBoundSavedData.get(player.level()).takeItems(player);
+        if (pending == null) {
+            return;
+        }
+
+        try {
+            Method getTargetState = event.getClass().getMethod("getTargetState");
+            Object targetState = getTargetState.invoke(event);
+            if (targetState == null) {
+                SoulBoundSavedData.get(player.level()).storeItems(player, pending);
+                return;
+            }
+
+            Method getInventory = targetState.getClass().getMethod("getInventory");
+            Object targetInventory = getInventory.invoke(targetState);
+            if (!(targetInventory instanceof Container container)) {
+                SoulBoundSavedData.get(player.level()).storeItems(player, pending);
+                LOGGER.warn("SoulBound: Sync target inventory was not a Minecraft container for player {}", player.getGameProfile().getName());
+                return;
+            }
+
+            List<ItemStack> leftovers = insertItems(container, pending);
+            if (!leftovers.isEmpty()) {
+                SoulBoundSavedData.get(player.level()).storeItems(player, leftovers);
+                LOGGER.warn("SoulBound: SyncStart staged {} items for player {}, {} stacks left for delayed restore",
+                    pending.size(), player.getGameProfile().getName(), leftovers.size());
+                return;
+            }
+
+            LOGGER.info("SoulBound: SyncStart staged {} items in target shell for player {}", pending.size(), player.getGameProfile().getName());
+        } catch (ReflectiveOperationException e) {
+            SoulBoundSavedData.get(player.level()).storeItems(player, pending);
+            LOGGER.warn("SoulBound: failed to stage items in Sync target shell for player {}", player.getGameProfile().getName(), e);
+        }
+    }
+
+    private static void syncStopHandler(Event event) {
+        if (!SYNC_STOP_EVENT_CLASS.equals(event.getClass().getName()) || !(event instanceof PlayerEvent playerEvent)) {
+            return;
+        }
+
+        Player player = playerEvent.getEntity();
+        if (player.level().isClientSide) {
+            return;
+        }
+
+        syncingPlayers.remove(player.getUUID());
+        syncRestoreReadyTicks.put(player.getUUID(), player.tickCount + SYNC_STOP_RESTORE_DELAY_TICKS);
+        LOGGER.info("SoulBound: Sync stop detected for player {}, queued pending restore", player.getGameProfile().getName());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void tryRegisterSyncHandlers() {
+        if (syncHandlersRegistered || !isSyncLoaded()) {
+            return;
+        }
+
+        try {
+            Class<? extends Event> syncStartEvent = Class.forName(SYNC_START_EVENT_CLASS).asSubclass(Event.class);
+            Class<? extends Event> syncStopEvent = Class.forName(SYNC_STOP_EVENT_CLASS).asSubclass(Event.class);
+            MinecraftForge.EVENT_BUS.addListener(EventPriority.LOWEST, false, (Class) syncStartEvent,
+                (java.util.function.Consumer<Event>) SoulBoundHandler::syncStartHandler);
+            MinecraftForge.EVENT_BUS.addListener(EventPriority.LOWEST, false, (Class) syncStopEvent,
+                (java.util.function.Consumer<Event>) SoulBoundHandler::syncStopHandler);
+            syncHandlersRegistered = true;
+            LOGGER.info("SoulBound: registered Sync restore hooks");
+        } catch (ClassNotFoundException ignored) {
+            syncHandlersRegistered = true;
+            LOGGER.warn("SoulBound: Sync is loaded but sync event classes were not found");
+        }
+    }
+
+    private static boolean isSyncLoaded() {
+        return ModList.get().isLoaded("sync");
+    }
+
+    private static boolean restorePendingItems(Player player, String source) {
+        if (!isReadyForRestore(player)) {
+            return false;
+        }
+
+        List<ItemStack> pending = SoulBoundSavedData.get(player.level()).takeItems(player);
+        if (pending == null) {
+            return false;
+        }
+
+        LOGGER.info("SoulBound: {} restored {} items for player {}", source, pending.size(), player.getGameProfile().getName());
+        restoreItems(player, pending);
+        return true;
+    }
+
+    private static boolean isSyncing(Player player) {
+        return isSyncLoaded() && syncingPlayers.contains(player.getUUID());
+    }
+
+    private static boolean isReadyForRestore(Player player) {
+        return !player.level().isClientSide
+            && player.isAlive()
+            && !player.isDeadOrDying()
+            && player.getHealth() > 0.0F
+            && player.deathTime == 0;
+    }
+
+    private static void restoreItems(Player player, List<ItemStack> items) {
+        for (ItemStack stack : items) {
+            if (!player.addItem(stack)) {
+                player.drop(stack, false, false);
+            }
+        }
+    }
+
+    private static List<ItemStack> insertItems(Container container, List<ItemStack> items) {
+        List<ItemStack> leftovers = new ArrayList<>();
+        for (ItemStack stack : items) {
+            ItemStack remaining = stack.copy();
+            mergeIntoExistingStacks(container, remaining);
+            moveIntoEmptySlots(container, remaining);
+            if (!remaining.isEmpty()) {
+                leftovers.add(remaining.copy());
+            }
+        }
+        container.setChanged();
+        return leftovers;
+    }
+
+    private static void mergeIntoExistingStacks(Container container, ItemStack stack) {
+        for (int slot = 0; slot < container.getContainerSize() && !stack.isEmpty(); slot++) {
+            ItemStack existing = container.getItem(slot);
+            if (existing.isEmpty() || !ItemStack.isSameItemSameTags(existing, stack)) {
+                continue;
+            }
+
+            int maxStackSize = Math.min(existing.getMaxStackSize(), container.getMaxStackSize());
+            int transferable = Math.min(stack.getCount(), maxStackSize - existing.getCount());
+            if (transferable <= 0) {
+                continue;
+            }
+
+            existing.grow(transferable);
+            stack.shrink(transferable);
+        }
+    }
+
+    private static void moveIntoEmptySlots(Container container, ItemStack stack) {
+        for (int slot = 0; slot < container.getContainerSize() && !stack.isEmpty(); slot++) {
+            if (!container.getItem(slot).isEmpty()) {
+                continue;
+            }
+
+            int transferable = Math.min(stack.getCount(), Math.min(stack.getMaxStackSize(), container.getMaxStackSize()));
+            ItemStack moved = stack.copy();
+            moved.setCount(transferable);
+            container.setItem(slot, moved);
+            stack.shrink(transferable);
+        }
+    }
+
+    private static void copySoulBoundItems(Inventory inventory, Player newPlayer) {
+        for (ItemStack item : inventory.items) {
+            if (isSoulBound(item) && !item.isEmpty()) {
+                ItemStack stack = item.copy();
+                if (!newPlayer.addItem(stack)) {
+                    newPlayer.drop(stack, false, false);
+                }
+            }
+        }
+        for (ItemStack armor : inventory.armor) {
+            if (isSoulBound(armor) && !armor.isEmpty()) {
+                ItemStack stack = armor.copy();
+                if (!newPlayer.addItem(stack)) {
+                    newPlayer.drop(stack, false, false);
+                }
+            }
+        }
+        for (ItemStack offhand : inventory.offhand) {
+            if (isSoulBound(offhand) && !offhand.isEmpty()) {
+                ItemStack stack = offhand.copy();
+                if (!newPlayer.addItem(stack)) {
+                    newPlayer.drop(stack, false, false);
+                }
+            }
+        }
     }
 
     public static boolean isSoulBound(ItemStack item) {
         return item.getEnchantmentLevel(EIOEnchantments.SOULBOUND.get()) > 0;
     }
-
 }

--- a/src/main/java/com/enderio/base/common/enchantment/SoulBoundSavedData.java
+++ b/src/main/java/com/enderio/base/common/enchantment/SoulBoundSavedData.java
@@ -1,0 +1,111 @@
+package com.enderio.base.common.enchantment;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.saveddata.SavedData;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class SoulBoundSavedData extends SavedData {
+
+    private static final String DATA_NAME = "enderio_soulbound";
+    private static final String ENTRIES = "Entries";
+    private static final String UUID_KEY = "UUID";
+    private static final String ITEMS = "Items";
+
+    private final Map<UUID, List<ItemStack>> pendingItems = new HashMap<>();
+
+    public SoulBoundSavedData() {}
+
+    public SoulBoundSavedData(CompoundTag nbt) {
+        ListTag entries = nbt.getList(ENTRIES, Tag.TAG_COMPOUND);
+        for (Tag entry : entries) {
+            CompoundTag entryTag = (CompoundTag) entry;
+            UUID uuid = entryTag.getUUID(UUID_KEY);
+            ListTag itemsTag = entryTag.getList(ITEMS, Tag.TAG_COMPOUND);
+            List<ItemStack> items = new ArrayList<>();
+            for (Tag itemTag : itemsTag) {
+                ItemStack stack = ItemStack.of((CompoundTag) itemTag);
+                if (!stack.isEmpty()) {
+                    items.add(stack);
+                }
+            }
+            if (!items.isEmpty()) {
+                pendingItems.put(uuid, items);
+            }
+        }
+    }
+
+    public static SoulBoundSavedData get(Level level) {
+        if (level.isClientSide) {
+            throw new IllegalStateException("SoulBoundSavedData accessed on client side");
+        }
+
+        MinecraftServer server = level.getServer();
+        if (server == null) {
+            throw new IllegalStateException("SoulBoundSavedData accessed without a server");
+        }
+
+        return get(server);
+    }
+
+    public static SoulBoundSavedData get(MinecraftServer server) {
+        ServerLevel overworld = server.overworld();
+        return overworld.getDataStorage().computeIfAbsent(SoulBoundSavedData::new, SoulBoundSavedData::new, DATA_NAME);
+    }
+
+    public void storeItems(Player player, List<ItemStack> items) {
+        List<ItemStack> storedItems = new ArrayList<>();
+        for (ItemStack stack : items) {
+            if (!stack.isEmpty()) {
+                storedItems.add(stack.copy());
+            }
+        }
+        if (storedItems.isEmpty()) {
+            return;
+        }
+
+        pendingItems.computeIfAbsent(player.getUUID(), uuid -> new ArrayList<>()).addAll(storedItems);
+        setDirty();
+    }
+
+    public List<ItemStack> takeItems(Player player) {
+        List<ItemStack> items = pendingItems.remove(player.getUUID());
+        if (items != null) {
+            setDirty();
+        }
+        return items;
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag nbt) {
+        ListTag entries = new ListTag();
+        for (Map.Entry<UUID, List<ItemStack>> entry : pendingItems.entrySet()) {
+            CompoundTag entryTag = new CompoundTag();
+            entryTag.putUUID(UUID_KEY, entry.getKey());
+            ListTag itemsTag = new ListTag();
+            for (ItemStack stack : entry.getValue()) {
+                itemsTag.add(stack.save(new CompoundTag()));
+            }
+            entryTag.put(ITEMS, itemsTag);
+            entries.add(entryTag);
+        }
+        nbt.put(ENTRIES, entries);
+        return nbt;
+    }
+
+    @Override
+    public boolean isDirty() {
+        return true;
+    }
+}


### PR DESCRIPTION
# Description

Fixes Soulbound item loss in death flows where another mod owns the final player state, especially Sync shell respawns combined with grave/corpse-style mods.

EnderIO's previous Soulbound handling removed enchanted stacks from `LivingDropsEvent`, which means grave mods such as Corpse never see those drops. The handler then tried to restore those stacks through the dead player / clone path. That is fragile when the player inventory is replaced later by another mod.

This PR changes Soulbound restoration to:

- capture Soulbound death drops into server saved data keyed by player UUID;
- store that data on the server overworld so pending items survive cross-dimension respawns;
- restore through vanilla-like safe points: clone, respawn, login, dimension change, and server tick fallback;
- keep the existing `keepInventory` guard to avoid duplication;
- drop overflow if the final player inventory cannot accept restored stacks.

It also adds optional Sync compatibility without adding a hard dependency on Sync. When Sync is loaded, EnderIO registers Sync's Forge `StartSyncing` and `StopSyncing` events by reflection. Pending Soulbound stacks are staged into the target shell inventory during `StartSyncing`, before Sync applies that shell state to the player. This avoids mutating the live player inventory during Sync's client-side limbo/camera transition. `StopSyncing` only schedules a delayed fallback restore for leftover stacks or reflection failures.

Related investigation and prior reports:

- Local reproduction/investigation: https://github.com/Larbaco/EnderIO/issues/1
- Related 1.20.1 Soulbound report: #582
- Older Soulbound disappearance report: #524
- KeepInventory/Soulbound prior fix context: #250 / #321
- 1.20.1 community bugfix policy: #1156

# How to Test

Validated in a Forge 1.20.1 client pack with:

- EnderIO dev build from this branch
- Sync `0.2.0` / `Sync-0.2.1.jar`
- Corpse `1.20.1-1.0.23`
- Soulbound PneumaticCraft boots

The final validated log sequence was:

```text
SoulBound: registered Sync restore hooks
SoulBound: captured 1 items for player Larbaco
SoulBound: SyncStart staged 1 items in target shell for player Larbaco
SoulBound: Sync stop detected for player Larbaco, queued pending restore
```

Result: the Soulbound item returned after Sync shell respawn and the player was not frozen in Sync's transition.

I also ran:

```text
./gradlew compileJava
./gradlew compileMachinesJava --rerun-tasks jarJar
```

# TODO

N/A

# Breaking Changes

None. Sync support is optional and reflection-based, so this does not add Sync as a dependency.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation. N/A, no user-facing documentation changed.
- [x] My changes are ready for review from a contributor.
