### PR TITLE
fix: ME conduits not connecting to AE2 cables placed next to them

### DIFF
--- a/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/appeng/MEConduit.java
+++ b/enderio-modded-conduits/src/main/java/com/enderio/modded_conduits/common/modules/appeng/MEConduit.java
@@ -68,7 +68,21 @@ public record MEConduit(ResourceLocation texture, Component description, AEColor
 
     @Override
     public boolean shouldCheckConnectionsOnNeighborChange() {
-        return false;
+        // canConnectToBlock does not use the ConduitCapabilityAccessor (it queries the AE2 grid
+        // directly), so there is no capability invalidation listener to trigger connection checks.
+        // Without checking on neighbor changes, an AE2 cable placed next to an existing ME conduit
+        // never forms a conduit-side connection, leaving the grid node unexposed on that side and
+        // the cable visually disconnected.
+        return true;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean hasConnectionDelay() {
+        // AE2 creates in-world grid nodes on the block entity's first tick, so a neighbor-change
+        // check that runs during placement sees no exposed node yet. Deferring the check by a
+        // couple of ticks lets the neighbor's grid node come up first.
+        return true;
     }
 
     @Override


### PR DESCRIPTION
# Description

Placement order matters way more than it should for ME conduits: cable + cable + conduit-in-the-middle works fine, but conduit-first and a second cable placed later leaves that cable visually disconnected, and the grid connection on that side never forms either. Replacing the cable is the usual workaround.

Root cause, as far as I can tell: `MEConduit#shouldCheckConnectionsOnNeighborChange()` returned false, but `canConnectToBlock` doesn't go through the `ConduitCapabilityAccessor` — it queries `GridHelper.getExposedNode` directly — so there's no capability invalidation listener covering it either (the javadoc on `Conduit#shouldCheckConnectionsOnNeighborChange` says false is only valid when the accessor handles that). Net result: a cable appearing next to an existing conduit never triggers `tryConnectTo` at all. And because `onConnectionsUpdated` narrows the node exposure to the connected sides, the node is never exposed toward the new cable, so AE2 never creates the in-world grid connection — `CablePart` draws its arms from `IGridNode#getConnectedSides`, so the cable stays visually disconnected. That's also why conduit-placed-last works: at that point the node still has its default all-sides exposure.

Changes:
- Re-enable connection checks on neighbor changes for the ME conduit.
- Give it a connection delay: AE2 creates its in-world grid nodes on the block entity's first tick, so a synchronous check during placement still sees no exposed node on a freshly placed cable. The deferred `UpdateState` re-check a couple of ticks later is enough. I know `hasConnectionDelay` is deprecated — if you'd rather solve this through the accessor with `AECapabilities.IN_WORLD_GRID_NODE_HOST`, happy to rework it, though the first-tick timing will still want some kind of deferred re-check.

With both changes every placement order connects properly and removing a cable now cleanly disconnects the conduit side too.

Note: `RSConduit` looks like it has the same problem (returns false without using the accessor) — not touched here.

To test:
1. Row of 3 blocks, place an ME Conduit in the middle first.
2. Cable on one end — connects. Cable on the other end — previously stayed visually disconnected, now connects within a couple of ticks.
3. Break one cable — the conduit side disconnects cleanly.
4. Also try cable/cable first, conduit last — still fine.

Tested in ATM10 To the Sky (MC 1.21.1, NeoForge 21.1.221, AE2 19.2.17) on top of 8.2.11-beta.

# Breaking Changes

None.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.
