### PR TITLE
fix: Z-fighting between facades and conduit connector plates

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/client/content/conduits/ConduitFacadeRendering.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/conduits/ConduitFacadeRendering.java
@@ -95,6 +95,15 @@ public class ConduitFacadeRendering {
                 context.getPoseStack()
                         .translate(entry.getKey().getX() & 15, entry.getKey().getY() & 15, entry.getKey().getZ() & 15);
 
+                if (!opaque) {
+                    // The translucent "ghost" facade is rendered together with the conduits inside it.
+                    // Inflate it slightly so its faces are not coplanar with conduit connector plates,
+                    // which would otherwise z-fight (GH-1119).
+                    context.getPoseStack().translate(0.5, 0.5, 0.5);
+                    context.getPoseStack().scale(1.005f, 1.005f, 1.005f);
+                    context.getPoseStack().translate(-0.5, -0.5, -0.5);
+                }
+
                 var state = entry.getValue();
                 var pos = entry.getKey();
 

--- a/enderio/src/main/java/com/enderio/enderio/client/content/conduits/model/bundle/ConduitBundleRenderState.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/conduits/model/bundle/ConduitBundleRenderState.java
@@ -69,7 +69,10 @@ public class ConduitBundleRenderState {
         renderState.hasFacade = bundle.hasFacade();
         if (renderState.hasFacade) {
             renderState.facadeBlockstate = bundle.getFacadeBlock().defaultBlockState();
-            renderState.doesFacadeHideConduits = bundle.getFacadeType().doesHideConduits();
+            // Occluding facades fully cover the conduits, so skip rendering them to avoid
+            // z-fighting between the facade faces and conduit connector plates (GH-1119).
+            renderState.doesFacadeHideConduits = bundle.getFacadeType().doesHideConduits()
+                    || renderState.facadeBlockstate.canOcclude();
         } else {
             renderState.facadeBlockstate = Blocks.AIR.defaultBlockState();
             renderState.doesFacadeHideConduits = false;

--- a/enderio/src/main/java/com/enderio/enderio/client/content/conduits/model/bundle/ConduitBundleRenderState.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/conduits/model/bundle/ConduitBundleRenderState.java
@@ -5,10 +5,12 @@ import com.enderio.enderio.api.conduits.Conduit;
 import com.enderio.enderio.api.conduits.bundle.ConduitBundle;
 import com.enderio.enderio.client.content.conduits.model.modifier.ConduitModelModifiers;
 import com.enderio.enderio.content.conduits.OffsetHelper;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.fml.LogicalSide;
@@ -69,10 +71,12 @@ public class ConduitBundleRenderState {
         renderState.hasFacade = bundle.hasFacade();
         if (renderState.hasFacade) {
             renderState.facadeBlockstate = bundle.getFacadeBlock().defaultBlockState();
-            // Occluding facades fully cover the conduits, so skip rendering them to avoid
-            // z-fighting between the facade faces and conduit connector plates (GH-1119).
+            // Facades that render as a full solid cube fully cover the conduits, so skip
+            // rendering them to avoid z-fighting between the facade faces and conduit
+            // connector plates (GH-1119). isSolidRender is used rather than canOcclude so
+            // that partial blocks (slabs etc.) keep the conduits visible.
             renderState.doesFacadeHideConduits = bundle.getFacadeType().doesHideConduits()
-                    || renderState.facadeBlockstate.canOcclude();
+                    || renderState.facadeBlockstate.isSolidRender(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
         } else {
             renderState.facadeBlockstate = Blocks.AIR.defaultBlockState();
             renderState.doesFacadeHideConduits = false;


### PR DESCRIPTION
# Description

Fixes #1119.

Two related rendering fixes for facade z-fighting:

**Opaque facades:** BASIC/HARDENED facades don't hide the conduit geometry (`doesHideConduits()` is only true for the transparent types), so the whole conduit mesh is still baked under an opaque facade. Everything is occluded anyway except the connector plates, which sit exactly on the block boundary — coplanar with the facade's own faces, hence the flicker at connection points. `ConduitBundleRenderState` now also treats a facade as conduit-hiding when its paint block is occluding (`canOcclude()`). If the paint block is occluding you can't see the conduits anyway, so skipping them costs nothing; glass-like paints keep the current behaviour.

**Ghost mode:** while holding a wrench/conduit the facade renders translucent with the conduits intentionally visible, so the same coplanarity shows up there too and fix #1 can't apply. The ghost facade is now inflated by 0.5% around the block center before tessellation, which takes its faces just off the conduit planes. +0.25% per side isn't visually noticeable.

To test:
1. Run a conduit through a block and connect something so a connector plate sits on a face. Cover it with a facade painted with any opaque block (stone bricks etc.) — no more flicker at the exit point.
2. Hold a yeta wrench so facades go translucent — the plates now render cleanly in front of the ghost instead of fighting with it.

Tested in ATM10 To the Sky (MC 1.21.1, NeoForge 21.1.221, AE2 19.2.17) on top of 8.2.11-beta.

# Breaking Changes

None, rendering only.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
