### PR TITLE
fix: Machines can dupe items when pushing to neighboring inventories

### DIFF
--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1436.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1436.java
@@ -26,13 +26,19 @@ public class Issue1436 {
 
         test.onGameTest(EnderGameTestHelper.class, helper ->
             helper.startSequence()
-                .thenExecute(() -> helper.insertIntoContainer(0, 1, 0, Items.RAW_GOLD, 64 * 3))
-                .thenExecute(() -> helper.insertIntoContainer(0, 1, 0, EIOItems.OCTADIC_CAPACITOR.get(), 1))
+                // Configure the machine to push all items to the chest
                 .thenExecute(() -> {
                     var alloySmelter = helper.getBlockEntity(0, 1, 0, AlloySmelterBlockEntity.class);
                     alloySmelter.setIOMode(Direction.SOUTH, IOMode.PUSH);
                 })
-                .thenExecuteAfter(600, () -> helper.assertContainerHasExactly(0, 1, 1, Items.GOLD_INGOT, 64 * 3))
+                // Insert raw gold and an octadic capacitor
+                .thenExecute(() -> helper.insertIntoContainer(0, 1, 0, Items.RAW_GOLD, 64 * 3))
+                .thenExecute(() -> helper.insertIntoContainer(0, 1, 0, EIOItems.OCTADIC_CAPACITOR.get(), 1))
+                // Ensure the right amount of Gold was produced, and all raw gold consumed.
+                .thenExecuteAfter(600, () -> {
+                    helper.assertContainerHasExactly(0, 1, 1, Items.GOLD_INGOT, 64 * 3);
+                    helper.assertContainerEmpty(0, 1, 0);
+                })
                 .thenSucceed()
         );
     }

--- a/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1436.java
+++ b/enderio/src/gametest/java/com/enderio/enderio/gametests/regressions/issues/Issue1436.java
@@ -1,0 +1,39 @@
+package com.enderio.enderio.gametests.regressions.issues;
+
+import com.enderio.enderio.api.io.IOMode;
+import com.enderio.enderio.content.machines.alloy.AlloySmelterBlockEntity;
+import com.enderio.enderio.gametests.util.EnderGameTestHelper;
+import com.enderio.enderio.init.EIOBlocks;
+import com.enderio.enderio.init.EIOItems;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
+
+@ForEachTest(groups = "regression.issue1436")
+public class Issue1436 {
+    @GameTest(timeoutTicks = 650)
+    @TestHolder(description = "Ensures an alloy smelter with 3 slots of standard material generates the right result count")
+    public static void testIssue1436(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(2, 1, 2)
+            .set(0, 0, 0, EIOBlocks.ALLOY_SMELTER.get().defaultBlockState())
+            .set(1, 0, 0, EIOBlocks.CREATIVE_POWER.get().defaultBlockState())
+            .set(0, 0, 1, Blocks.CHEST.defaultBlockState()));
+
+        test.onGameTest(EnderGameTestHelper.class, helper ->
+            helper.startSequence()
+                .thenExecute(() -> helper.insertIntoContainer(0, 1, 0, Items.RAW_GOLD, 64 * 3))
+                .thenExecute(() -> helper.insertIntoContainer(0, 1, 0, EIOItems.OCTADIC_CAPACITOR.get(), 1))
+                .thenExecute(() -> {
+                    var alloySmelter = helper.getBlockEntity(0, 1, 0, AlloySmelterBlockEntity.class);
+                    alloySmelter.setIOMode(Direction.SOUTH, IOMode.PUSH);
+                })
+                .thenExecuteAfter(600, () -> helper.assertContainerHasExactly(0, 1, 1, Items.GOLD_INGOT, 64 * 3))
+                .thenSucceed()
+        );
+    }
+}

--- a/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
+++ b/enderio/src/main/java/com/enderio/enderio/foundation/io/TransferUtil.java
@@ -37,9 +37,9 @@ public class TransferUtil {
 
     private static void moveItems(IItemHandler from, IItemHandler to) {
         for (int i = 0; i < from.getSlots(); i++) {
-            ItemStack extracted = from.extractItem(i, from.getSlotLimit(i), true);
-            if (!extracted.isEmpty()) {
-                for (int j = 0; j < to.getSlots(); j++) {
+            for (int j = 0; j < to.getSlots(); j++) {
+                ItemStack extracted = from.extractItem(i, from.getSlotLimit(i), true);
+                if (!extracted.isEmpty()) {
                     ItemStack remainder = to.insertItem(j, extracted, false);
 
                     int successfullyMoved = extracted.getCount() - remainder.getCount();

--- a/enderio/src/test/java/com/enderio/enderio/tests/foundation/io/TransferUtilTests.java
+++ b/enderio/src/test/java/com/enderio/enderio/tests/foundation/io/TransferUtilTests.java
@@ -1,0 +1,89 @@
+package com.enderio.enderio.tests.foundation.io;
+
+import com.enderio.enderio.foundation.io.TransferUtil;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.neoforged.neoforge.items.ItemStackHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TransferUtilTests {
+
+    // region Items
+
+    @Test
+    public void distributeItems_Push() {
+        // Arrange.
+        ItemStackHandler from = new ItemStackHandler(1);
+        ItemStackHandler to = new ItemStackHandler(1);
+
+        from.setStackInSlot(0, new ItemStack(Items.GRASS_BLOCK, 3));
+
+        // Act.
+        TransferUtil.distributeItems(true, false, from, to);
+
+        // Assert.
+        Assertions.assertTrue(from.getStackInSlot(0).isEmpty());
+        Assertions.assertEquals(Items.GRASS_BLOCK, to.getStackInSlot(0).getItem());
+        Assertions.assertEquals(3, to.getStackInSlot(0).getCount());
+    }
+
+    @Test
+    public void distributeItems_PushMultipleSlotsOverflows() {
+        // Arrange.
+        ItemStackHandler from = new ItemStackHandler(1);
+        ItemStackHandler to = new ItemStackHandler(2);
+
+        from.setStackInSlot(0, new ItemStack(Items.GRASS_BLOCK, 3));
+        to.setStackInSlot(0, new ItemStack(Items.GRASS_BLOCK, 63));
+
+        // Act.
+        TransferUtil.distributeItems(true, false, from, to);
+
+        // Assert.
+        Assertions.assertTrue(from.getStackInSlot(0).isEmpty());
+        Assertions.assertEquals(Items.GRASS_BLOCK, to.getStackInSlot(0).getItem());
+        Assertions.assertEquals(64, to.getStackInSlot(0).getCount());
+        Assertions.assertEquals(Items.GRASS_BLOCK, to.getStackInSlot(1).getItem());
+        Assertions.assertEquals(2, to.getStackInSlot(1).getCount());
+    }
+
+    @Test
+    public void distributeItems_Pull() {
+        // Arrange.
+        ItemStackHandler from = new ItemStackHandler(1);
+        ItemStackHandler to = new ItemStackHandler(1);
+
+        to.setStackInSlot(0, new ItemStack(Items.GRASS_BLOCK, 3));
+
+        // Act.
+        TransferUtil.distributeItems(false, true, from, to);
+
+        // Assert.
+        Assertions.assertTrue(to.getStackInSlot(0).isEmpty());
+        Assertions.assertEquals(Items.GRASS_BLOCK, from.getStackInSlot(0).getItem());
+        Assertions.assertEquals(3, from.getStackInSlot(0).getCount());
+    }
+
+    @Test
+    public void distributeItems_PullMultipleSlotsOverflows() {
+        // Arrange.
+        ItemStackHandler from = new ItemStackHandler(2);
+        ItemStackHandler to = new ItemStackHandler(1);
+
+        from.setStackInSlot(0, new ItemStack(Items.GRASS_BLOCK, 63));
+        to.setStackInSlot(0, new ItemStack(Items.GRASS_BLOCK, 3));
+
+        // Act.
+        TransferUtil.distributeItems(false, true, from, to);
+
+        // Assert.
+        Assertions.assertTrue(to.getStackInSlot(0).isEmpty());
+        Assertions.assertEquals(Items.GRASS_BLOCK, from.getStackInSlot(0).getItem());
+        Assertions.assertEquals(64, from.getStackInSlot(0).getCount());
+        Assertions.assertEquals(Items.GRASS_BLOCK, from.getStackInSlot(1).getItem());
+        Assertions.assertEquals(2, from.getStackInSlot(1).getCount());
+    }
+
+    // endregion
+}


### PR DESCRIPTION
# Description

Always re-extract after every send in TransferUtil to ensure we don't dupe items.

Could probably also just update the value of extracted once we know the remainder, but this feels more fool proof.

Closes #1436 

<!-- For drafts, fill this in as you go; if you are leaving draft, make sure these are all complete. -->
# Checklist

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.

<!-- Thanks to: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ for the building blocks of this template -->
