### PR TITLE
fix: Re-check connections a few ticks after capability invalidation

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/bundle/ConduitBundleBlockEntity.java
@@ -125,6 +125,12 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
     // Deferred connection check
     private UpdateState checkConnection = UpdateState.NONE;
 
+    // Late connection re-check, armed by capability invalidation. Some neighbors (e.g.
+    // Mekanism transmitters) only finish exposing their capabilities on their first tick,
+    // after the quick check has already run, and never fire another invalidation (GH-1433).
+    private int lateConnectionCheck = 0;
+    private static final int LATE_CONNECTION_CHECK_DELAY = 10;
+
     // NBT Keys
     private static final String FACADE_PROVIDER_KEY = "FacadeProvider";
     private static final String CONDUITS_KEY = "Conduits";
@@ -178,6 +184,10 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
         if (level != null) {
             checkConnection = checkConnection.next();
             if (checkConnection.isInitialized()) {
+                updateConnections(level, getBlockPos(), null, false);
+            }
+
+            if (lateConnectionCheck > 0 && --lateConnectionCheck == 0) {
                 updateConnections(level, getBlockPos(), null, false);
             }
 
@@ -1017,6 +1027,7 @@ public final class ConduitBundleBlockEntity extends EnderBlockEntity
 
     private void onCapabilityInvalidated() {
         checkConnection = checkConnection.activate();
+        lateConnectionCheck = LATE_CONNECTION_CHECK_DELAY;
     }
 
     private NeighboringCapabilityCaches getCacheFor(Holder<Conduit<?, ?>> conduit) {


### PR DESCRIPTION
# Description

Should address #1433 - I couldn't reproduce it on my own setup (it looks tick-order dependent), so this is a fix based on reading the code. Confirmation from someone who can reproduce it would be ideal.

When a block is placed next to a conduit, the capability invalidation arms the deferred `UpdateState` check, which runs a tick or two later. Some neighbors - Mekanism transmitters being the reported case - only finish exposing their capabilities on their own first tick, and depending on block entity tick order the conduit's check can run just before that. The conduit then caches the missing capability, and since the neighbor's later internal state change never fires another invalidation, the connection is never attempted again. That matches the report pretty exactly: the Mekanism cable looks connected (it makes its own decision when it queries the conduit's cap), the conduit side stays disconnected and transfers nothing, and breaking/replacing the conduit "fixes" it because a fresh placement re-checks all sides after the neighbor has long settled.

The change: whenever a neighboring capability is invalidated, arm a one-shot late re-check that runs ~10 ticks later, in addition to the existing quick check. It's a single extra `updateConnections` pass per invalidation burst, nothing is persisted, and already-connected sides aren't touched (they don't pass `canConnect()`), so the cost is negligible. It's also generic - any neighbor that initializes late gets picked up, not just Mekanism cables.

To test:
1. Place an EnderIO energy conduit first, then a Mekanism universal cable next to it (the failing order from the report; might need a few attempts since it depends on tick order).
2. Power should flow without having to break/replace anything.

Tested in ATM10 To the Sky (MC 1.21.1, NeoForge 21.1.221) - no regressions in conduit/cable behaviour on my end, though as said I couldn't trigger the original race myself either way.

# Breaking Changes

None.

# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

