### PR TITLE
Feature: Make fluid tank capacities configurable (#838)

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/config/base/common/BlocksConfig.java
+++ b/enderio/src/main/java/com/enderio/enderio/config/base/common/BlocksConfig.java
@@ -6,6 +6,8 @@ public class BlocksConfig {
     public final ModConfigSpec.DoubleValue BROKEN_SPAWNER_DROP_CHANCE;
     public final ModConfigSpec.DoubleValue EXPLOSION_RESISTANCE;
     public final ModConfigSpec.DoubleValue DARK_STEEL_LADDER_BOOST;
+    public final ModConfigSpec.IntValue STANDARD_TANK_CAPACITY;
+    public final ModConfigSpec.IntValue PRESSURIZED_TANK_CAPACITY;
 
     public BlocksConfig(ModConfigSpec.Builder builder) {
         builder.push("blocks");
@@ -17,6 +19,15 @@ public class BlocksConfig {
         EXPLOSION_RESISTANCE = builder.comment("The explosion resistance of explosion resistant blocks.").defineInRange("explosionResistance", 1200.0d, 0.0d, Double.MAX_VALUE);
 
         DARK_STEEL_LADDER_BOOST = builder.comment("The speed boost granted by the Dark Steel ladder.").defineInRange("darkSteelLadderBoost", 0.15d, 0.0d, 1.0d);
+        builder.pop();
+
+        builder.push("fluidTank");
+
+        STANDARD_TANK_CAPACITY = builder.comment("The maximum capacity of the Standard Fluid Tank in mB.").defineInRange("standardCapacity", 16000 , 1000, Integer.MAX_VALUE);
+
+        PRESSURIZED_TANK_CAPACITY = builder
+            .comment("The maximum capacity of the Pressurized Fluid Tank in mB.").defineInRange("pressurizedCapacity", 32000, 1000, Integer.MAX_VALUE);
+
         builder.pop();
     }
 }

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
@@ -1,5 +1,7 @@
 package com.enderio.enderio.content.storage.fluid_tank;
 
+import com.enderio.enderio.config.base.BaseConfig;
+import com.enderio.enderio.config.base.common.BlocksConfig;
 import com.enderio.enderio.foundation.attachment.FluidTankUser;
 import com.enderio.enderio.foundation.block.entity.MachineBlockEntity;
 import com.enderio.enderio.foundation.inventory.MachineInventoryLayout;
@@ -46,7 +48,7 @@ import java.util.Optional;
 public abstract class FluidTankBlockEntity extends MachineBlockEntity implements FluidItemInteractive, FluidTankUser {
 
     public static class Standard extends FluidTankBlockEntity {
-        public static final int CAPACITY = 16 * FluidType.BUCKET_VOLUME;
+        public static final int CAPACITY = BaseConfig.COMMON.BLOCKS.STANDARD_TANK_CAPACITY.get();
 
         public Standard(BlockPos worldPosition, BlockState blockState) {
             super(EIOBlockEntities.FLUID_TANK.get(), worldPosition, blockState);
@@ -59,7 +61,7 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
     }
 
     public static class Enhanced extends FluidTankBlockEntity {
-        public static final int CAPACITY = 32 * FluidType.BUCKET_VOLUME;
+        public static final int CAPACITY = BaseConfig.COMMON.BLOCKS.PRESSURIZED_TANK_CAPACITY.get();
 
         public Enhanced(BlockPos worldPosition, BlockState blockState) {
             super(EIOBlockEntities.PRESSURIZED_FLUID_TANK.get(), worldPosition, blockState);


### PR DESCRIPTION
# Description

Closes #838

This PR removes the hardcoded capacity values for fluid tanks (normal and pressurized) and exposes them via the configuration system, allowing server administrators to adjust the maximum fluid storage.

**Changes implemented:**
* Created a new `fluidTank` section within `BlocksConfig`.
* Added `STANDARD_TANK_CAPACITY` (default: 16000 mB).
* Replaced the hardcoded `CAPACITY` constant in the `Standard` fluid tank class with the dynamic call to `Config.COMMON.BLOCKS.STANDARD_TANK_CAPACITY.get()`.
* Same for pressurized

**Design choices:**
*I placed the configuration values inside `BlocksConfig`
*Didn't use x * FluidType.BUCKET_VOLUME because could hit loading problems(?) -> just used integer (16000)

**Things to test:**
(I already tested it)
1. Launch the game.
2. Verify that the new `[blocks.fluidTank]` section is generated in `run/config/enderio/base-common.toml`.
3. Change the capacity value in the config, save, and place a new Standard Fluid Tank in the world.
4. Verify the new maximum capacity is correctly applied to the newly placed tank.

# Breaking Changes

None. The default configuration values exactly match the previous hardcoded values (`16 * FluidType.BUCKET_VOLUME`).

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
