### PR TITLE
#1404 Found Bug and Fixed It

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlock.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlock.java
@@ -296,6 +296,7 @@ public class ConduitBundleBlock extends Block implements EntityBlock, SimpleWate
                         popResource(level, pos, conduitBundle.getFacadeProvider());
                     } else {
                         var lastConduit = conduitBundle.getConduits().getFirst();
+                        conduitBundle.dropConnectionInventories(lastConduit, stack -> popResource(level, pos, stack));
                         popResource(level, pos, ConduitBlockItem.getStackFor(lastConduit, 1));
                     }
                 }

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
@@ -674,20 +674,7 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
             droppedItemConsumer.accept(ConduitBlockItem.getStackFor(conduit, 1));
 
             // Empty connection inventories.
-            for (Direction side : Direction.values()) {
-                var inventory = getConnectionInventory(conduit, side);
-                if (inventory == null) {
-                    continue;
-                }
-
-                for (int i = 0; i < inventory.getSlots(); i++) {
-                    ItemStack stack = inventory.getStackInSlot(i);
-                    if (!stack.isEmpty()) {
-                        droppedItemConsumer.accept(stack);
-                        inventory.setStackInSlot(i, ItemStack.EMPTY);
-                    }
-                }
-            }
+            dropConnectionInventories(conduit, droppedItemConsumer);
         }
 
         // Node remove event
@@ -719,6 +706,23 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
         }
 
         bundleChanged();
+    }
+
+    public void dropConnectionInventories(Holder<Conduit<?, ?>> conduit, Consumer<ItemStack> droppedItemConsumer) {
+        for (Direction side : Direction.values()) {
+            var inventory = getConnectionInventory(conduit, side);
+            if (inventory == null) {
+                continue;
+            }
+
+            for (int i = 0; i < inventory.getSlots(); i++) {
+                ItemStack stack = inventory.getStackInSlot(i);
+                if (!stack.isEmpty()) {
+                    droppedItemConsumer.accept(stack);
+                    inventory.setStackInSlot(i, ItemStack.EMPTY);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
#1404 
# Description
Didn't drop the inventory when a conduit is the last object of a ConduitBundle.
Created dropConnectionInventories() with already used code to make it reusable.
Reused it in onDestroyedByPlayer() without modifying block entity.

Tested all functions 

# Breaking Changes

# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [X] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.


