### PR TITLE
Fix: farming station screen width

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/client/content/machines/gui/screen/FarmingStationScreen.java
+++ b/enderio/src/main/java/com/enderio/enderio/client/content/machines/gui/screen/FarmingStationScreen.java
@@ -18,7 +18,7 @@ public class FarmingStationScreen extends MachineScreen<FarmingStationMenu> {
     public static final ResourceLocation BG_TEXTURE = EnderIO.rl("textures/gui/screen/farm_station.png");
     private static final ResourceLocation RANGE_BUTTON_TEXTURE = EnderIO.rl("textures/gui/icons/range_buttons.png");
 
-    private static final int WIDTH = 176;
+    private static final int WIDTH = 184;
     private static final int HEIGHT = 169;
 
     public FarmingStationScreen(FarmingStationMenu menu, Inventory inventory, Component title) {
@@ -34,17 +34,17 @@ public class FarmingStationScreen extends MachineScreen<FarmingStationMenu> {
         addRenderableOnly(new CapacitorEnergyWidget(leftPos + 16, topPos + 14, 9, 45, menu::getEnergyStorage,
                 menu::isCapacitorInstalled));
 
-        addRenderableWidget(new RedstoneControlPickerWidget(leftPos + imageWidth - 16, topPos + 6,
+        addRenderableWidget(new RedstoneControlPickerWidget(leftPos + imageWidth - 6 - 16, topPos + 6,
                 menu::getRedstoneControl, menu::setRedstoneControl, EIOCommonLang.REDSTONE_MODE));
 
         var overlay = addIOConfigOverlay(1, leftPos + 7, topPos + 86, 162, 76);
-        addIOConfigButton(leftPos + imageWidth - 16, topPos + 6 + 16 + 2, overlay);
+        addIOConfigButton(leftPos + imageWidth - 6 - 16, topPos + 6 + 16 + 2, overlay);
 
-        addRenderableWidget(EIOCommonWidgets.createRange(leftPos + imageWidth - 16, topPos + 6 + (16 + 2) * 2,
+        addRenderableWidget(EIOCommonWidgets.createRange(leftPos + imageWidth - 6 - 16, topPos + 6 + (16 + 2) * 2,
             MachinesLang.HIDE_RANGE, MachinesLang.SHOW_RANGE, menu::isRangeVisible,
             (ignore) -> handleButtonPress(FarmingStationMenu.VISIBILITY_BUTTON_ID)));
 
-        addRenderableOnly(new ActivityWidget(leftPos + imageWidth - 16, topPos + 62, menu::getMachineStates, false));
+        addRenderableOnly(new ActivityWidget(leftPos + imageWidth - 6 - 16, topPos + 62, menu::getMachineStates, false));
 
     }
 

--- a/enderio/src/main/java/com/enderio/enderio/init/EIOBlocks.java
+++ b/enderio/src/main/java/com/enderio/enderio/init/EIOBlocks.java
@@ -481,13 +481,14 @@ public class EIOBlocks {
         BlockDetectorBlock::new,
         BlockBehaviour.Properties.ofFullCopy(Blocks.OBSERVER));
 
-    // Obelisks
-    public static final DeferredBlock<MachineBlock<XPObeliskBlockEntity>> XP_OBELISK =
-        obelisk("xp_obelisk", () -> EIOBlockEntities.XP_OBELISK::get);
-
+    // Farming Station
     public static final DeferredBlock<FarmingStationBlock> FARMING_STATION = registerWithItem("farming_station",
         FarmingStationBlock::new,
         BlockBehaviour.Properties.of().strength(2.5f, 8));
+
+    // Obelisks
+    public static final DeferredBlock<MachineBlock<XPObeliskBlockEntity>> XP_OBELISK =
+        obelisk("xp_obelisk", () -> EIOBlockEntities.XP_OBELISK::get);
 
     public static final DeferredBlock<MachineBlock<InhibitorObeliskBlockEntity>> INHIBITOR_OBELISK =
         obelisk("inhibitor_obelisk", () -> EIOBlockEntities.INHIBITOR_OBELISK::get);

--- a/enderio/src/main/java/com/enderio/enderio/init/EIOMenus.java
+++ b/enderio/src/main/java/com/enderio/enderio/init/EIOMenus.java
@@ -123,9 +123,9 @@ public class EIOMenus {
 
     public static final DeferredHolder<MenuType<?>, MenuType<TravelAnchorMenu>> TRAVEL_ANCHOR = MENUS.register("travel_anchor", TravelAnchorMenu::new);
 
-    public static final DeferredHolder<MenuType<?>, MenuType<XPObeliskMenu>> XP_OBELISK = MENUS.register("xp_obelisk", XPObeliskMenu::new);
-
     public static final DeferredHolder<MenuType<?>, MenuType<FarmingStationMenu>> FARMING_STATION = MENUS.register("farming_station", FarmingStationMenu::new);
+
+    public static final DeferredHolder<MenuType<?>, MenuType<XPObeliskMenu>> XP_OBELISK = MENUS.register("xp_obelisk", XPObeliskMenu::new);
 
     public static final DeferredHolder<MenuType<?>, MenuType<InhibitorObeliskMenu>> INHIBITOR_OBELISK = MENUS.register("inhibitor_obelisk",
         InhibitorObeliskMenu::new);


### PR DESCRIPTION
# Description

I am new to contributing to minecraft mods and I was trying to fix the GUI screen of the farming station, which was cut off. Please see the picture below:
<img width="929" height="425" alt="Cut off screen" src="https://github.com/user-attachments/assets/250bb7af-35c4-4e98-8305-0d2970ddd408" />
I propose to increase the width to include the border, but was wondering if the water tank was left out on purpose in the new design choices. 
<img width="2256" height="1504" alt="Screenshot_20260901_195816" src="https://github.com/user-attachments/assets/20041843-aa46-4952-9e84-d4f1dedfafcd" />
# Breaking Changes

No breaking changes

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation. I am not sure which documentation to change.
- [X] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->

Thank you to all the maintainers for keeping this mod alive.
