### PR TITLE
fix: render opaque conduit facades through Sodium for correct shader …

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/client/content/conduits/ConduitFacadeRendering.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/conduits/ConduitFacadeRendering.java
@@ -93,8 +93,9 @@ public class ConduitFacadeRendering {
             for (Map.Entry<BlockPos, BlockState> entry : facades.entrySet()) {
                 // Opaque facades are rendered natively through Sodium's BlockRenderer (see
                 // SodiumConduitFacadeMixin) so they get shader lighting and occlude the conduits.
-                // Skip them here to avoid drawing them twice.
-                if (this.opaque && ModCompatHelper.hasSodium() && entry.getValue().canOcclude()) {
+                // Only skip them here once that mixin is confirmed active, otherwise a failed
+                // injection would leave opaque facades unrendered by both paths.
+                if (this.opaque && ModCompatHelper.isSodiumFacadeMixinActive() && entry.getValue().canOcclude()) {
                     continue;
                 }
 

--- a/enderio/src/main/java/com/enderio/enderio/client/content/conduits/ConduitFacadeRendering.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/conduits/ConduitFacadeRendering.java
@@ -91,6 +91,13 @@ public class ConduitFacadeRendering {
             RandomSource random = RANDOM.get();
 
             for (Map.Entry<BlockPos, BlockState> entry : facades.entrySet()) {
+                // Opaque facades are rendered natively through Sodium's BlockRenderer (see
+                // SodiumConduitFacadeMixin) so they get shader lighting and occlude the conduits.
+                // Skip them here to avoid drawing them twice.
+                if (this.opaque && ModCompatHelper.hasSodium() && entry.getValue().canOcclude()) {
+                    continue;
+                }
+
                 context.getPoseStack().pushPose();
                 context.getPoseStack()
                         .translate(entry.getKey().getX() & 15, entry.getKey().getY() & 15, entry.getKey().getZ() & 15);

--- a/enderio/src/main/java/com/enderio/enderio/compat/ModCompatHelper.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/ModCompatHelper.java
@@ -8,10 +8,12 @@ public class ModCompatHelper {
     private static boolean hasJEI;
     private static boolean hasIris;
 
-    // Set by SodiumConduitFacadeMixin the first time it runs, proving the injection actually applied.
-    // The conduit facade overlay only skips opaque facades once this is confirmed, so a failed mixin
-    // target never leaves opaque facades unrendered by both paths.
-    private static volatile boolean sodiumFacadeMixinActive = false;
+    // Set by SodiumConduitFacadeMixin's two @ModifyVariable injectors the first time each runs, proving
+    // the injection actually applied. Both the state and the model interceptor must swap in lockstep, so
+    // the overlay only defers to the mixin once BOTH are confirmed - a partial injection failure (one
+    // interceptor unresolved) then cleanly falls back to overlay rendering instead of a broken half-swap.
+    private static volatile boolean sodiumFacadeStateMixinActive = false;
+    private static volatile boolean sodiumFacadeModelMixinActive = false;
 
     public static boolean hasRecipeViewer() {
         init();
@@ -24,12 +26,16 @@ public class ModCompatHelper {
         return hasIris;
     }
 
-    public static void markSodiumFacadeMixinActive() {
-        sodiumFacadeMixinActive = true;
+    public static void markSodiumFacadeStateMixinActive() {
+        sodiumFacadeStateMixinActive = true;
+    }
+
+    public static void markSodiumFacadeModelMixinActive() {
+        sodiumFacadeModelMixinActive = true;
     }
 
     public static boolean isSodiumFacadeMixinActive() {
-        return sodiumFacadeMixinActive;
+        return sodiumFacadeStateMixinActive && sodiumFacadeModelMixinActive;
     }
 
     private static void init() {

--- a/enderio/src/main/java/com/enderio/enderio/compat/ModCompatHelper.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/ModCompatHelper.java
@@ -7,7 +7,11 @@ public class ModCompatHelper {
     private static boolean initialized = false;
     private static boolean hasJEI;
     private static boolean hasIris;
-    private static boolean hasSodium;
+
+    // Set by SodiumConduitFacadeMixin the first time it runs, proving the injection actually applied.
+    // The conduit facade overlay only skips opaque facades once this is confirmed, so a failed mixin
+    // target never leaves opaque facades unrendered by both paths.
+    private static volatile boolean sodiumFacadeMixinActive = false;
 
     public static boolean hasRecipeViewer() {
         init();
@@ -20,16 +24,18 @@ public class ModCompatHelper {
         return hasIris;
     }
 
-    public static boolean hasSodium() {
-        init();
-        return hasSodium;
+    public static void markSodiumFacadeMixinActive() {
+        sodiumFacadeMixinActive = true;
+    }
+
+    public static boolean isSodiumFacadeMixinActive() {
+        return sodiumFacadeMixinActive;
     }
 
     private static void init() {
         if (!initialized) {
             hasJEI = ModList.get().isLoaded("jei");
             hasIris = ModList.get().isLoaded("iris");
-            hasSodium = ModList.get().isLoaded("sodium");
             initialized = true;
         }
     }

--- a/enderio/src/main/java/com/enderio/enderio/compat/ModCompatHelper.java
+++ b/enderio/src/main/java/com/enderio/enderio/compat/ModCompatHelper.java
@@ -7,6 +7,7 @@ public class ModCompatHelper {
     private static boolean initialized = false;
     private static boolean hasJEI;
     private static boolean hasIris;
+    private static boolean hasSodium;
 
     public static boolean hasRecipeViewer() {
         init();
@@ -19,10 +20,16 @@ public class ModCompatHelper {
         return hasIris;
     }
 
+    public static boolean hasSodium() {
+        init();
+        return hasSodium;
+    }
+
     private static void init() {
         if (!initialized) {
             hasJEI = ModList.get().isLoaded("jei");
             hasIris = ModList.get().isLoaded("iris");
+            hasSodium = ModList.get().isLoaded("sodium");
             initialized = true;
         }
     }

--- a/enderio/src/main/java/com/enderio/enderio/mixin/sodium/SodiumConduitFacadeMixin.java
+++ b/enderio/src/main/java/com/enderio/enderio/mixin/sodium/SodiumConduitFacadeMixin.java
@@ -1,0 +1,64 @@
+package com.enderio.enderio.mixin.sodium;
+
+import com.enderio.enderio.client.content.conduits.model.facades.ClientFacadeVisibility;
+import com.enderio.enderio.content.conduits.bundle.ConduitBundleBlockEntity;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+/**
+ * Makes Sodium render an opaque full-block conduit facade in place of the conduit bundle: the facade
+ * goes through Sodium's own BlockRenderer, so it gets Iris block ids (shader shading), correct lighting
+ * and connected textures for free - instead of being drawn separately via {@code AddSectionGeometryEvent}
+ * (which never receives an Iris block id and therefore renders too bright under shaders, and lets conduit
+ * connections poke through the cover). Transparent facades keep the existing separate render path.
+ */
+@Mixin(targets = "net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer", remap = false)
+public class SodiumConduitFacadeMixin {
+
+    @Nullable
+    private static BlockState enderio$opaqueFacadeAt(BlockPos pos) {
+        if (!ClientFacadeVisibility.areFacadesVisible()) {
+            return null;
+        }
+
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level == null) {
+            return null;
+        }
+
+        Long2ObjectMap<BlockState> facadesForDim = ConduitBundleBlockEntity.FACADES.get(level.dimension());
+        if (facadesForDim == null) {
+            return null;
+        }
+
+        BlockState facade = facadesForDim.get(pos.asLong());
+        if (facade != null && facade.canOcclude()) {
+            return facade;
+        }
+
+        return null;
+    }
+
+    @ModifyVariable(method = "renderModel", at = @At("HEAD"), argsOnly = true, ordinal = 0, remap = false)
+    private BlockState enderio$mirrorState(BlockState state, BakedModel model, BlockState stateArg, BlockPos pos) {
+        BlockState facade = enderio$opaqueFacadeAt(pos);
+        return facade != null ? facade : state;
+    }
+
+    @ModifyVariable(method = "renderModel", at = @At("HEAD"), argsOnly = true, ordinal = 0, remap = false)
+    private BakedModel enderio$mirrorModel(BakedModel model, BakedModel modelArg, BlockState state, BlockPos pos) {
+        BlockState facade = enderio$opaqueFacadeAt(pos);
+        if (facade != null) {
+            return Minecraft.getInstance().getBlockRenderer().getBlockModel(facade);
+        }
+        return model;
+    }
+}

--- a/enderio/src/main/java/com/enderio/enderio/mixin/sodium/SodiumConduitFacadeMixin.java
+++ b/enderio/src/main/java/com/enderio/enderio/mixin/sodium/SodiumConduitFacadeMixin.java
@@ -26,9 +26,6 @@ public class SodiumConduitFacadeMixin {
 
     @Nullable
     private static BlockState enderio$opaqueFacadeAt(BlockPos pos) {
-        // Reaching this method means the injection applied; let the overlay path defer to us.
-        ModCompatHelper.markSodiumFacadeMixinActive();
-
         if (!ClientFacadeVisibility.areFacadesVisible()) {
             return null;
         }
@@ -53,12 +50,16 @@ public class SodiumConduitFacadeMixin {
 
     @ModifyVariable(method = "renderModel", at = @At("HEAD"), argsOnly = true, ordinal = 0, remap = false)
     private BlockState enderio$mirrorState(BlockState state, BakedModel model, BlockState stateArg, BlockPos pos) {
+        // Reaching here proves the state interceptor resolved; the overlay only defers once both do.
+        ModCompatHelper.markSodiumFacadeStateMixinActive();
         BlockState facade = enderio$opaqueFacadeAt(pos);
         return facade != null ? facade : state;
     }
 
     @ModifyVariable(method = "renderModel", at = @At("HEAD"), argsOnly = true, ordinal = 0, remap = false)
     private BakedModel enderio$mirrorModel(BakedModel model, BakedModel modelArg, BlockState state, BlockPos pos) {
+        // Reaching here proves the model interceptor resolved; the overlay only defers once both do.
+        ModCompatHelper.markSodiumFacadeModelMixinActive();
         BlockState facade = enderio$opaqueFacadeAt(pos);
         if (facade != null) {
             return Minecraft.getInstance().getBlockRenderer().getBlockModel(facade);

--- a/enderio/src/main/java/com/enderio/enderio/mixin/sodium/SodiumConduitFacadeMixin.java
+++ b/enderio/src/main/java/com/enderio/enderio/mixin/sodium/SodiumConduitFacadeMixin.java
@@ -1,6 +1,7 @@
 package com.enderio.enderio.mixin.sodium;
 
 import com.enderio.enderio.client.content.conduits.model.facades.ClientFacadeVisibility;
+import com.enderio.enderio.compat.ModCompatHelper;
 import com.enderio.enderio.content.conduits.bundle.ConduitBundleBlockEntity;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import net.minecraft.client.Minecraft;
@@ -25,6 +26,9 @@ public class SodiumConduitFacadeMixin {
 
     @Nullable
     private static BlockState enderio$opaqueFacadeAt(BlockPos pos) {
+        // Reaching this method means the injection applied; let the overlay path defer to us.
+        ModCompatHelper.markSodiumFacadeMixinActive();
+
         if (!ClientFacadeVisibility.areFacadesVisible()) {
             return null;
         }

--- a/enderio/src/main/resources/enderio.sodium.mixins.json
+++ b/enderio/src/main/resources/enderio.sodium.mixins.json
@@ -1,0 +1,12 @@
+{
+    "required" : false,
+    "package" : "com.enderio.enderio.mixin.sodium",
+    "compatibilityLevel" : "JAVA_17",
+    "client" : [
+        "SodiumConduitFacadeMixin"
+    ],
+    "injectors" : {
+        "defaultRequire" : 0
+    },
+    "minVersion" : "0.8"
+}

--- a/enderio/src/main/templates/META-INF/neoforge.mods.toml
+++ b/enderio/src/main/templates/META-INF/neoforge.mods.toml
@@ -16,6 +16,9 @@ featureFlags="META-INF/feature_flags.json"
 [[mixins]]
 config="enderio.mixins.json"
 
+[[mixins]]
+config="enderio.sodium.mixins.json"
+
 [[dependencies.enderio]]
 modId="minecraft"
 type="required"


### PR DESCRIPTION
# Description

Opaque full-block conduit facades were drawn via AddSectionGeometryEvent + vanilla tesselateBlock directly into Sodium's chunk buffer. That path never receives an Iris block id, so under shader packs the facade rendered noticeably too bright compared to the same block placed normally, and conduit connections poked through the cover (issue #1062).

Instead of drawing the facade as a separate overlay, this PR lets Sodium render it natively. A BlockRenderer mixin mirrors the covered conduit bundle to the facade's BlockState + BakedModel for opaque facades, so Sodium draws the facade through its own pipeline — getting shader lighting, connected textures and correct occlusion for free, and replacing the conduit model so connections no longer show through.

Fixes #1062

Design choices

  - Opaque facades only (state.canOcclude()). Transparent facades (glass, etc.) keep the existing AddSectionGeometryEvent path, including the current shader-pack skip — Sodium's native path isn't needed there and changing it risks the translucent preview rendering.
  - Sodium mixin targeted by name (net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer, remap=false, required=false) in a separate enderio.sodium.mixins.json. No Sodium compile/runtime dependency is introduced; the config silently no-ops when Sodium is absent.
  - Gated on facade visibility via ClientFacadeVisibility.areFacadesVisible(), so holding a conduit still hides the facade and reveals the conduits exactly as before (the visibility toggle already marks the sections dirty for a rebuild).
  - The overlay path skips opaque facades when Sodium is loaded so they aren't drawn twice

<!-- If you're submitting a Draft PR, consider providing a TODO list using checkboxes -->

# Breaking Changes

None. No API, item/block, recipe or gameplay changes. Rendering-only, and only active when Sodium is present.

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.  (none needed — internal rendering change)
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
