### PR TITLE
Fix: farming station farm tasks

### DIFF
--- a/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantBlockFarmTask.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantBlockFarmTask.java
@@ -23,7 +23,7 @@ public class PlantBlockFarmTask implements FarmTask {
     public <T extends BlockEntity & FarmingMachine> FarmInteraction process(BlockPos targetBlock, T blockEntity) {
         ItemStack seeds = blockEntity.getSeedsForPos(targetBlock);
         if (seeds.isEmpty() || blockEntity.getLevel().getBlockState(targetBlock).isAir()) {
-            return FarmInteraction.BLOCKED;
+            return FarmInteraction.IGNORED;
         }
         if (seeds.getItem() instanceof BlockItem blockItem) {
             var block = blockItem.getBlock();

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantCropFarmTask.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantCropFarmTask.java
@@ -22,7 +22,7 @@ public class PlantCropFarmTask implements FarmTask {
     public <T extends BlockEntity & FarmingMachine> FarmInteraction process(BlockPos targetBlock, T blockEntity) {
         ItemStack seeds = blockEntity.getSeedsForPos(targetBlock);
         if (seeds.isEmpty() || blockEntity.getLevel().getBlockState(targetBlock).isAir()) {
-            return FarmInteraction.BLOCKED;
+            return FarmInteraction.IGNORED;
         }
 
         if (seeds.getItem() instanceof BlockItem blockItem) {

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantNetherWartFarmTask.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantNetherWartFarmTask.java
@@ -21,7 +21,7 @@ public class PlantNetherWartFarmTask implements FarmTask {
     public <T extends BlockEntity & FarmingMachine> FarmInteraction process(BlockPos targetBlock, T blockEntity) {
         ItemStack seeds = blockEntity.getSeedsForPos(targetBlock);
         if (seeds.isEmpty() || blockEntity.getLevel().getBlockState(targetBlock).isAir()) {
-            return FarmInteraction.BLOCKED;
+            return FarmInteraction.IGNORED;
         }
         if (seeds.getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof NetherWartBlock) {
             InteractionResult result = blockEntity.useStack(targetBlock, seeds);

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantSaplingFarmTask.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/farming_station/tasks/PlantSaplingFarmTask.java
@@ -21,7 +21,7 @@ public class PlantSaplingFarmTask implements FarmTask {
     public <T extends BlockEntity & FarmingMachine> FarmInteraction process(BlockPos targetBlock, T blockEntity) {
         ItemStack seeds = blockEntity.getSeedsForPos(targetBlock);
         if (seeds.isEmpty() || blockEntity.getLevel().getBlockState(targetBlock).isAir()) {
-            return FarmInteraction.BLOCKED;
+            return FarmInteraction.IGNORED;
         }
         if (seeds.getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof SaplingBlock) {
             InteractionResult result = blockEntity.useStack(targetBlock, seeds);


### PR DESCRIPTION
# Description

I noticed when trying to use the farming station for melons, that I could not get it to farm a prepared area.
This is because when a farming station has no available seeds it hangs on the blocked PlantTasks. I propose to allow the farming station to complete the other tasks. I managed to get the farming station to farm melons if melon seeds are provided but then it plants the melons on every block and melons can only grow on certain blocks (see: https://minecraft.wiki/w/Melon#Farming). So a solution without any code changes would be to set e.g. moss blocks where melons are supposed to grow. This was quite unintuitive for me. So I changed the behavior of the PlantTasks to return IGNORED instead of BLOCKED when there are no seeds or if the block is air. 
I tested both different versions and have recordings that are too large to attach but can provide on request.
I formated the BonemealFarmTask as well.

<img width="2256" height="1416" alt="Prepared melon area in question" src="https://github.com/user-attachments/assets/4c53a5ef-a2f6-4ceb-92b6-73e49a461e9e" />


# Breaking Changes
No breaking changes

# Checklist

- [X] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [ ] I have made corresponding changes to the documentation.
- [X] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->

Thank you (:
