### PR TITLE
Fix fluid component handling

### DIFF
--- a/endercore/src/main/java/com/enderio/core/common/capability/EnderFluidUtil.java
+++ b/endercore/src/main/java/com/enderio/core/common/capability/EnderFluidUtil.java
@@ -1,0 +1,25 @@
+package com.enderio.core.common.capability;
+
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
+
+public class EnderFluidUtil {
+    public static boolean isEmpty(IFluidHandler fluidHandler) {
+        for (int i = 0; i < fluidHandler.getTanks(); i++) {
+            if (fluidHandler.getFluidInTank(i).getAmount() >= fluidHandler.getTankCapacity(i)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static boolean isFull(IFluidHandler fluidHandler) {
+        for (int i = 0; i < fluidHandler.getTanks(); i++) {
+            if (fluidHandler.getFluidInTank(i).getAmount() < fluidHandler.getTankCapacity(i)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/endercore/src/main/java/com/enderio/core/common/capability/EnderFluidUtil.java
+++ b/endercore/src/main/java/com/enderio/core/common/capability/EnderFluidUtil.java
@@ -5,7 +5,7 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 public class EnderFluidUtil {
     public static boolean isEmpty(IFluidHandler fluidHandler) {
         for (int i = 0; i < fluidHandler.getTanks(); i++) {
-            if (fluidHandler.getFluidInTank(i).getAmount() >= fluidHandler.getTankCapacity(i)) {
+            if (!fluidHandler.getFluidInTank(i).isEmpty()) {
                 return false;
             }
         }

--- a/endercore/src/main/java/com/enderio/core/common/capability/StrictFluidHandlerItemStack.java
+++ b/endercore/src/main/java/com/enderio/core/common/capability/StrictFluidHandlerItemStack.java
@@ -56,7 +56,7 @@ public class StrictFluidHandlerItemStack extends FluidHandlerItemStack {
     @Override
     public int fill(FluidStack resource, FluidAction doFill) {
         if (!getFluid().isEmpty() && fluidPredicate.test(resource.getFluid())) {
-            resource = new FluidStack(getFluid().getFluid(), resource.getAmount());
+            resource = getFluid().copyWithAmount(resource.getAmount());
         }
         return super.fill(resource, doFill);
     }

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/EnderIOTests.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/EnderIOTests.java
@@ -1,24 +1,36 @@
 package com.enderio.enderio.gametests;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.serialization.Codec;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.ExtraCodecs;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.testframework.conf.ClientConfiguration;
 import net.neoforged.testframework.conf.Feature;
 import net.neoforged.testframework.conf.FrameworkConfiguration;
 import net.neoforged.testframework.impl.MutableTestFramework;
 import org.lwjgl.glfw.GLFW;
 
+import java.util.function.UnaryOperator;
+
 @Mod(EnderIOTests.MOD_ID)
 public class EnderIOTests {
 
     public static final String MOD_ID = "enderio_tests";
+
+    private static final DeferredRegister<DataComponentType<?>> DATA_COMPONENT_TYPES = DeferredRegister.create(Registries.DATA_COMPONENT_TYPE, MOD_ID);
+
+    public static final DataComponentType<Integer> TEST_NUMBER = registerDataComponentType("test_number",
+        builder -> builder.persistent(Codec.INT));
 
     public EnderIOTests(IEventBus eventBus, ModContainer container) {
         final MutableTestFramework framework = FrameworkConfiguration
@@ -31,6 +43,8 @@ public class EnderIOTests {
                 .build()
                 .create();
 
+        DATA_COMPONENT_TYPES.register(eventBus);
+
         framework.init(eventBus, container);
 
         NeoForge.EVENT_BUS.addListener((final RegisterCommandsEvent event) -> {
@@ -38,5 +52,11 @@ public class EnderIOTests {
             framework.registerCommands(node);
             event.getDispatcher().register(node);
         });
+    }
+
+    private static <T> DataComponentType<T> registerDataComponentType(String name, UnaryOperator<DataComponentType.Builder<T>> builder) {
+        var componentType = builder.apply(DataComponentType.builder()).build();
+        DATA_COMPONENT_TYPES.register(name, () -> componentType);
+        return componentType;
     }
 }

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/conduits/fluid/FluidConduitTests.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/conduits/fluid/FluidConduitTests.java
@@ -2,6 +2,7 @@ package com.enderio.enderio.gametests.conduits.fluid;
 
 import com.enderio.enderio.EnderIO;
 import com.enderio.enderio.api.io.RedstoneControl;
+import com.enderio.enderio.gametests.EnderIOTests;
 import com.enderio.enderio.gametests.conduits.ConduitGameTestHelper;
 import com.enderio.enderio.content.conduits.type.fluid.FluidConduit;
 import com.enderio.enderio.content.conduits.type.fluid.FluidConduitConnectionConfig;
@@ -12,6 +13,7 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.RegisterStructureTemplate;
@@ -24,6 +26,7 @@ import java.util.function.Supplier;
 public class FluidConduitTests {
 
     private static final String THREE_TANKS = EnderIO.MOD_ID + ":fluid_conduit_three_tanks";
+    private static final String TWO_TANKS = EnderIO.MOD_ID + ":fluid_conduit_two_tanks";
 
     // @formatter:off
     @RegisterStructureTemplate(THREE_TANKS)
@@ -35,6 +38,15 @@ public class FluidConduitTests {
             // Receivers
             .set(0, 0, 2, EIOBlocks.FLUID_TANK.get().defaultBlockState())
             .set(2, 0, 2, EIOBlocks.FLUID_TANK.get().defaultBlockState())
+    );
+    // @formatter:on
+
+    // @formatter:off
+    @RegisterStructureTemplate(TWO_TANKS)
+    public static final Supplier<StructureTemplate> TWO_TANKS_TEMPLATE = StructureTemplateBuilder.lazy(3, 1, 1,
+        builder -> builder
+            .set(0, 0, 0, EIOBlocks.FLUID_TANK.get().defaultBlockState())
+            .set(2, 0, 0, EIOBlocks.FLUID_TANK.get().defaultBlockState())
     );
     // @formatter:on
 
@@ -140,6 +152,37 @@ public class FluidConduitTests {
             // Ensure the fluid moves to the closer tank
             .thenExecuteAfter(tickRate, () -> helper.assertContainerHasExactly(0, 1, 2, Fluids.WATER, 1))
             .thenExecute(() -> helper.assertContainerHasExactly(2, 1, 2, Fluids.WATER, 0))
+            .thenSucceed();
+    }
+
+    @GameTest(template = TWO_TANKS)
+    @TestHolder(description = "Ensures fluid conduits keep fluid components intact.")
+    public static void fluidConduitsKeepComponents(final ConduitGameTestHelper helper) {
+        var fluidConduit = helper.getConduit(EIOConduits.ENERGETIC_FLUID);
+        final int tickRate = fluidConduit.value().type().getTickRate(fluidConduit);
+
+        var fluidWithComponent = new FluidStack(Fluids.WATER, 1);
+        fluidWithComponent.set(EnderIOTests.TEST_NUMBER, 2);
+
+        helper.startSequence()
+            // Destroy the previous conduit
+            .thenExecute(() -> helper.fillAir(1, 1, 0, 1, 1, 0))
+            // Place a conduit between the tanks
+            .thenExecute(() -> helper.fillConduits(fluidConduit, 1, 1, 0, 1, 1, 0))
+            // Configure the insert ends
+            .thenExecute(() -> helper
+                .getConduitBundle(1, 1, 0, false)
+                .setConnectionConfig(fluidConduit, Direction.EAST, FluidConduitConnectionConfig.DEFAULT.withIsExtract(false).withIsInsert(true)))
+            // Configure the extract end
+            .thenExecute(() -> helper
+                .getConduitBundle(1, 1, 0, false)
+                .setConnectionConfig(fluidConduit, Direction.WEST,
+                    FluidConduitConnectionConfig.DEFAULT.withIsExtract(true).withIsInsert(false).withExtractRedstoneControl(RedstoneControl.ALWAYS_ACTIVE)))
+            // Put some fluid in the tank we'll extract from
+            .thenExecute(() -> helper.fillContainer(0, 1, 0, fluidWithComponent))
+            // Ensure the fluid moves to the next tank with its components intact.
+            .thenExecuteAfter(tickRate, () -> helper.assertContainerHasExactly(2, 1, 0, fluidWithComponent))
+            .thenExecute(() -> helper.assertContainerHasExactly(0, 1, 0, Fluids.WATER, 0))
             .thenSucceed();
     }
 

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/content/storage/FluidTankTests.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/content/storage/FluidTankTests.java
@@ -1,0 +1,31 @@
+package com.enderio.enderio.gametests.content.storage;
+
+import com.enderio.enderio.gametests.EnderIOTests;
+import com.enderio.enderio.gametests.util.EnderGameTestHelper;
+import com.enderio.enderio.init.EIOBlocks;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
+
+@ForEachTest(groups = "content.storage")
+public class FluidTankTests {
+    @GameTest
+    @TestHolder(description = "Ensures the fluid tank can store fluids with components")
+    public static void fluidTankStoresComponents(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(1, 1, 1)
+            .set(0, 0, 0, EIOBlocks.FLUID_TANK.get().defaultBlockState()));
+
+        var fluidToInsert = new FluidStack(Fluids.WATER, 1000);
+        fluidToInsert.set(EnderIOTests.TEST_NUMBER, 2);
+
+        // Ensure that after insertion, we could still extract the same fluid with components in tact.
+        test.onGameTest(EnderGameTestHelper.class, helper -> helper.startSequence()
+            .thenExecute(() -> helper.fillContainer(0, 1, 0, fluidToInsert))
+            .thenExecute(() -> helper.assertContainerHasExactly(0, 1, 0, fluidToInsert))
+            .thenSucceed());
+    }
+}

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/util/EnderGameTestHelper.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/util/EnderGameTestHelper.java
@@ -156,19 +156,23 @@ public class EnderGameTestHelper extends ExtendedGameTestHelper {
 
     // endregion
 
-    public void fillContainer(int x, int y, int z, Fluid fluid, int amount) {
+    public void fillContainer(int x, int y, int z, FluidStack stack) {
         var fluidHandler = getLevel().getCapability(Capabilities.FluidHandler.BLOCK, absolutePos(new BlockPos(x, y, z)),
             null);
         if (fluidHandler == null) {
             throw new GameTestAssertException("No fluid handler at " + x + "," + y + "," + z);
         }
 
-        int filled = fluidHandler.fill(new FluidStack(fluid, amount), IFluidHandler.FluidAction.EXECUTE);
+        int filled = fluidHandler.fill(stack, IFluidHandler.FluidAction.EXECUTE);
 
-        if (filled < amount) {
+        if (filled < stack.getAmount()) {
             throw new GameTestAssertException(
-                "Could not fill tank with all " + amount + " of the fluid into container at " + x + "," + y + "," + z);
+                "Could not fill tank with all " + stack.getAmount() + " of the fluid into container at " + x + "," + y + "," + z);
         }
+    }
+
+    public void fillContainer(int x, int y, int z, Fluid fluid, int amount) {
+        fillContainer(x, y, z, new FluidStack(fluid, amount));
     }
 
     public long getAmountInHandler(int x, int y, int z, Fluid fluid) {
@@ -186,6 +190,21 @@ public class EnderGameTestHelper extends ExtendedGameTestHelper {
         }
 
         return totalAmount;
+    }
+
+    public void assertContainerHasExactly(int x, int y, int z, FluidStack stack) {
+        var fluidHandler = getLevel().getCapability(Capabilities.FluidHandler.BLOCK, absolutePos(new BlockPos(x, y, z)),
+            null);
+        if (fluidHandler == null) {
+            throw new GameTestAssertException("No fluid handler at " + x + "," + y + "," + z);
+        }
+
+        int foundAmount = fluidHandler.drain(stack.copyWithAmount(Integer.MAX_VALUE), IFluidHandler.FluidAction.SIMULATE).getAmount();
+
+        if (foundAmount != stack.getAmount()) {
+            throw new GameTestAssertException("Expected " + stack.getAmount() + " of " + stack + " in tank at " + x + "," + y
+                + "," + z + " but found " + foundAmount);
+        }
     }
 
     public void assertContainerHasExactly(int x, int y, int z, Fluid fluid, int amount) {

--- a/enderio/src/main/java/com/enderio/enderio/content/conduits/type/fluid/FluidConduitTicker.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/conduits/type/fluid/FluidConduitTicker.java
@@ -54,20 +54,20 @@ public class FluidConduitTicker extends ConduitTickerBase<FluidConduit> {
                         continue;
                     }
 
-                    Fluid fluid = extractHandler.getFluidInTank(i).getFluid();
+                    FluidStack fluid = extractHandler.getFluidInTank(i);
                     remaining = doFluidTransfer(fluid, remaining, extractConnection, insertPaths, insertedPerPath);
                 }
             }
         }
     }
 
-    private int doFluidTransfer(Fluid fluid, int maxTransfer, ConduitBlockConnection extractConnection,
+    private int doFluidTransfer(FluidStack fluid, int maxTransfer, ConduitBlockConnection extractConnection,
         List<ConduitConnectionPath> insertPaths, Map<ConduitConnectionPath, Integer> insertedPerPath) {
         var extractHandler = Objects
             .requireNonNull(extractConnection.getSidedCapability(Capabilities.FluidHandler.BLOCK));
 
         // Attempt to drain fluid from the target.
-        FluidStack extractedFluid = extractHandler.drain(new FluidStack(fluid, maxTransfer),
+        FluidStack extractedFluid = extractHandler.drain(fluid.copyWithAmount(maxTransfer),
             IFluidHandler.FluidAction.SIMULATE);
         if (extractedFluid.isEmpty()) {
             return maxTransfer;

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/obelisks/xp/XPObeliskBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/obelisks/xp/XPObeliskBlockEntity.java
@@ -75,11 +75,11 @@ public class XPObeliskBlockEntity extends MachineBlockEntity implements FluidTan
 
                 // Convert into XP Juice
                 if (TANK.isFluidValid(this, resource)) {
-                    var currentFluid = TANK.getFluid(this).getFluid();
-                    if (currentFluid == Fluids.EMPTY || resource.getFluid().isSame(currentFluid)) {
+                    FluidStack currentFluid = TANK.getFluid(this);
+                    if (currentFluid.isEmpty() || FluidStack.isSameFluidSameComponents(resource, currentFluid)) {
                         return super.fill(resource, action);
                     } else {
-                        return super.fill(new FluidStack(currentFluid, resource.getAmount()), action);
+                        return super.fill(currentFluid.copyWithAmount(resource.getAmount()), action);
                     }
                 }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/soul_binder/SoulBinderBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/soul_binder/SoulBinderBlockEntity.java
@@ -212,11 +212,11 @@ public class SoulBinderBlockEntity extends PoweredMachineBlockEntity implements 
             public int fill(FluidStack resource, FluidAction action) {
                 // Convert into XP Juice
                 if (TANK.isFluidValid(this, resource)) {
-                    var currentFluid = TANK.getFluid(this).getFluid();
-                    if (currentFluid == Fluids.EMPTY || resource.getFluid().isSame(currentFluid)) {
+                    FluidStack currentFluid = TANK.getFluid(this);
+                    if (currentFluid.isEmpty() || FluidStack.isSameFluidSameComponents(resource, currentFluid)) {
                         return super.fill(resource, action);
                     } else {
-                        return super.fill(new FluidStack(currentFluid, resource.getAmount()), action);
+                        return super.fill(currentFluid.copyWithAmount(resource.getAmount()), action);
                     }
                 }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/machines/soul_engine/SoulEngineBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/machines/soul_engine/SoulEngineBlockEntity.java
@@ -199,11 +199,11 @@ public class SoulEngineBlockEntity extends PoweredMachineBlockEntity implements 
             public int fill(FluidStack resource, FluidAction action) {
                 // Convert into tagged fluid
                 if (TANK.isFluidValid(this, resource)) {
-                    var currentFluid = TANK.getFluid(this).getFluid();
-                    if (currentFluid == Fluids.EMPTY || resource.getFluid().isSame(currentFluid)) {
+                    FluidStack currentFluid = TANK.getFluid(this);
+                    if (currentFluid.isEmpty() || FluidStack.isSameFluidSameComponents(resource, currentFluid)) {
                         return super.fill(resource, action);
                     } else {
-                        return super.fill(new FluidStack(currentFluid, resource.getAmount()), action);
+                        return super.fill(currentFluid.copyWithAmount(resource.getAmount()), action);
                     }
                 }
 

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/FluidTankBlockEntity.java
@@ -1,5 +1,6 @@
 package com.enderio.enderio.content.storage.fluid_tank;
 
+import com.enderio.core.common.capability.EnderFluidUtil;
 import com.enderio.enderio.foundation.attachment.FluidTankUser;
 import com.enderio.enderio.foundation.block.entity.MachineBlockEntity;
 import com.enderio.enderio.foundation.inventory.MachineInventoryLayout;
@@ -115,8 +116,8 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
 
     public boolean acceptItemFill(ItemStack item) {
         // bucket types
-        IFluidHandlerItem fluidHandlerCap = item.getCapability(Capabilities.FluidHandler.ITEM);
-        if (fluidHandlerCap != null) {
+        IFluidHandlerItem fluidHandlerCap = item.copyWithCount(1).getCapability(Capabilities.FluidHandler.ITEM);
+        if (fluidHandlerCap != null && !fluidHandlerCap.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE).isEmpty()) {
             return true;
         }
 
@@ -133,14 +134,15 @@ public abstract class FluidTankBlockEntity extends MachineBlockEntity implements
     }
 
     public boolean acceptItemDrain(ItemStack item) {
-        // bucket types
-        IFluidHandlerItem fluidHandlerCap = item.getCapability(Capabilities.FluidHandler.ITEM);
-        if (fluidHandlerCap != null) {
+        FluidStack fluid = TANK.getFluid(this);
+
+        // Receive items that can accept our current fluid as input -or- if our current contents are empty.
+        IFluidHandlerItem fluidHandlerCap = item.copyWithCount(1).getCapability(Capabilities.FluidHandler.ITEM);
+        if (fluidHandlerCap != null && (fluid.isEmpty() || fluidHandlerCap.fill(fluid.copyWithAmount(Integer.MAX_VALUE), IFluidHandler.FluidAction.SIMULATE) > 0)) {
             return true;
         }
 
         // Mending
-        FluidStack fluid = TANK.getFluid(this);
 
         if (item.isDamageableItem() && !fluid.isEmpty() && fluid.is(Tags.Fluids.EXPERIENCE)) {
             var enchantmentsRecipe = level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/InternalTankTasks.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/InternalTankTasks.java
@@ -1,5 +1,6 @@
 package com.enderio.enderio.content.storage.fluid_tank;
 
+import com.enderio.core.common.capability.EnderFluidUtil;
 import com.enderio.enderio.foundation.attachment.FluidTankUser;
 import com.enderio.enderio.foundation.block.entity.MachineBlockEntity;
 import com.enderio.enderio.foundation.inventory.SingleSlotAccess;
@@ -20,51 +21,50 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
 
 public class InternalTankTasks {
 
-    // TODO: enable fluid tanks to receive stackable fluid containers
     public static <T extends MachineBlockEntity & FluidTankUser> void fillInternal(
         T blockEntity,
         TankAccess tank,
         SingleSlotAccess fluidFillInput,
-        SingleSlotAccess fluidFillOutput
-    ) {
+        SingleSlotAccess fluidFillOutput) {
+
         ItemStack inputItem = fluidFillInput.getItemStack(blockEntity);
-        ItemStack outputItem = fluidFillOutput.getItemStack(blockEntity);
+        if (inputItem.isEmpty()) {
+            return;
+        }
 
-        if (!inputItem.isEmpty()) {
-            if (inputItem.getItem() instanceof BucketItem filledBucket) {
-                if (outputItem.isEmpty() || (outputItem.getItem() == Items.BUCKET
-                    && outputItem.getCount() < outputItem.getMaxStackSize())) {
+        // Only ever handle a single item at a time.
+        ItemStack singleInputItem = inputItem.copyWithCount(1);
+        IFluidHandlerItem fluidHandlerItem = singleInputItem.getCapability(Capabilities.FluidHandler.ITEM);
+        if (fluidHandlerItem == null) {
+            return;
+        }
 
-                    int filled = tank.fill(blockEntity, new FluidStack(filledBucket.content, FluidType.BUCKET_VOLUME),
-                        IFluidHandler.FluidAction.SIMULATE);
+        // See what fluid is available to drain from the item.
+        // We act here because we're acting on a copy of the input.
+        FluidStack availableFluid = fluidHandlerItem.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.EXECUTE);
 
-                    if (filled == FluidType.BUCKET_VOLUME) {
-                        tank.fill(blockEntity, new FluidStack(filledBucket.content, FluidType.BUCKET_VOLUME),
-                            IFluidHandler.FluidAction.EXECUTE);
+        // See if we can insert this fluid into the block's tank.
+        int filled = tank.fill(blockEntity, availableFluid, IFluidHandler.FluidAction.SIMULATE);
+        if (filled <= 0) {
+            return;
+        }
 
-                        inputItem.shrink(1);
-                        fluidFillOutput.insertItem(blockEntity, Items.BUCKET.getDefaultInstance(), false);
-                    }
-                }
-            } else {
-                IFluidHandlerItem fluidHandlerItem = inputItem.getCapability(Capabilities.FluidHandler.ITEM);
-                if (fluidHandlerItem != null && outputItem.isEmpty()) {
-                    int filled = FluidUtil.tryFluidTransfer(
-                        blockEntity.getFluidHandler(),
-                        fluidHandlerItem,
-                        tank.getFluidAmount(blockEntity),
-                        true
-                    ).getAmount();
+        // Get the resulting emptied container
+        ItemStack resultStack = fluidHandlerItem.getContainer();
 
-                    if (filled > 0) {
-                        fluidFillOutput.setStackInSlot(blockEntity, fluidHandlerItem.getContainer());
-                        fluidFillInput.setStackInSlot(blockEntity, ItemStack.EMPTY);
-                    }
-                }
-            }
+        // If this is the only input, and it's not fully empty we will retain it in the input slot, so long as the
+        //  destination tank is not full
+        if (inputItem.getCount() == 1 && !EnderFluidUtil.isEmpty(fluidHandlerItem) && !tank.isFull(blockEntity)) {
+            tank.fill(blockEntity, availableFluid.copyWithAmount(filled), IFluidHandler.FluidAction.EXECUTE);
+            fluidFillInput.setStackInSlot(blockEntity, resultStack);
+        } else if (!fluidFillInput.extractItem(blockEntity, 1, true).isEmpty() &&
+            fluidFillOutput.insertItem(blockEntity, resultStack, true).isEmpty()) {
+
+            tank.fill(blockEntity, availableFluid.copyWithAmount(filled), IFluidHandler.FluidAction.EXECUTE);
+            fluidFillInput.extractItem(blockEntity, 1, false);
+            fluidFillOutput.insertItem(blockEntity, resultStack, false);
         }
     }
-
 
     // TODO: enable fluid tanks to receive stackable fluid containers
     public static <T extends MachineBlockEntity & FluidTankUser> void drainInternal(
@@ -74,47 +74,38 @@ public class InternalTankTasks {
         SingleSlotAccess fluidDrainOutput
     ) {
         ItemStack inputItem = fluidDrainInput.getItemStack(blockEntity);
-        ItemStack outputItem = fluidDrainOutput.getItemStack(blockEntity);
+        if (inputItem.isEmpty()) {
+            return;
+        }
 
-        if (!inputItem.isEmpty()) {
-            if (inputItem.getItem() == Items.BUCKET) {
-                if (!tank.getFluid(blockEntity).isEmpty()) {
-                    FluidStack stack = tank.drain(blockEntity, FluidType.BUCKET_VOLUME, IFluidHandler.FluidAction.SIMULATE);
+        // Only ever handle a single item at a time.
+        ItemStack singleInputItem = inputItem.copyWithCount(1);
+        IFluidHandlerItem fluidHandlerItem = singleInputItem.getCapability(Capabilities.FluidHandler.ITEM);
+        if (fluidHandlerItem == null) {
+            return;
+        }
 
-                    // Ensure there's a bucket to be given to the player.
-                    if (stack.getFluid().getBucket() == Items.AIR) {
-                        return;
-                    }
+        // See what fluid the tank can drain into the item
+        FluidStack availableFluid = tank.drain(blockEntity, Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE);
 
-                    if (stack.getAmount() == FluidType.BUCKET_VOLUME &&
-                        (outputItem.isEmpty() || (outputItem.getItem() == stack.getFluid().getBucket()
-                            && outputItem.getCount() < outputItem.getMaxStackSize()))) {
+        // See if we can insert this fluid into the container
+        int filled = fluidHandlerItem.fill(availableFluid, IFluidHandler.FluidAction.EXECUTE);
+        if (filled <= 0) {
+            return;
+        }
 
-                        tank.drain(blockEntity, FluidType.BUCKET_VOLUME, IFluidHandler.FluidAction.EXECUTE);
-                        inputItem.shrink(1);
-                        if (outputItem.isEmpty()) {
-                            fluidDrainOutput.setStackInSlot(blockEntity, stack.getFluid().getBucket().getDefaultInstance());
-                        } else {
-                            outputItem.grow(1);
-                        }
-                    }
-                }
-            } else {
-                IFluidHandlerItem fluidHandlerItem = inputItem.getCapability(Capabilities.FluidHandler.ITEM);
-                if (fluidHandlerItem != null && outputItem.isEmpty()) {
-                    int filled = FluidUtil.tryFluidTransfer(
-                        fluidHandlerItem,
-                        blockEntity.getFluidHandler(), // méthode à définir dans ton interface
-                        tank.getFluidAmount(blockEntity),
-                        true
-                    ).getAmount();
+        // Get the resulting filled item
+        ItemStack resultStack = fluidHandlerItem.getContainer();
 
-                    if (filled > 0) {
-                        fluidDrainOutput.setStackInSlot(blockEntity, fluidHandlerItem.getContainer());
-                        fluidDrainInput.setStackInSlot(blockEntity, ItemStack.EMPTY);
-                    }
-                }
-            }
+        // If this is the only input, and it isn't completely full, and the destination still has fluid, we will retain it
+        if (inputItem.getCount() == 1 && !EnderFluidUtil.isFull(fluidHandlerItem) && !tank.isEmpty(blockEntity)) {
+            tank.drain(blockEntity, availableFluid.copyWithAmount(filled), IFluidHandler.FluidAction.EXECUTE);
+        } else if (!fluidDrainInput.extractItem(blockEntity, 1, true).isEmpty() &&
+            fluidDrainOutput.insertItem(blockEntity, resultStack, true).isEmpty()) {
+
+            tank.drain(blockEntity, availableFluid.copyWithAmount(filled), IFluidHandler.FluidAction.EXECUTE);
+            fluidDrainInput.extractItem(blockEntity, 1, false);
+            fluidDrainOutput.insertItem(blockEntity, resultStack, false);
         }
     }
 
@@ -151,5 +142,4 @@ public class InternalTankTasks {
             }
         }
     }
-
 }

--- a/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/InternalTankTasks.java
+++ b/enderio/src/main/java/com/enderio/enderio/content/storage/fluid_tank/InternalTankTasks.java
@@ -41,7 +41,7 @@ public class InternalTankTasks {
 
         // See what fluid is available to drain from the item.
         // We act here because we're acting on a copy of the input.
-        FluidStack availableFluid = fluidHandlerItem.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.EXECUTE);
+        FluidStack availableFluid = fluidHandlerItem.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE);
 
         // See if we can insert this fluid into the block's tank.
         int filled = tank.fill(blockEntity, availableFluid, IFluidHandler.FluidAction.SIMULATE);
@@ -100,6 +100,7 @@ public class InternalTankTasks {
         // If this is the only input, and it isn't completely full, and the destination still has fluid, we will retain it
         if (inputItem.getCount() == 1 && !EnderFluidUtil.isFull(fluidHandlerItem) && !tank.isEmpty(blockEntity)) {
             tank.drain(blockEntity, availableFluid.copyWithAmount(filled), IFluidHandler.FluidAction.EXECUTE);
+            fluidDrainInput.setStackInSlot(blockEntity, resultStack);
         } else if (!fluidDrainInput.extractItem(blockEntity, 1, true).isEmpty() &&
             fluidDrainOutput.insertItem(blockEntity, resultStack, true).isEmpty()) {
 

--- a/enderio/src/main/java/com/enderio/enderio/foundation/inventory/SingleSlotAccess.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/inventory/SingleSlotAccess.java
@@ -35,6 +35,18 @@ public class SingleSlotAccess {
         return insertItem(machine.getInventory(), itemStack, simulate);
     }
 
+    public ItemStack extractItem(MachineInventory inventory, int amount, boolean simulate) {
+        return inventory.extractItem(index, amount, simulate);
+    }
+
+    public ItemStack extractItem(MachineInventoryHolder machine, int amount, boolean simulate) {
+        if (!machine.hasInventory()) {
+            throw new IllegalArgumentException("BlockEntity does not have an inventory");
+        }
+
+        return extractItem(machine.getInventory(), amount, simulate);
+    }
+
     public void setStackInSlot(MachineInventory inventory, ItemStack itemStack) {
         inventory.setStackInSlot(index, itemStack);
     }

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
@@ -70,7 +70,7 @@ public class TransferUtil {
         if (canPush) {
             int filled = 0;
             for (int i = 0; i < selfItemHandler.getTanks(); i++) {
-                filled += FluidUtil.tryFluidTransfer(otherItemHandler, selfItemHandler, new FluidStack(selfItemHandler.getFluidInTank(i).getFluid(), Integer.MAX_VALUE), true).getAmount();
+                filled += FluidUtil.tryFluidTransfer(otherItemHandler, selfItemHandler, selfItemHandler.getFluidInTank(i).copyWithAmount(Integer.MAX_VALUE), true).getAmount();
             }
             if (filled > 0) {
                 return;
@@ -82,7 +82,7 @@ public class TransferUtil {
                 if (selfItemHandler.getFluidInTank(i).isEmpty()) {
                     FluidUtil.tryFluidTransfer(selfItemHandler, otherItemHandler, Integer.MAX_VALUE, true);
                 } else {
-                    FluidUtil.tryFluidTransfer(selfItemHandler, otherItemHandler, new FluidStack(selfItemHandler.getFluidInTank(i).getFluid(), Integer.MAX_VALUE), true);
+                    FluidUtil.tryFluidTransfer(selfItemHandler, otherItemHandler, selfItemHandler.getFluidInTank(i).copyWithAmount(Integer.MAX_VALUE), true);
                 }
             }
         }

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/FluidItemInteractive.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/FluidItemInteractive.java
@@ -31,7 +31,7 @@ public interface FluidItemInteractive {
                 //Otherwise, try draining the same type of fluid we have stored
                 // We do this to better support multiple tanks in case the fluid we have stored we could pull out of a block's
                 // second tank but just asking to drain a specific amount
-                fluidInItem = handler.drain(new FluidStack(tankAccess.getFluid(machine).getFluid(), Integer.MAX_VALUE), IFluidHandler.FluidAction.SIMULATE);
+                fluidInItem = handler.drain(tankAccess.getFluid(machine).copyWithAmount(Integer.MAX_VALUE), IFluidHandler.FluidAction.SIMULATE);
             }
             if (fluidInItem.isEmpty()) {
                 if (!tankAccess.isEmpty(machine) && tankAccess.canExtract(machine)) {
@@ -64,7 +64,7 @@ public interface FluidItemInteractive {
                 int filledAmount = tankAccess.fill(machine, fluidInItem, IFluidHandler.FluidAction.SIMULATE);
                 if (filledAmount > 0) {
                     boolean filled = false;
-                    FluidStack fluidToFill = handler.drain(new FluidStack(fluidInItem.getFluid(), filledAmount),
+                    FluidStack fluidToFill = handler.drain(fluidInItem.copyWithAmount(filledAmount),
                         player.isCreative() ? IFluidHandler.FluidAction.SIMULATE : IFluidHandler.FluidAction.EXECUTE);
                     if (!fluidToFill.isEmpty()) {
                         ItemStack container = handler.getContainer();

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/MachineFluidHandler.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/MachineFluidHandler.java
@@ -132,7 +132,7 @@ public class MachineFluidHandler implements IFluidHandler, INBTSerializable<Comp
         }
 
         if (fluid.isEmpty()) {
-            fluid = new FluidStack(resource.getFluid(), Math.min(capacity, resource.getAmount()));
+            fluid = resource.copyWithAmount(Math.min(capacity, resource.getAmount()));
             setFluidInTank(tank, fluid);
             onContentsChanged(tank);
             return fluid.getAmount();
@@ -198,7 +198,7 @@ public class MachineFluidHandler implements IFluidHandler, INBTSerializable<Comp
         if (fluid.getAmount() < drained) {
             drained = fluid.getAmount();
         }
-        FluidStack stack = new FluidStack(fluid.getFluid(), drained);
+        FluidStack stack = fluid.copyWithAmount(drained);
         if (action.execute() && drained > 0) {
             fluid.shrink(drained);
             onContentsChanged(tank);

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/MachineFluidTank.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/MachineFluidTank.java
@@ -42,6 +42,10 @@ public class MachineFluidTank implements IFluidTank {
         return getFluid().isEmpty();
     }
 
+    public boolean isFull() {
+        return getFluid().getAmount() >= getCapacity();
+    }
+
     public int fill(FluidStack resource, IFluidHandler.FluidAction action) {
         return handler.fill(index, resource, action);
     }

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/TankAccess.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/fluid/TankAccess.java
@@ -64,6 +64,14 @@ public class TankAccess {
         return getFluid(handler).isEmpty();
     }
 
+    public boolean isFull(FluidTankUser machine) {
+        return isFull(machine.getFluidHandler());
+    }
+
+    public boolean isFull(MachineFluidHandler handler) {
+        return getTank(handler).isFull();
+    }
+
     public boolean canInsert(FluidTankUser machine) {
         return canInsert(machine.getFluidHandler());
     }


### PR DESCRIPTION
# Description

- Avoid creating fresh FluidStacks, favouring copyWithAmount instead to preserve components
- Remove problematic bucket special casing, does not seem to be required anymore
- Enable fluid conduits to handle fluid components during transfer

Closes: #1415 

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->