### PR TITLE
Fix default fluid buckets missing crafting remainders

### DIFF
--- a/endercore/src/main/java/com/enderio/core/common/registries/FluidDeferredRegister.java
+++ b/endercore/src/main/java/com/enderio/core/common/registries/FluidDeferredRegister.java
@@ -4,6 +4,7 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -137,7 +138,7 @@ public class FluidDeferredRegister {
         }
 
         public Builder defaultBucket() {
-            this.bucketFactory = (fluid) -> new BucketItem(fluid, new Item.Properties().stacksTo(1));
+            this.bucketFactory = (fluid) -> new BucketItem(fluid, new Item.Properties().craftRemainder(Items.BUCKET).stacksTo(1));
             return this;
         }
 

--- a/enderio/src/test/java/com/enderio/enderio/tests/recipes/FluidBucketRemainderTests.java
+++ b/enderio/src/test/java/com/enderio/enderio/tests/recipes/FluidBucketRemainderTests.java
@@ -1,0 +1,40 @@
+package com.enderio.enderio.tests.recipes;
+
+import com.enderio.enderio.init.EIOFluids;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.item.crafting.ShapedRecipePattern;
+import net.neoforged.testframework.junit.EphemeralTestServerProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(EphemeralTestServerProvider.class)
+public class FluidBucketRemainderTests {
+    @Test
+    public void testCraftingReturnsEachFluidBucket(MinecraftServer server) {
+        for (var bucket : EIOFluids.FLUIDS.itemsRegister().getEntries()) {
+            var recipe = new ShapedRecipe("", CraftingBookCategory.MISC,
+                ShapedRecipePattern.of(Map.of('B', Ingredient.of(bucket.get())), "BB", "BB"),
+                Items.STONE.getDefaultInstance());
+            var input = CraftingInput.of(2, 2, List.of(
+                bucket.get().getDefaultInstance(), bucket.get().getDefaultInstance(),
+                bucket.get().getDefaultInstance(), bucket.get().getDefaultInstance()));
+
+            Assertions.assertTrue(recipe.matches(input, server.overworld()));
+            var remainingItems = recipe.getRemainingItems(input);
+            Assertions.assertEquals(4, remainingItems.size());
+            for (var remainder : remainingItems) {
+                Assertions.assertTrue(remainder.is(Items.BUCKET), bucket.getId() + " must return an empty bucket");
+                Assertions.assertEquals(1, remainder.getCount());
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Ender IO's default fluid buckets do not declare an empty bucket crafting remainder. Shaped crafting recipes therefore consume the bucket as well as its fluid. This also prevents AE2's crafting-pattern fluid substitution, which requires the recipe slot to return one empty bucket: a cursed chicken feed pattern encoded with four XP Juice Buckets still requests four bucket items even when fluid substitution is enabled and XP Juice is available in the network.

Set `craftRemainder(Items.BUCKET)` in `FluidDeferredRegister.Builder.defaultBucket()` so all default fluid buckets retain their empty containers in crafting. Add a regression test that runs each registered Ender IO fluid bucket through a shaped recipe and checks the remainder in every occupied slot.

## Validation

- `:enderio:build` passed on Java 21 / NeoForge 21.1.216: 116 unit tests, no failures, errors, or skipped tests, including the new regression test.
- Tested the patched 8.2.12-beta build in a Minecraft 1.21.1 modpack with AE2 19.2.17, Mob Grinding Utils 1.1.10, and Neo ECO AE Extension 21.2.0. The player confirmed the previously failing cursed chicken feed autocraft works with fluid substitution enabled.
- Full GameTestServer suite was not run locally.

## Breaking Changes

Default fluid buckets now return empty buckets when consumed as crafting ingredients, matching vanilla fluid bucket behavior.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] No documentation changes are needed for this bug fix.
- [x] My changes are ready for review from a contributor.
