### PR TITLE
fix: missing textures for dark steel ladder, end/dark steel bars and soul chain

### DIFF
--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/client/models/EIOBlockStateProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/client/models/EIOBlockStateProvider.java
@@ -89,7 +89,6 @@ public class EIOBlockStateProvider extends ModelProvider {
                 simpleBlockWithModel(blockModels, block.get(), block.get().glassIdentifier().explosionResistance() ? fusedQuartzModel : clearGlassModel);
             }
         }
-
         // Miscellaneous
         blockModels.createAxisAlignedPillarBlockCustomModel(EIOBlocks.SOUL_CHAIN.get(),  plainVariant(ModelLocationUtils.getModelLocation(EIOBlocks.SOUL_CHAIN.get())));
         blockModels.registerSimpleFlatItemModel(EIOBlocks.SOUL_CHAIN.asItem());
@@ -141,13 +140,22 @@ public class EIOBlockStateProvider extends ModelProvider {
     }
 
     public void createBars(BlockModelGenerators blockModels, Block block) {
-        //TODO rendertype
-        MultiVariant multivariant = plainVariant(ModelLocationUtils.getModelLocation(block, "_post_ends"));
-        MultiVariant multivariant1 = plainVariant(ModelLocationUtils.getModelLocation(block, "_post"));
-        MultiVariant multivariant2 = plainVariant(ModelLocationUtils.getModelLocation(block, "_cap"));
-        MultiVariant multivariant3 = plainVariant(ModelLocationUtils.getModelLocation(block, "_cap_alt"));
-        MultiVariant multivariant4 = plainVariant(ModelLocationUtils.getModelLocation(block, "_side"));
-        MultiVariant multivariant5 = plainVariant(ModelLocationUtils.getModelLocation(block, "_side_alt"));
+        TextureMapping textures = TextureMapping.bars(block);
+
+        Identifier postEnds = ModelTemplates.BARS_POST_ENDS.create(block, textures, blockModels.modelOutput);
+        Identifier post     = ModelTemplates.BARS_POST.create(block, textures, blockModels.modelOutput);
+        Identifier cap      = ModelTemplates.BARS_CAP.create(block, textures, blockModels.modelOutput);
+        Identifier capAlt   = ModelTemplates.BARS_CAP_ALT.create(block, textures, blockModels.modelOutput);
+        Identifier side     = ModelTemplates.BARS_POST_SIDE.create(block, textures, blockModels.modelOutput);
+        Identifier sideAlt  = ModelTemplates.BARS_POST_SIDE_ALT.create(block, textures, blockModels.modelOutput);
+
+        MultiVariant multivariant  = plainVariant(postEnds);
+        MultiVariant multivariant1 = plainVariant(post);
+        MultiVariant multivariant2 = plainVariant(cap);
+        MultiVariant multivariant3 = plainVariant(capAlt);
+        MultiVariant multivariant4 = plainVariant(side);
+        MultiVariant multivariant5 = plainVariant(sideAlt);
+
         blockModels.blockStateOutput
             .accept(
                 MultiPartGenerator.multiPart(block)

--- a/enderio/src/datagen/java/com/enderio/enderio/datagen/client/models/EIOBlockStateProvider.java
+++ b/enderio/src/datagen/java/com/enderio/enderio/datagen/client/models/EIOBlockStateProvider.java
@@ -90,7 +90,7 @@ public class EIOBlockStateProvider extends ModelProvider {
             }
         }
         // Miscellaneous
-        blockModels.createAxisAlignedPillarBlockCustomModel(EIOBlocks.SOUL_CHAIN.get(),  plainVariant(ModelLocationUtils.getModelLocation(EIOBlocks.SOUL_CHAIN.get())));
+        blockModels.createAxisAlignedPillarBlockCustomModel(EIOBlocks.SOUL_CHAIN.get(),  plainVariant(TexturedModel.CHAIN.create(EIOBlocks.SOUL_CHAIN.get(), blockModels.modelOutput)));
         blockModels.registerSimpleFlatItemModel(EIOBlocks.SOUL_CHAIN.asItem());
 
         Identifier Identifier = ModelLocationUtils.decorateItemModelLocation("template_skull");

--- a/enderio/src/main/resources/assets/enderio/models/block/dark_steel_ladder.json
+++ b/enderio/src/main/resources/assets/enderio/models/block/dark_steel_ladder.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/ladder",
+  "render_type": "minecraft:cutout_mipped",
+  "textures": {
+    "particle": "enderio:block/dark_steel_ladder",
+    "texture": "enderio:block/dark_steel_ladder"
+  }
+}

--- a/enderio/src/main/resources/assets/enderio/models/block/soul_chain.json
+++ b/enderio/src/main/resources/assets/enderio/models/block/soul_chain.json
@@ -1,0 +1,7 @@
+{
+  "parent": "minecraft:block/template_chain",
+  "textures": {
+    "all": "enderio:block/soul_chain",
+    "particle": "enderio:block/soul_chain"
+  }
+}

--- a/enderio/src/main/resources/assets/enderio/models/block/soul_chain.json
+++ b/enderio/src/main/resources/assets/enderio/models/block/soul_chain.json
@@ -1,7 +1,0 @@
-{
-  "parent": "minecraft:block/template_chain",
-  "textures": {
-    "all": "enderio:block/soul_chain",
-    "particle": "enderio:block/soul_chain"
-  }
-}


### PR DESCRIPTION


# Description
Changed createBars() to create models for End and Dark Steel Bar.
Added dark_steel_ladder.json and soul_chain.json to models to assets because Minecraft has no blocModels.createLadder() and just blockModels.createCopperChain(); but then you have to add two textures.
Because there is just respectively one item of that kind I added the models manually.

Block Detector doesn't have texture like in 1.21.1.

fixes: #1412 